### PR TITLE
🔖 chore(release): bump MARKETING_VERSION to 2.1 and build to 3

### DIFF
--- a/mergen.xcodeproj/project.pbxproj
+++ b/mergen.xcodeproj/project.pbxproj
@@ -740,7 +740,7 @@
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 1;
+				CURRENT_PROJECT_VERSION = 3;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_ASSET_PATHS = mergen/Preview;
 				DEVELOPMENT_TEAM = HK2X69GGZH;
@@ -754,7 +754,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 13.5;
-				MARKETING_VERSION = 1.0;
+				MARKETING_VERSION = 2.1;
 				PRODUCT_BUNDLE_IDENTIFIER = sametsazak.mergen;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
@@ -771,7 +771,7 @@
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 1;
+				CURRENT_PROJECT_VERSION = 3;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_ASSET_PATHS = mergen/Preview;
 				DEVELOPMENT_TEAM = HK2X69GGZH;
@@ -786,7 +786,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 13.5;
-				MARKETING_VERSION = 1.0;
+				MARKETING_VERSION = 2.1;
 				PRODUCT_BUNDLE_IDENTIFIER = sametsazak.mergen;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;


### PR DESCRIPTION
## Summary

The v2.1 release shipped with `MARKETING_VERSION = 1.0` / `CURRENT_PROJECT_VERSION = 1` in the Xcode build settings, so the About box, `CFBundleShortVersionString`, and MDM inventory all continued to report "1.0" on machines that had the v2.1 binary installed.

Since the project uses `GENERATE_INFOPLIST_FILE = YES`, the pbxproj build settings are authoritative — there's no separate Info.plist to edit.

## Changes

\`mergen.xcodeproj/project.pbxproj\` (Debug + Release configs):

- \`MARKETING_VERSION\`: 1.0 → 2.1
- \`CURRENT_PROJECT_VERSION\`: 1 → 3 (leaves room for the skipped build 2 that would have matched the v2.1 tag)

4-line diff, no code changes.

## Test plan

- [ ] Build in Xcode
- [ ] Open the About window and confirm it reads "2.1"
- [ ] \`defaults read /Applications/mergen.app/Contents/Info.plist CFBundleShortVersionString\` returns \`2.1\`

Closes #13