### PR TITLE
🐛 fix(check): detect Location Services via launchctl print on macOS 26 Tahoe

### DIFF
--- a/mergen/checkmodules/CISBenchmark/LocationServicesCheck.swift
+++ b/mergen/checkmodules/CISBenchmark/LocationServicesCheck.swift
@@ -15,29 +15,64 @@ class LocationServicesCheck: Vulnerability {
             category: "CIS Benchmark",
             remediation: "To enable Location Services, go to System Settings > Security & Privacy > Privacy and check the option.",
             severity: "Low",
-            documentation: "This code checks the status of the com.apple.locationd launchctl service. If the locationd service is running, it means that Location Services is enabled; if not, it means that Location Services is disabled.",
+            documentation: "This check inspects the com.apple.locationd system LaunchDaemon. On macOS 26 Tahoe, `launchctl list` (no domain) no longer surfaces system daemons, so we probe `launchctl print system/com.apple.locationd` instead and look for `state = running`. A legacy `launchctl list | grep locationd` fallback keeps older macOS versions working.",
             mitigation: "Enabling Location Services allows applications to provide location-based features and services.",
             docID: 50, cisID: "2.6.1.1"
         )
     }
 
     override func check() {
-        let task = Process()
-        task.executableURL = URL(fileURLWithPath: "/bin/launchctl")
-        task.arguments = ["list", "com.apple.locationd"]
+        // Primary check: `launchctl print system/com.apple.locationd` works on
+        // modern macOS (including 26 Tahoe) where `launchctl list` no longer
+        // enumerates system LaunchDaemons from a user domain.
+        let printTask = Process()
+        printTask.executableURL = URL(fileURLWithPath: "/bin/launchctl")
+        printTask.arguments = ["print", "system/com.apple.locationd"]
 
-        task.standardOutput = Pipe()
-        task.standardError = Pipe()
+        let printOutputPipe = Pipe()
+        printTask.standardOutput = printOutputPipe
+        printTask.standardError = Pipe()
 
         do {
-            try task.run()
-            task.waitUntilExit()
+            try printTask.run()
+            printTask.waitUntilExit()
 
-            if task.terminationStatus == 0 {
+            if printTask.terminationStatus == 0 {
+                let outputData = printOutputPipe.fileHandleForReading.readDataToEndOfFile()
+                let output = String(data: outputData, encoding: .utf8) ?? ""
+                if output.contains("state = running") {
+                    status = "Location Services is enabled (locationd running)"
+                    checkstatus = "Green"
+                } else {
+                    status = "Location Services is disabled"
+                    checkstatus = "Red"
+                }
+                return
+            }
+            // Non-zero exit: fall through to legacy fallback below.
+        } catch let e {
+            // `launchctl print` itself failed to execute — try the legacy path.
+            print("launchctl print failed for \(name), falling back: \(e)")
+        }
+
+        // Fallback for very old macOS where `launchctl print system/...` is
+        // unavailable: the original `launchctl list com.apple.locationd`
+        // probe. Exit code 0 means the daemon is loaded in the current domain.
+        let legacyTask = Process()
+        legacyTask.executableURL = URL(fileURLWithPath: "/bin/launchctl")
+        legacyTask.arguments = ["list", "com.apple.locationd"]
+        legacyTask.standardOutput = Pipe()
+        legacyTask.standardError = Pipe()
+
+        do {
+            try legacyTask.run()
+            legacyTask.waitUntilExit()
+
+            if legacyTask.terminationStatus == 0 {
                 status = "Location Services is enabled."
                 checkstatus = "Green"
             } else {
-                status = "Location Services is disabled."
+                status = "Location Services is disabled"
                 checkstatus = "Red"
             }
         } catch let e {

--- a/mergen/checkmodules/CISBenchmark/LocationServicesMenuBarCheck.swift
+++ b/mergen/checkmodules/CISBenchmark/LocationServicesMenuBarCheck.swift
@@ -8,19 +8,26 @@
 import Foundation
 
 
-//This implementation checks whether the "Location.menu" item is present in the output of the defaults read com.apple.systemuiserver menuExtras command, which indicates that the Location Services icon is visible in the menu bar. If the "Location.menu" item is present, the status is set to "Location Services is visible in the menu bar", and the checkstatus is set to "Green". If the "Location.menu" item is not present, the status is set to "Location Services is not visible in the menu bar", and the checkstatus is set to "Red". If an error occurs during the check, the status is set to "Error checking menu bar status", and the checkstatus is set to "Yellow".
+// This check reads the authoritative preference
+// /Library/Preferences/com.apple.locationmenu.plist (key: ShowSystemServices).
+// The value is an Integer: 1 means the Location Services indicator is shown
+// (in the menu bar on older macOS, or in Control Center on macOS 26 Tahoe
+// or later), 0 means it is hidden. Using this plist avoids false positives
+// from probing com.apple.systemuiserver's menuExtras array, which no longer
+// contains "Location.menu" on recent macOS versions even when the indicator
+// is enabled.
 
 
 class LocationServicesMenuBarCheck: Vulnerability {
     init() {
         super.init(
             name: "Location services shown in menu bar",
-            description: "This check ensures that the Location Services icon is visible in the menu bar, providing users with awareness when Location Services is enabled.",
+            description: "This check ensures that the Location Services indicator is visible (in the menu bar, or in Control Center on macOS 26 Tahoe or later), providing users with awareness when Location Services is enabled.",
             category: "CIS Benchmark",
-            remediation: "To enable Location Services in the menu bar, go to System Settings > Security & Privacy > Privacy > Location Services and check the option.",
+            remediation: "To show the Location Services indicator, go to System Settings > Privacy & Security > Location Services > Details... and enable 'Show location icon in the menu bar when System Services request your location' (on macOS 26 Tahoe or later the indicator appears in Control Center).",
             severity: "Low",
-            documentation: "Having the Location Services icon visible in the menu bar helps users to be aware of its status and manage location-based features more effectively.",
-            mitigation: "Displaying the Location Services icon in the menu bar ensures that users are aware of when Location Services is enabled, reducing potential security risks.",
+            documentation: "Authoritative source is /Library/Preferences/com.apple.locationmenu.plist key ShowSystemServices (1 = enabled, 0 = disabled). On macOS 26 Tahoe or later the indicator was moved from the menu bar to Control Center but the preference key is unchanged.",
+            mitigation: "Displaying the Location Services indicator ensures users are aware of when Location Services is enabled, reducing potential privacy risks.",
             docID: 51, cisID: "2.6.1.2"
         )
     }
@@ -28,31 +35,37 @@ class LocationServicesMenuBarCheck: Vulnerability {
     override func check() {
         let task = Process()
         task.executableURL = URL(fileURLWithPath: "/usr/bin/defaults")
-        task.arguments = ["read", "com.apple.systemuiserver", "menuExtras"]
+        task.arguments = ["read", "/Library/Preferences/com.apple.locationmenu.plist", "ShowSystemServices"]
 
-        let pipe = Pipe()
-        task.standardOutput = pipe
+        let outputPipe = Pipe()
+        task.standardOutput = outputPipe
         task.standardError = Pipe()
 
         do {
             try task.run()
-            let data = pipe.fileHandleForReading.readDataToEndOfFile()
-            if let output = String(data: data, encoding: .utf8) {
-                if output.contains("Location.menu") {
-                    status = "Location Services is visible in the menu bar"
+            task.waitUntilExit()
+
+            if task.terminationStatus == 0 {
+                let outputData = outputPipe.fileHandleForReading.readDataToEndOfFile()
+                let output = String(data: outputData, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+
+                if output == "1" {
+                    status = "Location Services indicator is enabled (menu bar, or Control Center on macOS 26 Tahoe or later)"
                     checkstatus = "Green"
                 } else {
-                    status = "Location Services is not visible in the menu bar"
+                    status = "Location Services indicator is disabled (menu bar, or Control Center on macOS 26 Tahoe or later)"
                     checkstatus = "Red"
                 }
             } else {
-                status = "Error parsing menu bar status"
-                checkstatus = "Yellow"
+                // `defaults read` exited non-zero — typically means the plist
+                // or key is absent, which is treated as disabled.
+                status = "Location Services indicator is disabled (menu bar, or Control Center on macOS 26 Tahoe or later)"
+                checkstatus = "Red"
             }
         } catch let e {
             print("Error checking \(name): \(e)")
             checkstatus = "Yellow"
-            status = "Error checking menu bar status"
+            status = "Error checking Location Services indicator status"
             self.error = e
         }
     }


### PR DESCRIPTION
## Summary

On macOS 26 Tahoe, \`launchctl list\` without a domain argument no longer enumerates system LaunchDaemons — only the caller's user domain. \`com.apple.locationd\` therefore appears "missing" to the previous check even when it's running with 8 active clients, causing **CIS 2.6.1.1** and **2.6.1.2** to always report Red.

## Changes

**\`LocationServicesCheck.swift\` (2.6.1.1)**
- Primary probe: \`launchctl print system/com.apple.locationd\`, search output for \`state = running\`.
- Legacy fallback: original \`launchctl list com.apple.locationd\` kept for pre-Tahoe compatibility.
- Updated \`documentation\` string to describe the new detection strategy.

**\`LocationServicesMenuBarCheck.swift\` (2.6.1.2)**
- Switched from parsing \`com.apple.systemuiserver menuExtras\` (no longer reliable) to reading the authoritative \`/Library/Preferences/com.apple.locationmenu.plist\` key \`ShowSystemServices\` (1 = enabled, 0 = disabled).
- Updated status text to note the indicator lives in Control Center on macOS 26 Tahoe.

## Test plan

- [ ] Rescan on macOS 26 Tahoe with Location Services enabled → both checks Green
- [ ] Rescan with Location Services disabled → both checks Red
- [ ] Rescan on a pre-Tahoe macOS → fallback branch exercised, still works

Closes #14