### PR TITLE
🐛 fix(report): truncate JSON file on export instead of appending

### DIFF
--- a/mergen/view/ScanResultView.swift
+++ b/mergen/view/ScanResultView.swift
@@ -468,7 +468,7 @@ struct ExportButtons: View {
         panel.nameFieldStringValue = "MergenReport.json"
         panel.allowedContentTypes = [.json]
         if panel.runModal() == .OK, let url = panel.url {
-            try? data.write(to: url)
+            try? data.write(to: url, options: [.atomic])
         }
     }
 }


### PR DESCRIPTION
## Summary

Re-exporting scan results to the same JSON path was appending the new scan to the existing array, producing concatenated arrays and every check duplicated once per export (85 → 170 → 255 entries after 3 exports).

## Changes

\`mergen/view/ScanResultView.swift\` — one-line change in \`ExportButtons.exportJSON()\`:

\`\`\`diff
- try? data.write(to: url)
+ try? data.write(to: url, options: [.atomic])
\`\`\`

\`.atomic\` writes to a sibling temp file then \`rename(2)\`s it over the destination. Rename is atomic and unconditionally replaces the target — no concat, no partial-write corruption, matches the pattern already used in \`AuditLogger.swift\`.

## Test plan

- [ ] Scan, export JSON to \`~/Downloads/MergenReport.json\` → 85 entries
- [ ] Rescan, export JSON to the same path, click "Replace" → still 85 entries (not 170)
- [ ] \`jq '[.[] | .docID] | group_by(.) | map(select(length > 1)) | length' ~/Downloads/MergenReport.json\` returns \`0\`

Closes #15