### PR TITLE
🐛 fix(check): treat absent Bluetooth Sharing key as disabled default

### DIFF
--- a/mergen/checkmodules/CISBenchmark/BluetoothSharingDisabledCheck.swift
+++ b/mergen/checkmodules/CISBenchmark/BluetoothSharingDisabledCheck.swift
@@ -39,17 +39,16 @@ class BluetoothSharingDisabledCheck: Vulnerability {
             if task.terminationStatus == 0 {
                 let outputData = outputPipe.fileHandleForReading.readDataToEndOfFile()
                 let outputString = String(data: outputData, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines)
-                if outputString == "0" {
-                    status = "Bluetooth Sharing is Disabled"
-                    checkstatus = "Green"
-                } else {
-                    status = "Bluetooth Sharing is Enabled"
+                if outputString == "1" {
+                    status = "Bluetooth Sharing is enabled"
                     checkstatus = "Red"
+                } else {
+                    status = "Bluetooth Sharing is disabled"
+                    checkstatus = "Green"
                 }
             } else {
-                status = "Error checking Bluetooth Sharing status"
-                checkstatus = "Yellow"
-                self.error = NSError(domain: NSPOSIXErrorDomain, code: Int(task.terminationStatus), userInfo: nil)
+                status = "Bluetooth Sharing is disabled (default, preference key not set)"
+                checkstatus = "Green"
             }
         } catch let e {
             print("Error checking \(name): \(e)")


### PR DESCRIPTION
## Summary

\`PrefKeyServicesEnabled\` under \`com.apple.Bluetooth\` is only persisted once the user toggles Bluetooth Sharing on at least once. On a default Mac the key doesn't exist and \`defaults read\` exits non-zero — which the check was mis-reporting as Yellow "Error checking Bluetooth Sharing status".

Missing key == never enabled == disabled default == **Green**, matching the CIS benchmark's expected compliant state.

## Changes

\`mergen/checkmodules/CISBenchmark/BluetoothSharingDisabledCheck.swift\` — simplified logic:

- stdout \`"1"\` → Red (enabled)
- stdout \`"0"\` → Green (disabled)
- non-zero exit (key missing) → Green with status \`"Bluetooth Sharing is disabled (default, preference key not set)"\`

## Test plan

- [ ] Rescan on a default Mac (Bluetooth Sharing never toggled) → Green
- [ ] Toggle Bluetooth Sharing on, rescan → Red
- [ ] Toggle off, rescan → Green

Closes #16