### PR TITLE
🐛 fix(check): read DiagnosticMessagesHistory plist for 2.6.3.1 and 2.6.3.4

### DIFF
--- a/mergen/checkmodules/CISBenchmark/ShareMacAnalyticsCheck.swift
+++ b/mergen/checkmodules/CISBenchmark/ShareMacAnalyticsCheck.swift
@@ -7,6 +7,12 @@
 import Foundation
 
 class ShareMacAnalyticsCheck: Vulnerability {
+    // Authoritative, world-readable plist the system writes when the user
+    // toggles Share Mac Analytics in System Settings.
+    private static let diagnosticsPlistPath =
+        "/Library/Application Support/CrashReporter/DiagnosticMessagesHistory.plist"
+    private static let autoSubmitKey = "AutoSubmit"
+
     init() {
         super.init(
             name: "Share Mac Analytics Is Disabled",
@@ -23,45 +29,57 @@ class ShareMacAnalyticsCheck: Vulnerability {
     }
 
     override func check() {
+        // 1) Prefer an MDM-forced value if one is present (higher priority).
+        if let mdmValue = readMDMValue() {
+            if mdmValue {
+                status = "Share Mac Analytics is enabled (forced by MDM profile)."
+                checkstatus = "Red"
+            } else {
+                status = "Share Mac Analytics is disabled (enforced by MDM profile)."
+                checkstatus = "Green"
+            }
+            return
+        }
+
+        // 2) Otherwise read the world-readable authoritative plist.
+        let path = ShareMacAnalyticsCheck.diagnosticsPlistPath
+
+        if !FileManager.default.fileExists(atPath: path) {
+            // Fresh user: file isn't written until Analytics & Improvements
+            // has been visited, which is equivalent to "never submitted".
+            status = "Share Mac Analytics is disabled (no diagnostics history plist present)."
+            checkstatus = "Green"
+            return
+        }
+
+        guard let dict = NSDictionary(contentsOfFile: path) else {
+            status = "Share Mac Analytics state could not be determined (plist unreadable)."
+            checkstatus = "Yellow"
+            return
+        }
+
+        // Key absent or 0 -> disabled (Green). 1 -> enabled (Red).
+        if let raw = dict[ShareMacAnalyticsCheck.autoSubmitKey] as? NSNumber {
+            if raw.intValue == 1 {
+                status = "Share Mac Analytics is enabled."
+                checkstatus = "Red"
+            } else {
+                status = "Share Mac Analytics is disabled."
+                checkstatus = "Green"
+            }
+        } else {
+            status = "Share Mac Analytics is disabled (AutoSubmit key absent)."
+            checkstatus = "Green"
+        }
+    }
+
+    /// Check whether an MDM configuration profile is forcing AutoSubmit for
+    /// com.apple.SubmitDiagInfo. Returns nil when no profile enforces it.
+    private func readMDMValue() -> Bool? {
         let task = Process()
         task.executableURL = URL(fileURLWithPath: "/usr/bin/osascript")
         task.arguments = ["-l", "JavaScript", "-e",
             "$.NSUserDefaults.alloc.initWithSuiteName('com.apple.SubmitDiagInfo').objectForKey('AutoSubmit').js"]
-
-        let outputPipe = Pipe()
-        let errorPipe = Pipe()
-        task.standardOutput = outputPipe
-        task.standardError = errorPipe
-
-        do {
-            try task.run()
-            task.waitUntilExit()
-
-            let output = String(data: outputPipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8)?
-                .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
-
-            if output == "false" {
-                status = "Share Mac Analytics is disabled."
-                checkstatus = "Green"
-            } else if output == "true" {
-                status = "Share Mac Analytics is enabled."
-                checkstatus = "Red"
-            } else {
-                // Fall back to direct defaults read (user-level)
-                checkViaDefaults()
-            }
-        } catch let e {
-            print("Error checking \(name): \(e)")
-            self.error = e
-            checkstatus = "Yellow"
-            status = "Error checking Share Mac Analytics"
-        }
-    }
-
-    private func checkViaDefaults() {
-        let task = Process()
-        task.executableURL = URL(fileURLWithPath: "/usr/bin/env")
-        task.arguments = ["defaults", "read", "com.apple.SubmitDiagInfo", "AutoSubmit"]
 
         let outputPipe = Pipe()
         task.standardOutput = outputPipe
@@ -70,23 +88,17 @@ class ShareMacAnalyticsCheck: Vulnerability {
         do {
             try task.run()
             task.waitUntilExit()
-
-            let output = String(data: outputPipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8)?
-                .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
-
-            if output == "0" {
-                status = "Share Mac Analytics is disabled."
-                checkstatus = "Green"
-            } else if output == "1" {
-                status = "Share Mac Analytics is enabled."
-                checkstatus = "Red"
-            } else {
-                status = "Share Mac Analytics state could not be determined."
-                checkstatus = "Yellow"
-            }
         } catch {
-            checkstatus = "Yellow"
-            status = "Share Mac Analytics state could not be determined."
+            return nil
+        }
+
+        let output = String(data: outputPipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8)?
+            .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+
+        switch output {
+        case "true", "1":  return true
+        case "false", "0": return false
+        default:           return nil
         }
     }
 }

--- a/mergen/checkmodules/CISBenchmark/ShareWithAppDevelopersCheck.swift
+++ b/mergen/checkmodules/CISBenchmark/ShareWithAppDevelopersCheck.swift
@@ -7,6 +7,12 @@
 import Foundation
 
 class ShareWithAppDevelopersCheck: Vulnerability {
+    // Authoritative, world-readable plist the system writes when the user
+    // toggles "Share with app developers" in System Settings.
+    private static let diagnosticsPlistPath =
+        "/Library/Application Support/CrashReporter/DiagnosticMessagesHistory.plist"
+    private static let thirdPartyKey = "ThirdPartyDataSubmit"
+
     init() {
         super.init(
             name: "Share with App Developers Is Disabled",
@@ -23,38 +29,83 @@ class ShareWithAppDevelopersCheck: Vulnerability {
     }
 
     override func check() {
+        // 1) Prefer an MDM-forced value if one is present (higher priority).
+        if let mdmValue = readMDMValue() {
+            if mdmValue {
+                status = "Share with App Developers is enabled (forced by MDM profile)."
+                checkstatus = "Red"
+            } else {
+                status = "Share with App Developers is disabled (enforced by MDM profile)."
+                checkstatus = "Green"
+            }
+            return
+        }
+
+        // 2) Otherwise read the world-readable authoritative plist.
+        let path = ShareWithAppDevelopersCheck.diagnosticsPlistPath
+
+        if !FileManager.default.fileExists(atPath: path) {
+            // Fresh user: file isn't written until Analytics & Improvements
+            // has been visited, which is equivalent to "never submitted".
+            status = "Share with App Developers is disabled (no diagnostics history plist present)."
+            checkstatus = "Green"
+            return
+        }
+
+        guard let dict = NSDictionary(contentsOfFile: path) else {
+            status = "Share with App Developers state could not be determined (plist unreadable)."
+            checkstatus = "Yellow"
+            return
+        }
+
+        // Key absent or 0 -> disabled (Green). 1 -> enabled (Red).
+        if let raw = dict[ShareWithAppDevelopersCheck.thirdPartyKey] as? NSNumber {
+            if raw.intValue == 1 {
+                status = "Share with App Developers is enabled."
+                checkstatus = "Red"
+            } else {
+                status = "Share with App Developers is disabled."
+                checkstatus = "Green"
+            }
+        } else {
+            status = "Share with App Developers is disabled (ThirdPartyDataSubmit key absent)."
+            checkstatus = "Green"
+        }
+    }
+
+    /// Check whether an MDM configuration profile is forcing
+    /// allowDiagnosticSubmission for com.apple.applicationaccess. Returns
+    /// nil when no profile enforces it.
+    ///
+    /// Note: the MDM key is inverted semantically
+    /// (allowDiagnosticSubmission == false means sharing is disabled), so
+    /// we normalize it to "is sharing enabled?".
+    private func readMDMValue() -> Bool? {
         let task = Process()
         task.executableURL = URL(fileURLWithPath: "/usr/bin/osascript")
         task.arguments = ["-l", "JavaScript", "-e",
             "$.NSUserDefaults.alloc.initWithSuiteName('com.apple.applicationaccess').objectForKey('allowDiagnosticSubmission').js"]
 
         let outputPipe = Pipe()
-        let errorPipe = Pipe()
         task.standardOutput = outputPipe
-        task.standardError = errorPipe
+        task.standardError = Pipe()
 
         do {
             try task.run()
             task.waitUntilExit()
+        } catch {
+            return nil
+        }
 
-            let output = String(data: outputPipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8)?
-                .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        let output = String(data: outputPipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8)?
+            .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
 
-            if output == "false" {
-                status = "Share with App Developers is disabled."
-                checkstatus = "Green"
-            } else if output == "true" {
-                status = "Share with App Developers is enabled."
-                checkstatus = "Red"
-            } else {
-                status = "Share with App Developers state unknown (may require MDM profile)."
-                checkstatus = "Yellow"
-            }
-        } catch let e {
-            print("Error checking \(name): \(e)")
-            self.error = e
-            checkstatus = "Yellow"
-            status = "Error checking Share with App Developers setting"
+        switch output {
+        // allowDiagnosticSubmission true  -> sharing allowed  -> enabled
+        case "true", "1":  return true
+        // allowDiagnosticSubmission false -> sharing blocked  -> disabled
+        case "false", "0": return false
+        default:           return nil
         }
     }
 }


### PR DESCRIPTION
## Summary

**CIS 2.6.3.1** (Share Mac Analytics) and **CIS 2.6.3.4** (Share with App Developers) were returning Yellow "state unknown" on every run because the checks only queried MDM-owned domains and never looked at the actual user preference. Both values live in the world-readable plist at \`/Library/Application Support/CrashReporter/DiagnosticMessagesHistory.plist\`:

- Key \`AutoSubmit\` — Share Mac Analytics (1 = enabled)
- Key \`ThirdPartyDataSubmit\` — Share with App Developers (1 = enabled)

Neither requires an MDM profile or elevated privileges to read.

## Changes

**\`ShareMacAnalyticsCheck.swift\` / \`ShareWithAppDevelopersCheck.swift\`**

1. If an MDM profile forces the value (via the existing \`osascript\` probe against \`com.apple.SubmitDiagInfo\` / \`com.apple.applicationaccess\`), prefer that as the authoritative answer and label the status accordingly. Kept as a helper \`readMDMValue() -> Bool?\`.
2. Otherwise read the plist directly with \`NSDictionary(contentsOfFile:)\` and return Red/Green based on the actual integer value.
3. If the plist file doesn't exist, default to Green (fresh user, never submitted).
4. \`ShareWithAppDevelopersCheck\` correctly handles the inverted semantic of \`allowDiagnosticSubmission\` (MDM key true == sharing allowed == enabled).

## Test plan

- [ ] Toggle Share Mac Analytics on in System Settings → Analytics & Improvements → 2.6.3.1 reports Red
- [ ] Toggle it off → 2.6.3.1 reports Green
- [ ] Same for Share with App Developers / 2.6.3.4
- [ ] Install MDM profile forcing \`AutoSubmit = false\` → 2.6.3.1 reports Green with "enforced by MDM profile"

Closes #17