### PR TITLE
🐛 fix(check): parse pwpolicy's .{N,} regex form for CIS 5.2.2

### DIFF
--- a/mergen/checkmodules/CISBenchmark/PasswordMinLengthCheck.swift
+++ b/mergen/checkmodules/CISBenchmark/PasswordMinLengthCheck.swift
@@ -38,30 +38,54 @@ class PasswordMinLengthCheck: Vulnerability {
 
             let output = String(data: outputPipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
 
-            // Check for minimum length in the policy
-            if output.contains("policyAttributePassword matches") || output.contains("minimumLength") || output.contains("minChars") {
-                // Try to extract the minimum length value
-                let patterns = ["policyAttributePassword matches '.{(\\d+)}", "minimumLength.*?(\\d+)"]
-                for pattern in patterns {
-                    if let regex = try? NSRegularExpression(pattern: pattern),
-                       let match = regex.firstMatch(in: output, range: NSRange(output.startIndex..., in: output)),
-                       match.numberOfRanges > 1,
-                       let range = Range(match.range(at: 1), in: output),
-                       let value = Int(output[range]) {
-                        if value >= 15 {
-                            status = "Password minimum length is \(value) characters (≥ 15)."
-                            checkstatus = "Green"
-                        } else {
-                            status = "Password minimum length is \(value) characters (should be ≥ 15)."
-                            checkstatus = "Red"
-                        }
-                        return
+            // pwpolicy emits length predicates as:
+            //   policyAttributePassword matches '.{15,}'     (rare)
+            //   policyAttributePassword matches '.{15,}?'    (common)
+            //   policyAttributePassword matches '.{15,}+'    (common)
+            // A single policy may stack several such predicates (e.g. .{15,}? for
+            // min length AND .{4,}+ for "at least 4 alphanumeric chars"). The
+            // effective minimum length is the MAX N across all matches.
+            let lengthPattern = "policyAttributePassword matches '\\.\\{(\\d+),\\}[?+]?'"
+            var lengths: [Int] = []
+            if let regex = try? NSRegularExpression(pattern: lengthPattern) {
+                let range = NSRange(output.startIndex..., in: output)
+                for match in regex.matches(in: output, range: range) where match.numberOfRanges > 1 {
+                    if let r = Range(match.range(at: 1), in: output),
+                       let n = Int(output[r]) {
+                        lengths.append(n)
                     }
                 }
-                status = "Password length policy found but minimum length could not be parsed."
+            }
+
+            // Fallback: older/MDM-style profile keys.
+            if lengths.isEmpty {
+                let fallbackPatterns = ["minimumLength\\D+(\\d+)", "minChars\\D+(\\d+)"]
+                for pattern in fallbackPatterns {
+                    if let regex = try? NSRegularExpression(pattern: pattern) {
+                        let range = NSRange(output.startIndex..., in: output)
+                        for match in regex.matches(in: output, range: range) where match.numberOfRanges > 1 {
+                            if let r = Range(match.range(at: 1), in: output),
+                               let n = Int(output[r]) {
+                                lengths.append(n)
+                            }
+                        }
+                    }
+                }
+            }
+
+            if let maxLen = lengths.max() {
+                if maxLen >= 15 {
+                    status = "Minimum length: \(maxLen)"
+                    checkstatus = "Green"
+                } else {
+                    status = "Minimum length: \(maxLen) (< 15 required)"
+                    checkstatus = "Red"
+                }
+            } else if output.contains("policyAttributePassword matches") || output.contains("minimumLength") || output.contains("minChars") {
+                status = "Password length policy found but no minimum-length predicate could be parsed from pwpolicy output."
                 checkstatus = "Yellow"
             } else {
-                status = "No password minimum length policy configured."
+                status = "No minimum-length policy detected in pwpolicy output."
                 checkstatus = "Red"
             }
         } catch let e {


### PR DESCRIPTION
## Summary

\`pwpolicy -getaccountpolicies\` emits minimum-length rules as \`policyAttributePassword matches '.{N,}?'\` with an optional trailing \`?\` or \`+\` quantifier. The previous parser's regex didn't match the quantifier and reported Yellow "could not be parsed" on fully-compliant Macs.

A single policy can also stack multiple \`matches\` predicates (e.g. \`.{15,}?\` for min length AND \`.{4,}+\` for "at least 4 characters"). The effective minimum is the MAX of all captured Ns.

## Changes

\`mergen/checkmodules/CISBenchmark/PasswordMinLengthCheck.swift\`:

- Regex: \`policyAttributePassword matches '\\.\\{(\\d+),\\}[?+]?'\` — matches all three variants (\`.{N,}\`, \`.{N,}?\`, \`.{N,}+\`).
- Iterate **all** matches, collect every N, take \`max()\`.
- Preserved fallback patterns (\`minimumLength\`, \`minChars\`) for MDM-provided outputs.

Tested with input containing \`.{15,}?\` and \`.{4,}+\` → extracted \`[15, 4]\`, max = \`15\`.

## Test plan

- [ ] Set \`pwpolicy\` to 15-char minimum → 5.2.2 Green with "Minimum length: 15"
- [ ] Set to 8-char → 5.2.2 Red with "Minimum length: 8 (< 15 required)"
- [ ] Unset policy → 5.2.2 Red with "No minimum-length policy detected"

Closes #18