### PR TITLE
🐛 fix(check): convert Safari 6.3.3/6.3.4/6.3.6/6.3.10 to manual warnings

### DIFF
--- a/mergen/checkmodules/CISBenchmark/SafariAdvertisingPrivacyCheck.swift
+++ b/mergen/checkmodules/CISBenchmark/SafariAdvertisingPrivacyCheck.swift
@@ -23,6 +23,10 @@ class SafariAdvertisingPrivacyCheck: Vulnerability {
     }
 
     override func check() {
+        // On macOS Tahoe, Safari preferences are fully sandboxed and cannot be
+        // read from an external process via `defaults`. MDM-managed profiles
+        // are still visible through system_profiler, so prefer that signal
+        // when present; otherwise fall back to a manual-verification warning.
         let task = Process()
         task.executableURL = URL(fileURLWithPath: "/usr/sbin/system_profiler")
         task.arguments = ["SPConfigurationProfileDataType"]
@@ -47,42 +51,20 @@ class SafariAdvertisingPrivacyCheck: Vulnerability {
                     checkstatus = "Red"
                 }
             } else {
-                checkViaDefaults()
+                // Cannot verify from outside Safari's sandbox on macOS Tahoe.
+                // Manual review required. The label for this setting has
+                // varied across macOS versions — on Tahoe it appears as
+                // 'Privacy Preserving Ad Measurement' under Advanced; older
+                // macOS versions use 'Allow privacy-preserving measurement
+                // of ad effectiveness' or similar wording.
+                status = "Cannot verify from outside Safari's sandbox. Check Safari > Settings > Advanced > enable 'Privacy Preserving Ad Measurement' (older macOS: 'Allow privacy-preserving measurement of ad effectiveness')."
+                checkstatus = "Yellow"
             }
         } catch let e {
             print("Error checking \(name): \(e)")
             self.error = e
             checkstatus = "Yellow"
             status = "Error checking Safari advertising privacy protection"
-        }
-    }
-
-    private func checkViaDefaults() {
-        let task = Process()
-        task.executableURL = URL(fileURLWithPath: "/usr/bin/env")
-        task.arguments = ["defaults", "read", "com.apple.Safari", "WebKitPreferences.privateClickMeasurementEnabled"]
-
-        let outputPipe = Pipe()
-        task.standardOutput = outputPipe
-        task.standardError = Pipe()
-
-        do {
-            try task.run()
-            task.waitUntilExit()
-
-            let output = String(data: outputPipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8)?
-                .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
-
-            if output == "1" {
-                status = "Safari advertising privacy protection is enabled."
-                checkstatus = "Green"
-            } else {
-                status = "Safari advertising privacy protection status unknown."
-                checkstatus = "Yellow"
-            }
-        } catch {
-            checkstatus = "Yellow"
-            status = "Could not verify Safari advertising privacy status."
         }
     }
 }

--- a/mergen/checkmodules/CISBenchmark/SafariCrossSiteTrackingCheck.swift
+++ b/mergen/checkmodules/CISBenchmark/SafariCrossSiteTrackingCheck.swift
@@ -23,6 +23,10 @@ class SafariCrossSiteTrackingCheck: Vulnerability {
     }
 
     override func check() {
+        // On macOS Tahoe, Safari preferences are fully sandboxed and cannot be
+        // read from an external process via `defaults`. MDM-managed profiles
+        // are still visible through system_profiler, so prefer that signal
+        // when present; otherwise fall back to a manual-verification warning.
         let task = Process()
         task.executableURL = URL(fileURLWithPath: "/usr/sbin/system_profiler")
         task.arguments = ["SPConfigurationProfileDataType"]
@@ -48,43 +52,16 @@ class SafariCrossSiteTrackingCheck: Vulnerability {
                     checkstatus = "Red"
                 }
             } else {
-                // Check user defaults
-                checkViaDefaults()
+                // Cannot verify from outside Safari's sandbox on macOS Tahoe.
+                // Manual review required.
+                status = "Cannot verify from outside Safari's sandbox. Check Safari > Settings > Privacy > enable 'Prevent cross-site tracking'."
+                checkstatus = "Yellow"
             }
         } catch let e {
             print("Error checking \(name): \(e)")
             self.error = e
             checkstatus = "Yellow"
             status = "Error checking Safari cross-site tracking prevention"
-        }
-    }
-
-    private func checkViaDefaults() {
-        let task = Process()
-        task.executableURL = URL(fileURLWithPath: "/usr/bin/env")
-        task.arguments = ["defaults", "read", "com.apple.Safari", "BlockStoragePolicy"]
-
-        let outputPipe = Pipe()
-        task.standardOutput = outputPipe
-        task.standardError = Pipe()
-
-        do {
-            try task.run()
-            task.waitUntilExit()
-
-            let output = String(data: outputPipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8)?
-                .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
-
-            if output == "2" {
-                status = "Safari cross-site tracking prevention is enabled."
-                checkstatus = "Green"
-            } else {
-                status = "Safari cross-site tracking prevention is not fully configured."
-                checkstatus = "Yellow"
-            }
-        } catch {
-            checkstatus = "Yellow"
-            status = "Could not verify Safari cross-site tracking status."
         }
     }
 }

--- a/mergen/checkmodules/CISBenchmark/SafariFraudWarningCheck.swift
+++ b/mergen/checkmodules/CISBenchmark/SafariFraudWarningCheck.swift
@@ -23,7 +23,10 @@ class SafariFraudWarningCheck: Vulnerability {
     }
 
     override func check() {
-        // Check via system_profiler for MDM profile first
+        // On macOS Tahoe, Safari preferences are fully sandboxed and cannot be
+        // read from an external process via `defaults`. MDM-managed profiles
+        // are still visible through system_profiler, so prefer that signal
+        // when present; otherwise fall back to a manual-verification warning.
         let task = Process()
         task.executableURL = URL(fileURLWithPath: "/usr/sbin/system_profiler")
         task.arguments = ["SPConfigurationProfileDataType"]
@@ -48,46 +51,16 @@ class SafariFraudWarningCheck: Vulnerability {
                     checkstatus = "Red"
                 }
             } else {
-                // Fall back to user defaults
-                checkViaDefaults()
+                // Cannot verify from outside Safari's sandbox on macOS Tahoe.
+                // Manual review required.
+                status = "Cannot verify from outside Safari's sandbox. Check Safari > Settings > Privacy > enable 'Warn when visiting a fraudulent website'."
+                checkstatus = "Yellow"
             }
         } catch let e {
             print("Error checking \(name): \(e)")
             self.error = e
             checkstatus = "Yellow"
             status = "Error checking Safari fraud warning"
-        }
-    }
-
-    private func checkViaDefaults() {
-        let task = Process()
-        task.executableURL = URL(fileURLWithPath: "/usr/bin/env")
-        task.arguments = ["defaults", "read", "com.apple.Safari", "WarnAboutFraudulentWebsites"]
-
-        let outputPipe = Pipe()
-        task.standardOutput = outputPipe
-        task.standardError = Pipe()
-
-        do {
-            try task.run()
-            task.waitUntilExit()
-
-            let output = String(data: outputPipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8)?
-                .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
-
-            if output == "1" {
-                status = "Safari fraudulent website warning is enabled."
-                checkstatus = "Green"
-            } else if output == "0" {
-                status = "Safari fraudulent website warning is disabled."
-                checkstatus = "Red"
-            } else {
-                status = "Safari fraudulent website warning state unknown (default is enabled)."
-                checkstatus = "Yellow"
-            }
-        } catch {
-            checkstatus = "Yellow"
-            status = "Could not verify Safari fraud warning status."
         }
     }
 }

--- a/mergen/checkmodules/CISBenchmark/SafariStatusBarCheck.swift
+++ b/mergen/checkmodules/CISBenchmark/SafariStatusBarCheck.swift
@@ -23,6 +23,10 @@ class SafariStatusBarCheck: Vulnerability {
     }
 
     override func check() {
+        // On macOS Tahoe, Safari preferences are fully sandboxed and cannot be
+        // read from an external process via `defaults`. MDM-managed profiles
+        // are still visible through system_profiler, so prefer that signal
+        // when present; otherwise fall back to a manual-verification warning.
         let task = Process()
         task.executableURL = URL(fileURLWithPath: "/usr/sbin/system_profiler")
         task.arguments = ["SPConfigurationProfileDataType"]
@@ -47,45 +51,16 @@ class SafariStatusBarCheck: Vulnerability {
                     checkstatus = "Red"
                 }
             } else {
-                checkViaDefaults()
+                // Cannot verify from outside Safari's sandbox on macOS Tahoe.
+                // Manual review required.
+                status = "Cannot verify from outside Safari's sandbox. In Safari, open the View menu and choose 'Show Status Bar'."
+                checkstatus = "Yellow"
             }
         } catch let e {
             print("Error checking \(name): \(e)")
             self.error = e
             checkstatus = "Yellow"
             status = "Error checking Safari status bar"
-        }
-    }
-
-    private func checkViaDefaults() {
-        let task = Process()
-        task.executableURL = URL(fileURLWithPath: "/usr/bin/env")
-        task.arguments = ["defaults", "read", "com.apple.Safari", "ShowOverlayStatusBar"]
-
-        let outputPipe = Pipe()
-        task.standardOutput = outputPipe
-        task.standardError = Pipe()
-
-        do {
-            try task.run()
-            task.waitUntilExit()
-
-            let output = String(data: outputPipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8)?
-                .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
-
-            if output == "1" {
-                status = "Safari status bar is enabled."
-                checkstatus = "Green"
-            } else if output == "0" {
-                status = "Safari status bar is disabled."
-                checkstatus = "Red"
-            } else {
-                status = "Safari status bar state unknown."
-                checkstatus = "Yellow"
-            }
-        } catch {
-            checkstatus = "Yellow"
-            status = "Could not verify Safari status bar setting."
         }
     }
 }


### PR DESCRIPTION
## Summary

Safari's container plist is fully sandboxed on macOS 26 Tahoe and cannot be read from an external process via \`defaults\` regardless of the path used. v2.1 already converted **CIS 6.3.1** to a manual-verification Yellow warning with explicit Safari Settings instructions. This PR applies the **same pattern** to the four sibling Safari checks that were still returning ambiguous Yellow "state unknown":

| Check | CIS ID |
|---|---|
| Safari Fraudulent Website Warning | 6.3.3 |
| Safari Cross-Site Tracking Prevention | 6.3.4 |
| Safari Advertising Privacy Protection | 6.3.6 |
| Safari Status Bar | 6.3.10 |

## Changes

For each of the 4 check files:

1. **Kept** the \`system_profiler SPConfigurationProfileDataType\` MDM probe (still works on Tahoe — MDM payloads are not sandboxed) as the authoritative primary signal.
2. **Removed** the dead \`checkViaDefaults()\` method that tried \`defaults read com.apple.Safari ...\` (the Tahoe sandbox blocks this unconditionally).
3. **Replaced** with a Yellow warning containing the exact Safari Settings path to check manually, phrased the same way as the existing 6.3.1 fix in \`SafariSafeFileChecks.swift\`.

Net \`-129\` lines of dead/broken code.

## Manual-verification messages per check

- **6.3.3**: \`Safari → Settings → Privacy → enable 'Warn when visiting a fraudulent website'\`
- **6.3.4**: \`Safari → Settings → Privacy → enable 'Prevent cross-site tracking'\`
- **6.3.6**: \`Safari → Settings → Advanced → enable 'Privacy Preserving Ad Measurement'\` (also lists the legacy label for older macOS)
- **6.3.10**: \`Safari → View menu → 'Show Status Bar'\`

## Test plan

- [ ] Rescan on macOS 26 Tahoe without MDM → all 4 checks return Yellow with the manual-verification path (no more false "state unknown")
- [ ] Apply an MDM profile forcing one of the settings → corresponding check reports Green/Red via the \`system_profiler\` branch
- [ ] Verify label text matches the current Safari UI (6.3.6 label may need tweaking across macOS versions)

Closes #19