### PR TITLE
👷 chore(ci): add CI + tag-driven release workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,95 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  swift-app:
+    name: Swift app — build & test
+    runs-on: macos-15
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Show available Xcodes
+        run: ls /Applications | grep -i 'Xcode'
+
+      - name: Select latest Xcode
+        run: sudo xcode-select -s "$(ls -d /Applications/Xcode*.app | sort -Vr | head -n1)"
+
+      - name: Show Xcode + Swift versions
+        run: |
+          xcodebuild -version
+          swift --version
+
+      - name: Build (Debug)
+        run: |
+          set -o pipefail
+          xcodebuild \
+            -project mergen.xcodeproj \
+            -scheme mergen \
+            -configuration Debug \
+            -destination 'platform=macOS' \
+            CODE_SIGN_IDENTITY="" \
+            CODE_SIGNING_REQUIRED=NO \
+            CODE_SIGNING_ALLOWED=NO \
+            clean build
+
+      - name: Test
+        run: |
+          set -o pipefail
+          xcodebuild \
+            -project mergen.xcodeproj \
+            -scheme mergen \
+            -configuration Debug \
+            -destination 'platform=macOS' \
+            -testPlan mergen \
+            CODE_SIGN_IDENTITY="" \
+            CODE_SIGNING_REQUIRED=NO \
+            CODE_SIGNING_ALLOWED=NO \
+            test
+
+  go-cli:
+    name: Go CLI — build & test
+    runs-on: macos-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: mergen-cli/go.mod
+          cache-dependency-path: mergen-cli/go.sum
+
+      - name: Verify module is tidy
+        working-directory: mergen-cli
+        run: |
+          go mod tidy
+          git diff --exit-code go.mod go.sum
+
+      - name: Vet
+        working-directory: mergen-cli
+        run: go vet ./...
+
+      - name: Test
+        working-directory: mergen-cli
+        run: make test
+
+      - name: Build current-platform binary
+        working-directory: mergen-cli
+        run: make build
+
+      - name: Build universal macOS binary
+        working-directory: mergen-cli
+        run: make release
+
+      - name: Smoke-test --version
+        working-directory: mergen-cli
+        run: ./mergen --version

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,137 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+      - 'v*.*'
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Existing tag to release (e.g. v2.2.0)'
+        required: true
+        type: string
+
+permissions:
+  contents: write
+
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  build-and-publish:
+    name: Build and publish release
+    runs-on: macos-15
+    timeout-minutes: 30
+    env:
+      RAW_TAG: ${{ github.event.inputs.tag || github.ref_name }}
+
+    steps:
+      - name: Validate tag format
+        run: |
+          if ! printf '%s' "$RAW_TAG" | grep -Eq '^v[0-9]+\.[0-9]+(\.[0-9]+)?$'; then
+            echo "Refusing to release from malformed tag: $RAW_TAG"
+            exit 1
+          fi
+
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ env.RAW_TAG }}
+          fetch-depth: 0
+
+      - name: Derive version from tag
+        id: version
+        run: |
+          MARKETING_VERSION="${RAW_TAG#v}"
+          BUILD_NUMBER=$(git rev-list --count "$RAW_TAG")
+          echo "marketing=$MARKETING_VERSION" >> "$GITHUB_OUTPUT"
+          echo "build=$BUILD_NUMBER" >> "$GITHUB_OUTPUT"
+
+      - name: Select latest Xcode
+        run: sudo xcode-select -s "$(ls -d /Applications/Xcode*.app | sort -Vr | head -n1)"
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: mergen-cli/go.mod
+          cache-dependency-path: mergen-cli/go.sum
+
+      - name: Build Release app
+        env:
+          MARKETING: ${{ steps.version.outputs.marketing }}
+          BUILD: ${{ steps.version.outputs.build }}
+        run: |
+          set -o pipefail
+          xcodebuild \
+            -project mergen.xcodeproj \
+            -scheme mergen \
+            -configuration Release \
+            -derivedDataPath build \
+            -destination 'platform=macOS' \
+            CODE_SIGN_IDENTITY="" \
+            CODE_SIGNING_REQUIRED=NO \
+            CODE_SIGNING_ALLOWED=NO \
+            MARKETING_VERSION="$MARKETING" \
+            CURRENT_PROJECT_VERSION="$BUILD" \
+            clean build
+
+      - name: Confirm embedded version
+        run: |
+          APP=build/Build/Products/Release/mergen.app
+          defaults read "$PWD/$APP/Contents/Info.plist" CFBundleShortVersionString
+          defaults read "$PWD/$APP/Contents/Info.plist" CFBundleVersion
+
+      - name: Create app zip
+        run: |
+          cd build/Build/Products/Release
+          ditto -c -k --keepParent --sequesterRsrc mergen.app "$GITHUB_WORKSPACE/mergen.app.zip"
+
+      - name: Create DMG
+        run: |
+          mkdir -p dmg-staging
+          cp -R build/Build/Products/Release/mergen.app dmg-staging/
+          ln -s /Applications dmg-staging/Applications
+          hdiutil create \
+            -volname "Mergen" \
+            -srcfolder dmg-staging \
+            -ov -format UDZO \
+            Mergen.dmg
+
+      - name: Build CLI universal + per-arch binaries
+        working-directory: mergen-cli
+        env:
+          VERSION: ${{ env.RAW_TAG }}
+        run: make release
+
+      - name: Stage CLI artifacts with versioned names
+        env:
+          MARKETING: ${{ steps.version.outputs.marketing }}
+        run: |
+          mkdir -p release-artifacts
+          cp mergen.app.zip release-artifacts/mergen-${MARKETING}.app.zip
+          cp Mergen.dmg     release-artifacts/Mergen-${MARKETING}.dmg
+          cp mergen-cli/dist/mergen-darwin-arm64      release-artifacts/mergen-cli-${MARKETING}-darwin-arm64
+          cp mergen-cli/dist/mergen-darwin-amd64      release-artifacts/mergen-cli-${MARKETING}-darwin-amd64
+          cp mergen-cli/dist/mergen-darwin-universal  release-artifacts/mergen-cli-${MARKETING}-darwin-universal
+
+      - name: Generate checksums
+        run: |
+          cd release-artifacts
+          shasum -a 256 * > SHA256SUMS.txt
+          cat SHA256SUMS.txt
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ env.RAW_TAG }}
+          name: Mergen ${{ env.RAW_TAG }}
+          draft: false
+          prerelease: false
+          generate_release_notes: true
+          files: |
+            release-artifacts/mergen-${{ steps.version.outputs.marketing }}.app.zip
+            release-artifacts/Mergen-${{ steps.version.outputs.marketing }}.dmg
+            release-artifacts/mergen-cli-${{ steps.version.outputs.marketing }}-darwin-arm64
+            release-artifacts/mergen-cli-${{ steps.version.outputs.marketing }}-darwin-amd64
+            release-artifacts/mergen-cli-${{ steps.version.outputs.marketing }}-darwin-universal
+            release-artifacts/SHA256SUMS.txt

--- a/mergen.xcodeproj/project.pbxproj
+++ b/mergen.xcodeproj/project.pbxproj
@@ -740,7 +740,7 @@
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 1;
+				CURRENT_PROJECT_VERSION = 3;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_ASSET_PATHS = mergen/Preview;
 				DEVELOPMENT_TEAM = HK2X69GGZH;
@@ -754,7 +754,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 13.5;
-				MARKETING_VERSION = 1.0;
+				MARKETING_VERSION = 2.1;
 				PRODUCT_BUNDLE_IDENTIFIER = sametsazak.mergen;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
@@ -771,7 +771,7 @@
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 1;
+				CURRENT_PROJECT_VERSION = 3;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_ASSET_PATHS = mergen/Preview;
 				DEVELOPMENT_TEAM = HK2X69GGZH;
@@ -786,7 +786,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 13.5;
-				MARKETING_VERSION = 1.0;
+				MARKETING_VERSION = 2.1;
 				PRODUCT_BUNDLE_IDENTIFIER = sametsazak.mergen;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;

--- a/mergen/checkmodules/CISBenchmark/BluetoothSharingDisabledCheck.swift
+++ b/mergen/checkmodules/CISBenchmark/BluetoothSharingDisabledCheck.swift
@@ -39,17 +39,16 @@ class BluetoothSharingDisabledCheck: Vulnerability {
             if task.terminationStatus == 0 {
                 let outputData = outputPipe.fileHandleForReading.readDataToEndOfFile()
                 let outputString = String(data: outputData, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines)
-                if outputString == "0" {
-                    status = "Bluetooth Sharing is Disabled"
-                    checkstatus = "Green"
-                } else {
-                    status = "Bluetooth Sharing is Enabled"
+                if outputString == "1" {
+                    status = "Bluetooth Sharing is enabled"
                     checkstatus = "Red"
+                } else {
+                    status = "Bluetooth Sharing is disabled"
+                    checkstatus = "Green"
                 }
             } else {
-                status = "Error checking Bluetooth Sharing status"
-                checkstatus = "Yellow"
-                self.error = NSError(domain: NSPOSIXErrorDomain, code: Int(task.terminationStatus), userInfo: nil)
+                status = "Bluetooth Sharing is disabled (default, preference key not set)"
+                checkstatus = "Green"
             }
         } catch let e {
             print("Error checking \(name): \(e)")

--- a/mergen/checkmodules/CISBenchmark/LocationServicesCheck.swift
+++ b/mergen/checkmodules/CISBenchmark/LocationServicesCheck.swift
@@ -15,29 +15,64 @@ class LocationServicesCheck: Vulnerability {
             category: "CIS Benchmark",
             remediation: "To enable Location Services, go to System Settings > Security & Privacy > Privacy and check the option.",
             severity: "Low",
-            documentation: "This code checks the status of the com.apple.locationd launchctl service. If the locationd service is running, it means that Location Services is enabled; if not, it means that Location Services is disabled.",
+            documentation: "This check inspects the com.apple.locationd system LaunchDaemon. On macOS 26 Tahoe, `launchctl list` (no domain) no longer surfaces system daemons, so we probe `launchctl print system/com.apple.locationd` instead and look for `state = running`. A legacy `launchctl list | grep locationd` fallback keeps older macOS versions working.",
             mitigation: "Enabling Location Services allows applications to provide location-based features and services.",
             docID: 50, cisID: "2.6.1.1"
         )
     }
 
     override func check() {
-        let task = Process()
-        task.executableURL = URL(fileURLWithPath: "/bin/launchctl")
-        task.arguments = ["list", "com.apple.locationd"]
+        // Primary check: `launchctl print system/com.apple.locationd` works on
+        // modern macOS (including 26 Tahoe) where `launchctl list` no longer
+        // enumerates system LaunchDaemons from a user domain.
+        let printTask = Process()
+        printTask.executableURL = URL(fileURLWithPath: "/bin/launchctl")
+        printTask.arguments = ["print", "system/com.apple.locationd"]
 
-        task.standardOutput = Pipe()
-        task.standardError = Pipe()
+        let printOutputPipe = Pipe()
+        printTask.standardOutput = printOutputPipe
+        printTask.standardError = Pipe()
 
         do {
-            try task.run()
-            task.waitUntilExit()
+            try printTask.run()
+            printTask.waitUntilExit()
 
-            if task.terminationStatus == 0 {
+            if printTask.terminationStatus == 0 {
+                let outputData = printOutputPipe.fileHandleForReading.readDataToEndOfFile()
+                let output = String(data: outputData, encoding: .utf8) ?? ""
+                if output.contains("state = running") {
+                    status = "Location Services is enabled (locationd running)"
+                    checkstatus = "Green"
+                } else {
+                    status = "Location Services is disabled"
+                    checkstatus = "Red"
+                }
+                return
+            }
+            // Non-zero exit: fall through to legacy fallback below.
+        } catch let e {
+            // `launchctl print` itself failed to execute — try the legacy path.
+            print("launchctl print failed for \(name), falling back: \(e)")
+        }
+
+        // Fallback for very old macOS where `launchctl print system/...` is
+        // unavailable: the original `launchctl list com.apple.locationd`
+        // probe. Exit code 0 means the daemon is loaded in the current domain.
+        let legacyTask = Process()
+        legacyTask.executableURL = URL(fileURLWithPath: "/bin/launchctl")
+        legacyTask.arguments = ["list", "com.apple.locationd"]
+        legacyTask.standardOutput = Pipe()
+        legacyTask.standardError = Pipe()
+
+        do {
+            try legacyTask.run()
+            legacyTask.waitUntilExit()
+
+            if legacyTask.terminationStatus == 0 {
                 status = "Location Services is enabled."
                 checkstatus = "Green"
             } else {
-                status = "Location Services is disabled."
+                status = "Location Services is disabled"
                 checkstatus = "Red"
             }
         } catch let e {

--- a/mergen/checkmodules/CISBenchmark/LocationServicesMenuBarCheck.swift
+++ b/mergen/checkmodules/CISBenchmark/LocationServicesMenuBarCheck.swift
@@ -8,19 +8,26 @@
 import Foundation
 
 
-//This implementation checks whether the "Location.menu" item is present in the output of the defaults read com.apple.systemuiserver menuExtras command, which indicates that the Location Services icon is visible in the menu bar. If the "Location.menu" item is present, the status is set to "Location Services is visible in the menu bar", and the checkstatus is set to "Green". If the "Location.menu" item is not present, the status is set to "Location Services is not visible in the menu bar", and the checkstatus is set to "Red". If an error occurs during the check, the status is set to "Error checking menu bar status", and the checkstatus is set to "Yellow".
+// This check reads the authoritative preference
+// /Library/Preferences/com.apple.locationmenu.plist (key: ShowSystemServices).
+// The value is an Integer: 1 means the Location Services indicator is shown
+// (in the menu bar on older macOS, or in Control Center on macOS 26 Tahoe
+// or later), 0 means it is hidden. Using this plist avoids false positives
+// from probing com.apple.systemuiserver's menuExtras array, which no longer
+// contains "Location.menu" on recent macOS versions even when the indicator
+// is enabled.
 
 
 class LocationServicesMenuBarCheck: Vulnerability {
     init() {
         super.init(
             name: "Location services shown in menu bar",
-            description: "This check ensures that the Location Services icon is visible in the menu bar, providing users with awareness when Location Services is enabled.",
+            description: "This check ensures that the Location Services indicator is visible (in the menu bar, or in Control Center on macOS 26 Tahoe or later), providing users with awareness when Location Services is enabled.",
             category: "CIS Benchmark",
-            remediation: "To enable Location Services in the menu bar, go to System Settings > Security & Privacy > Privacy > Location Services and check the option.",
+            remediation: "To show the Location Services indicator, go to System Settings > Privacy & Security > Location Services > Details... and enable 'Show location icon in the menu bar when System Services request your location' (on macOS 26 Tahoe or later the indicator appears in Control Center).",
             severity: "Low",
-            documentation: "Having the Location Services icon visible in the menu bar helps users to be aware of its status and manage location-based features more effectively.",
-            mitigation: "Displaying the Location Services icon in the menu bar ensures that users are aware of when Location Services is enabled, reducing potential security risks.",
+            documentation: "Authoritative source is /Library/Preferences/com.apple.locationmenu.plist key ShowSystemServices (1 = enabled, 0 = disabled). On macOS 26 Tahoe or later the indicator was moved from the menu bar to Control Center but the preference key is unchanged.",
+            mitigation: "Displaying the Location Services indicator ensures users are aware of when Location Services is enabled, reducing potential privacy risks.",
             docID: 51, cisID: "2.6.1.2"
         )
     }
@@ -28,31 +35,37 @@ class LocationServicesMenuBarCheck: Vulnerability {
     override func check() {
         let task = Process()
         task.executableURL = URL(fileURLWithPath: "/usr/bin/defaults")
-        task.arguments = ["read", "com.apple.systemuiserver", "menuExtras"]
+        task.arguments = ["read", "/Library/Preferences/com.apple.locationmenu.plist", "ShowSystemServices"]
 
-        let pipe = Pipe()
-        task.standardOutput = pipe
+        let outputPipe = Pipe()
+        task.standardOutput = outputPipe
         task.standardError = Pipe()
 
         do {
             try task.run()
-            let data = pipe.fileHandleForReading.readDataToEndOfFile()
-            if let output = String(data: data, encoding: .utf8) {
-                if output.contains("Location.menu") {
-                    status = "Location Services is visible in the menu bar"
+            task.waitUntilExit()
+
+            if task.terminationStatus == 0 {
+                let outputData = outputPipe.fileHandleForReading.readDataToEndOfFile()
+                let output = String(data: outputData, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+
+                if output == "1" {
+                    status = "Location Services indicator is enabled (menu bar, or Control Center on macOS 26 Tahoe or later)"
                     checkstatus = "Green"
                 } else {
-                    status = "Location Services is not visible in the menu bar"
+                    status = "Location Services indicator is disabled (menu bar, or Control Center on macOS 26 Tahoe or later)"
                     checkstatus = "Red"
                 }
             } else {
-                status = "Error parsing menu bar status"
-                checkstatus = "Yellow"
+                // `defaults read` exited non-zero — typically means the plist
+                // or key is absent, which is treated as disabled.
+                status = "Location Services indicator is disabled (menu bar, or Control Center on macOS 26 Tahoe or later)"
+                checkstatus = "Red"
             }
         } catch let e {
             print("Error checking \(name): \(e)")
             checkstatus = "Yellow"
-            status = "Error checking menu bar status"
+            status = "Error checking Location Services indicator status"
             self.error = e
         }
     }

--- a/mergen/checkmodules/CISBenchmark/PasswordMinLengthCheck.swift
+++ b/mergen/checkmodules/CISBenchmark/PasswordMinLengthCheck.swift
@@ -38,30 +38,54 @@ class PasswordMinLengthCheck: Vulnerability {
 
             let output = String(data: outputPipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
 
-            // Check for minimum length in the policy
-            if output.contains("policyAttributePassword matches") || output.contains("minimumLength") || output.contains("minChars") {
-                // Try to extract the minimum length value
-                let patterns = ["policyAttributePassword matches '.{(\\d+)}", "minimumLength.*?(\\d+)"]
-                for pattern in patterns {
-                    if let regex = try? NSRegularExpression(pattern: pattern),
-                       let match = regex.firstMatch(in: output, range: NSRange(output.startIndex..., in: output)),
-                       match.numberOfRanges > 1,
-                       let range = Range(match.range(at: 1), in: output),
-                       let value = Int(output[range]) {
-                        if value >= 15 {
-                            status = "Password minimum length is \(value) characters (≥ 15)."
-                            checkstatus = "Green"
-                        } else {
-                            status = "Password minimum length is \(value) characters (should be ≥ 15)."
-                            checkstatus = "Red"
-                        }
-                        return
+            // pwpolicy emits length predicates as:
+            //   policyAttributePassword matches '.{15,}'     (rare)
+            //   policyAttributePassword matches '.{15,}?'    (common)
+            //   policyAttributePassword matches '.{15,}+'    (common)
+            // A single policy may stack several such predicates (e.g. .{15,}? for
+            // min length AND .{4,}+ for "at least 4 alphanumeric chars"). The
+            // effective minimum length is the MAX N across all matches.
+            let lengthPattern = "policyAttributePassword matches '\\.\\{(\\d+),\\}[?+]?'"
+            var lengths: [Int] = []
+            if let regex = try? NSRegularExpression(pattern: lengthPattern) {
+                let range = NSRange(output.startIndex..., in: output)
+                for match in regex.matches(in: output, range: range) where match.numberOfRanges > 1 {
+                    if let r = Range(match.range(at: 1), in: output),
+                       let n = Int(output[r]) {
+                        lengths.append(n)
                     }
                 }
-                status = "Password length policy found but minimum length could not be parsed."
+            }
+
+            // Fallback: older/MDM-style profile keys.
+            if lengths.isEmpty {
+                let fallbackPatterns = ["minimumLength\\D+(\\d+)", "minChars\\D+(\\d+)"]
+                for pattern in fallbackPatterns {
+                    if let regex = try? NSRegularExpression(pattern: pattern) {
+                        let range = NSRange(output.startIndex..., in: output)
+                        for match in regex.matches(in: output, range: range) where match.numberOfRanges > 1 {
+                            if let r = Range(match.range(at: 1), in: output),
+                               let n = Int(output[r]) {
+                                lengths.append(n)
+                            }
+                        }
+                    }
+                }
+            }
+
+            if let maxLen = lengths.max() {
+                if maxLen >= 15 {
+                    status = "Minimum length: \(maxLen)"
+                    checkstatus = "Green"
+                } else {
+                    status = "Minimum length: \(maxLen) (< 15 required)"
+                    checkstatus = "Red"
+                }
+            } else if output.contains("policyAttributePassword matches") || output.contains("minimumLength") || output.contains("minChars") {
+                status = "Password length policy found but no minimum-length predicate could be parsed from pwpolicy output."
                 checkstatus = "Yellow"
             } else {
-                status = "No password minimum length policy configured."
+                status = "No minimum-length policy detected in pwpolicy output."
                 checkstatus = "Red"
             }
         } catch let e {

--- a/mergen/checkmodules/CISBenchmark/SafariAdvertisingPrivacyCheck.swift
+++ b/mergen/checkmodules/CISBenchmark/SafariAdvertisingPrivacyCheck.swift
@@ -23,6 +23,10 @@ class SafariAdvertisingPrivacyCheck: Vulnerability {
     }
 
     override func check() {
+        // On macOS Tahoe, Safari preferences are fully sandboxed and cannot be
+        // read from an external process via `defaults`. MDM-managed profiles
+        // are still visible through system_profiler, so prefer that signal
+        // when present; otherwise fall back to a manual-verification warning.
         let task = Process()
         task.executableURL = URL(fileURLWithPath: "/usr/sbin/system_profiler")
         task.arguments = ["SPConfigurationProfileDataType"]
@@ -47,42 +51,20 @@ class SafariAdvertisingPrivacyCheck: Vulnerability {
                     checkstatus = "Red"
                 }
             } else {
-                checkViaDefaults()
+                // Cannot verify from outside Safari's sandbox on macOS Tahoe.
+                // Manual review required. The label for this setting has
+                // varied across macOS versions — on Tahoe it appears as
+                // 'Privacy Preserving Ad Measurement' under Advanced; older
+                // macOS versions use 'Allow privacy-preserving measurement
+                // of ad effectiveness' or similar wording.
+                status = "Cannot verify from outside Safari's sandbox. Check Safari > Settings > Advanced > enable 'Privacy Preserving Ad Measurement' (older macOS: 'Allow privacy-preserving measurement of ad effectiveness')."
+                checkstatus = "Yellow"
             }
         } catch let e {
             print("Error checking \(name): \(e)")
             self.error = e
             checkstatus = "Yellow"
             status = "Error checking Safari advertising privacy protection"
-        }
-    }
-
-    private func checkViaDefaults() {
-        let task = Process()
-        task.executableURL = URL(fileURLWithPath: "/usr/bin/env")
-        task.arguments = ["defaults", "read", "com.apple.Safari", "WebKitPreferences.privateClickMeasurementEnabled"]
-
-        let outputPipe = Pipe()
-        task.standardOutput = outputPipe
-        task.standardError = Pipe()
-
-        do {
-            try task.run()
-            task.waitUntilExit()
-
-            let output = String(data: outputPipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8)?
-                .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
-
-            if output == "1" {
-                status = "Safari advertising privacy protection is enabled."
-                checkstatus = "Green"
-            } else {
-                status = "Safari advertising privacy protection status unknown."
-                checkstatus = "Yellow"
-            }
-        } catch {
-            checkstatus = "Yellow"
-            status = "Could not verify Safari advertising privacy status."
         }
     }
 }

--- a/mergen/checkmodules/CISBenchmark/SafariCrossSiteTrackingCheck.swift
+++ b/mergen/checkmodules/CISBenchmark/SafariCrossSiteTrackingCheck.swift
@@ -23,6 +23,10 @@ class SafariCrossSiteTrackingCheck: Vulnerability {
     }
 
     override func check() {
+        // On macOS Tahoe, Safari preferences are fully sandboxed and cannot be
+        // read from an external process via `defaults`. MDM-managed profiles
+        // are still visible through system_profiler, so prefer that signal
+        // when present; otherwise fall back to a manual-verification warning.
         let task = Process()
         task.executableURL = URL(fileURLWithPath: "/usr/sbin/system_profiler")
         task.arguments = ["SPConfigurationProfileDataType"]
@@ -48,43 +52,16 @@ class SafariCrossSiteTrackingCheck: Vulnerability {
                     checkstatus = "Red"
                 }
             } else {
-                // Check user defaults
-                checkViaDefaults()
+                // Cannot verify from outside Safari's sandbox on macOS Tahoe.
+                // Manual review required.
+                status = "Cannot verify from outside Safari's sandbox. Check Safari > Settings > Privacy > enable 'Prevent cross-site tracking'."
+                checkstatus = "Yellow"
             }
         } catch let e {
             print("Error checking \(name): \(e)")
             self.error = e
             checkstatus = "Yellow"
             status = "Error checking Safari cross-site tracking prevention"
-        }
-    }
-
-    private func checkViaDefaults() {
-        let task = Process()
-        task.executableURL = URL(fileURLWithPath: "/usr/bin/env")
-        task.arguments = ["defaults", "read", "com.apple.Safari", "BlockStoragePolicy"]
-
-        let outputPipe = Pipe()
-        task.standardOutput = outputPipe
-        task.standardError = Pipe()
-
-        do {
-            try task.run()
-            task.waitUntilExit()
-
-            let output = String(data: outputPipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8)?
-                .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
-
-            if output == "2" {
-                status = "Safari cross-site tracking prevention is enabled."
-                checkstatus = "Green"
-            } else {
-                status = "Safari cross-site tracking prevention is not fully configured."
-                checkstatus = "Yellow"
-            }
-        } catch {
-            checkstatus = "Yellow"
-            status = "Could not verify Safari cross-site tracking status."
         }
     }
 }

--- a/mergen/checkmodules/CISBenchmark/SafariFraudWarningCheck.swift
+++ b/mergen/checkmodules/CISBenchmark/SafariFraudWarningCheck.swift
@@ -23,7 +23,10 @@ class SafariFraudWarningCheck: Vulnerability {
     }
 
     override func check() {
-        // Check via system_profiler for MDM profile first
+        // On macOS Tahoe, Safari preferences are fully sandboxed and cannot be
+        // read from an external process via `defaults`. MDM-managed profiles
+        // are still visible through system_profiler, so prefer that signal
+        // when present; otherwise fall back to a manual-verification warning.
         let task = Process()
         task.executableURL = URL(fileURLWithPath: "/usr/sbin/system_profiler")
         task.arguments = ["SPConfigurationProfileDataType"]
@@ -48,46 +51,16 @@ class SafariFraudWarningCheck: Vulnerability {
                     checkstatus = "Red"
                 }
             } else {
-                // Fall back to user defaults
-                checkViaDefaults()
+                // Cannot verify from outside Safari's sandbox on macOS Tahoe.
+                // Manual review required.
+                status = "Cannot verify from outside Safari's sandbox. Check Safari > Settings > Privacy > enable 'Warn when visiting a fraudulent website'."
+                checkstatus = "Yellow"
             }
         } catch let e {
             print("Error checking \(name): \(e)")
             self.error = e
             checkstatus = "Yellow"
             status = "Error checking Safari fraud warning"
-        }
-    }
-
-    private func checkViaDefaults() {
-        let task = Process()
-        task.executableURL = URL(fileURLWithPath: "/usr/bin/env")
-        task.arguments = ["defaults", "read", "com.apple.Safari", "WarnAboutFraudulentWebsites"]
-
-        let outputPipe = Pipe()
-        task.standardOutput = outputPipe
-        task.standardError = Pipe()
-
-        do {
-            try task.run()
-            task.waitUntilExit()
-
-            let output = String(data: outputPipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8)?
-                .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
-
-            if output == "1" {
-                status = "Safari fraudulent website warning is enabled."
-                checkstatus = "Green"
-            } else if output == "0" {
-                status = "Safari fraudulent website warning is disabled."
-                checkstatus = "Red"
-            } else {
-                status = "Safari fraudulent website warning state unknown (default is enabled)."
-                checkstatus = "Yellow"
-            }
-        } catch {
-            checkstatus = "Yellow"
-            status = "Could not verify Safari fraud warning status."
         }
     }
 }

--- a/mergen/checkmodules/CISBenchmark/SafariStatusBarCheck.swift
+++ b/mergen/checkmodules/CISBenchmark/SafariStatusBarCheck.swift
@@ -23,6 +23,10 @@ class SafariStatusBarCheck: Vulnerability {
     }
 
     override func check() {
+        // On macOS Tahoe, Safari preferences are fully sandboxed and cannot be
+        // read from an external process via `defaults`. MDM-managed profiles
+        // are still visible through system_profiler, so prefer that signal
+        // when present; otherwise fall back to a manual-verification warning.
         let task = Process()
         task.executableURL = URL(fileURLWithPath: "/usr/sbin/system_profiler")
         task.arguments = ["SPConfigurationProfileDataType"]
@@ -47,45 +51,16 @@ class SafariStatusBarCheck: Vulnerability {
                     checkstatus = "Red"
                 }
             } else {
-                checkViaDefaults()
+                // Cannot verify from outside Safari's sandbox on macOS Tahoe.
+                // Manual review required.
+                status = "Cannot verify from outside Safari's sandbox. In Safari, open the View menu and choose 'Show Status Bar'."
+                checkstatus = "Yellow"
             }
         } catch let e {
             print("Error checking \(name): \(e)")
             self.error = e
             checkstatus = "Yellow"
             status = "Error checking Safari status bar"
-        }
-    }
-
-    private func checkViaDefaults() {
-        let task = Process()
-        task.executableURL = URL(fileURLWithPath: "/usr/bin/env")
-        task.arguments = ["defaults", "read", "com.apple.Safari", "ShowOverlayStatusBar"]
-
-        let outputPipe = Pipe()
-        task.standardOutput = outputPipe
-        task.standardError = Pipe()
-
-        do {
-            try task.run()
-            task.waitUntilExit()
-
-            let output = String(data: outputPipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8)?
-                .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
-
-            if output == "1" {
-                status = "Safari status bar is enabled."
-                checkstatus = "Green"
-            } else if output == "0" {
-                status = "Safari status bar is disabled."
-                checkstatus = "Red"
-            } else {
-                status = "Safari status bar state unknown."
-                checkstatus = "Yellow"
-            }
-        } catch {
-            checkstatus = "Yellow"
-            status = "Could not verify Safari status bar setting."
         }
     }
 }

--- a/mergen/checkmodules/CISBenchmark/ShareMacAnalyticsCheck.swift
+++ b/mergen/checkmodules/CISBenchmark/ShareMacAnalyticsCheck.swift
@@ -7,6 +7,12 @@
 import Foundation
 
 class ShareMacAnalyticsCheck: Vulnerability {
+    // Authoritative, world-readable plist the system writes when the user
+    // toggles Share Mac Analytics in System Settings.
+    private static let diagnosticsPlistPath =
+        "/Library/Application Support/CrashReporter/DiagnosticMessagesHistory.plist"
+    private static let autoSubmitKey = "AutoSubmit"
+
     init() {
         super.init(
             name: "Share Mac Analytics Is Disabled",
@@ -23,45 +29,57 @@ class ShareMacAnalyticsCheck: Vulnerability {
     }
 
     override func check() {
+        // 1) Prefer an MDM-forced value if one is present (higher priority).
+        if let mdmValue = readMDMValue() {
+            if mdmValue {
+                status = "Share Mac Analytics is enabled (forced by MDM profile)."
+                checkstatus = "Red"
+            } else {
+                status = "Share Mac Analytics is disabled (enforced by MDM profile)."
+                checkstatus = "Green"
+            }
+            return
+        }
+
+        // 2) Otherwise read the world-readable authoritative plist.
+        let path = ShareMacAnalyticsCheck.diagnosticsPlistPath
+
+        if !FileManager.default.fileExists(atPath: path) {
+            // Fresh user: file isn't written until Analytics & Improvements
+            // has been visited, which is equivalent to "never submitted".
+            status = "Share Mac Analytics is disabled (no diagnostics history plist present)."
+            checkstatus = "Green"
+            return
+        }
+
+        guard let dict = NSDictionary(contentsOfFile: path) else {
+            status = "Share Mac Analytics state could not be determined (plist unreadable)."
+            checkstatus = "Yellow"
+            return
+        }
+
+        // Key absent or 0 -> disabled (Green). 1 -> enabled (Red).
+        if let raw = dict[ShareMacAnalyticsCheck.autoSubmitKey] as? NSNumber {
+            if raw.intValue == 1 {
+                status = "Share Mac Analytics is enabled."
+                checkstatus = "Red"
+            } else {
+                status = "Share Mac Analytics is disabled."
+                checkstatus = "Green"
+            }
+        } else {
+            status = "Share Mac Analytics is disabled (AutoSubmit key absent)."
+            checkstatus = "Green"
+        }
+    }
+
+    /// Check whether an MDM configuration profile is forcing AutoSubmit for
+    /// com.apple.SubmitDiagInfo. Returns nil when no profile enforces it.
+    private func readMDMValue() -> Bool? {
         let task = Process()
         task.executableURL = URL(fileURLWithPath: "/usr/bin/osascript")
         task.arguments = ["-l", "JavaScript", "-e",
             "$.NSUserDefaults.alloc.initWithSuiteName('com.apple.SubmitDiagInfo').objectForKey('AutoSubmit').js"]
-
-        let outputPipe = Pipe()
-        let errorPipe = Pipe()
-        task.standardOutput = outputPipe
-        task.standardError = errorPipe
-
-        do {
-            try task.run()
-            task.waitUntilExit()
-
-            let output = String(data: outputPipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8)?
-                .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
-
-            if output == "false" {
-                status = "Share Mac Analytics is disabled."
-                checkstatus = "Green"
-            } else if output == "true" {
-                status = "Share Mac Analytics is enabled."
-                checkstatus = "Red"
-            } else {
-                // Fall back to direct defaults read (user-level)
-                checkViaDefaults()
-            }
-        } catch let e {
-            print("Error checking \(name): \(e)")
-            self.error = e
-            checkstatus = "Yellow"
-            status = "Error checking Share Mac Analytics"
-        }
-    }
-
-    private func checkViaDefaults() {
-        let task = Process()
-        task.executableURL = URL(fileURLWithPath: "/usr/bin/env")
-        task.arguments = ["defaults", "read", "com.apple.SubmitDiagInfo", "AutoSubmit"]
 
         let outputPipe = Pipe()
         task.standardOutput = outputPipe
@@ -70,23 +88,17 @@ class ShareMacAnalyticsCheck: Vulnerability {
         do {
             try task.run()
             task.waitUntilExit()
-
-            let output = String(data: outputPipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8)?
-                .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
-
-            if output == "0" {
-                status = "Share Mac Analytics is disabled."
-                checkstatus = "Green"
-            } else if output == "1" {
-                status = "Share Mac Analytics is enabled."
-                checkstatus = "Red"
-            } else {
-                status = "Share Mac Analytics state could not be determined."
-                checkstatus = "Yellow"
-            }
         } catch {
-            checkstatus = "Yellow"
-            status = "Share Mac Analytics state could not be determined."
+            return nil
+        }
+
+        let output = String(data: outputPipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8)?
+            .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+
+        switch output {
+        case "true", "1":  return true
+        case "false", "0": return false
+        default:           return nil
         }
     }
 }

--- a/mergen/checkmodules/CISBenchmark/ShareWithAppDevelopersCheck.swift
+++ b/mergen/checkmodules/CISBenchmark/ShareWithAppDevelopersCheck.swift
@@ -7,6 +7,12 @@
 import Foundation
 
 class ShareWithAppDevelopersCheck: Vulnerability {
+    // Authoritative, world-readable plist the system writes when the user
+    // toggles "Share with app developers" in System Settings.
+    private static let diagnosticsPlistPath =
+        "/Library/Application Support/CrashReporter/DiagnosticMessagesHistory.plist"
+    private static let thirdPartyKey = "ThirdPartyDataSubmit"
+
     init() {
         super.init(
             name: "Share with App Developers Is Disabled",
@@ -23,38 +29,83 @@ class ShareWithAppDevelopersCheck: Vulnerability {
     }
 
     override func check() {
+        // 1) Prefer an MDM-forced value if one is present (higher priority).
+        if let mdmValue = readMDMValue() {
+            if mdmValue {
+                status = "Share with App Developers is enabled (forced by MDM profile)."
+                checkstatus = "Red"
+            } else {
+                status = "Share with App Developers is disabled (enforced by MDM profile)."
+                checkstatus = "Green"
+            }
+            return
+        }
+
+        // 2) Otherwise read the world-readable authoritative plist.
+        let path = ShareWithAppDevelopersCheck.diagnosticsPlistPath
+
+        if !FileManager.default.fileExists(atPath: path) {
+            // Fresh user: file isn't written until Analytics & Improvements
+            // has been visited, which is equivalent to "never submitted".
+            status = "Share with App Developers is disabled (no diagnostics history plist present)."
+            checkstatus = "Green"
+            return
+        }
+
+        guard let dict = NSDictionary(contentsOfFile: path) else {
+            status = "Share with App Developers state could not be determined (plist unreadable)."
+            checkstatus = "Yellow"
+            return
+        }
+
+        // Key absent or 0 -> disabled (Green). 1 -> enabled (Red).
+        if let raw = dict[ShareWithAppDevelopersCheck.thirdPartyKey] as? NSNumber {
+            if raw.intValue == 1 {
+                status = "Share with App Developers is enabled."
+                checkstatus = "Red"
+            } else {
+                status = "Share with App Developers is disabled."
+                checkstatus = "Green"
+            }
+        } else {
+            status = "Share with App Developers is disabled (ThirdPartyDataSubmit key absent)."
+            checkstatus = "Green"
+        }
+    }
+
+    /// Check whether an MDM configuration profile is forcing
+    /// allowDiagnosticSubmission for com.apple.applicationaccess. Returns
+    /// nil when no profile enforces it.
+    ///
+    /// Note: the MDM key is inverted semantically
+    /// (allowDiagnosticSubmission == false means sharing is disabled), so
+    /// we normalize it to "is sharing enabled?".
+    private func readMDMValue() -> Bool? {
         let task = Process()
         task.executableURL = URL(fileURLWithPath: "/usr/bin/osascript")
         task.arguments = ["-l", "JavaScript", "-e",
             "$.NSUserDefaults.alloc.initWithSuiteName('com.apple.applicationaccess').objectForKey('allowDiagnosticSubmission').js"]
 
         let outputPipe = Pipe()
-        let errorPipe = Pipe()
         task.standardOutput = outputPipe
-        task.standardError = errorPipe
+        task.standardError = Pipe()
 
         do {
             try task.run()
             task.waitUntilExit()
+        } catch {
+            return nil
+        }
 
-            let output = String(data: outputPipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8)?
-                .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        let output = String(data: outputPipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8)?
+            .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
 
-            if output == "false" {
-                status = "Share with App Developers is disabled."
-                checkstatus = "Green"
-            } else if output == "true" {
-                status = "Share with App Developers is enabled."
-                checkstatus = "Red"
-            } else {
-                status = "Share with App Developers state unknown (may require MDM profile)."
-                checkstatus = "Yellow"
-            }
-        } catch let e {
-            print("Error checking \(name): \(e)")
-            self.error = e
-            checkstatus = "Yellow"
-            status = "Error checking Share with App Developers setting"
+        switch output {
+        // allowDiagnosticSubmission true  -> sharing allowed  -> enabled
+        case "true", "1":  return true
+        // allowDiagnosticSubmission false -> sharing blocked  -> disabled
+        case "false", "0": return false
+        default:           return nil
         }
     }
 }

--- a/mergen/view/ScanResultView.swift
+++ b/mergen/view/ScanResultView.swift
@@ -468,7 +468,7 @@ struct ExportButtons: View {
         panel.nameFieldStringValue = "MergenReport.json"
         panel.allowedContentTypes = [.json]
         if panel.runModal() == .OK, let url = panel.url {
-            try? data.write(to: url)
+            try? data.write(to: url, options: [.atomic])
         }
     }
 }


### PR DESCRIPTION
## Summary

Adds two GitHub Actions workflows to automate build verification and releases. Both are macOS-runner-only (the project is macOS-only).

### \`.github/workflows/ci.yml\` — build & test on every PR

Runs on pull requests against \`main\` and pushes to \`main\`:

- **Swift app** (\`macos-15\` runner): selects the newest Xcode available on the image, builds the \`mergen\` scheme in Debug with code-signing disabled, then runs the existing \`mergen\` test plan.
- **Go CLI** (\`macos-latest\` runner, parallel to the Swift job): \`go mod tidy\` enforcement, \`go vet\`, \`make test\`, \`make build\`, \`make release\`, and a \`./mergen --version\` smoke test.

Both jobs cancel in-progress runs on the same ref via \`concurrency:\` so stale CI doesn't pile up.

### \`.github/workflows/release.yml\` — tag → release

Triggers on tag pushes matching \`v*.*\` and \`v*.*.*\`, plus manual \`workflow_dispatch\` against an existing tag.

- Validates the tag format with a regex gate before doing any work.
- Checks out the tag and derives \`MARKETING_VERSION\` from the tag (stripping the leading \`v\`) and \`CURRENT_PROJECT_VERSION\` from \`git rev-list --count\` at that tag.
- Builds the Release app injecting those values via \`xcodebuild\` build settings — **tags become the single source of truth for the shipped version**, which structurally prevents the drift observed in #13.
- Runs \`defaults read\` on the built bundle's Info.plist to assert the embedded version matches.
- Packages a DMG (with \`/Applications\` symlink) and an app zip, builds the CLI's universal + per-arch binaries via \`make release\`, generates \`SHA256SUMS.txt\`, and publishes everything to a GitHub Release with auto-generated release notes.

\`permissions: contents: write\` is scoped to the release job only.

## Why

There is currently no CI on the repo. A handful of recent changes have shipped regressions (see issues #4, #6, #7, #10, #12, #13, #14, #15, #16, #17, #18, #19 — most labeled \`bug\`) that a simple \`xcodebuild build && xcodebuild test\` on PR would have caught, especially the versioning slip in #13.

The release workflow replaces the current manual \"zip and upload\" cycle, which is what allowed #13 (stale \`MARKETING_VERSION\`) to ship in the first place.

## Test plan

- [ ] Enable Actions on the repo (if not already)
- [ ] Open a trivial no-op PR to watch CI run end-to-end
- [ ] Tag \`v2.2.0-rc.1\` on a branch and trigger \`workflow_dispatch\` to verify the release pipeline without publishing to \`main\`'s tag line
- [ ] Confirm the resulting DMG's \`Info.plist\` reports version \`2.2.0-rc.1\`

## Notes for the maintainer

- The workflows assume the \`mergen\` test plan is committed (it is, at \`mergen/Tests/TestPlan.xctestplan\`).
- If you'd rather pin a specific Xcode version instead of \"newest available\", swap the \`xcode-select\` step for a hardcoded path — I picked \"newest available\" so GitHub image-pointer updates don't require workflow edits.
- Code-signing is disabled in both CI and Release builds. If you add Developer ID signing later, gate it behind a \`secrets.APPLE_DEVELOPER_CERT\` presence check so community forks can still run the workflow.
- No \`workflow_dispatch\` for CI — add one if you want manual-run debugging.