### PR TITLE
Add manual audit guide for users who prefer not to install

### DIFF
--- a/.codesight/CODESIGHT.md
+++ b/.codesight/CODESIGHT.md
@@ -1,0 +1,84 @@
+# mergen — AI Context Map
+
+> **Stack:** swiftui, go-net-http | none | unknown | mixed
+> **Monorepo:** mergen-cli, mergen.xcodeproj
+
+> 0 routes | 0 models | 24 components | 7 lib files | 0 env vars | 0 middleware
+> **Token savings:** this file is ~1,900 tokens. Without it, AI exploration would cost ~15,400 tokens. **Saves ~13,600 tokens per conversation.**
+> **Last scanned:** 2026-04-29 00:28 — re-run after significant changes
+
+---
+
+# Components
+
+- **ContentView** [client] — props: selectedVulnerability, isWelcome, scanManager, automated, passCount, failCount, warnCount, score, fixable, scoreColor — `mergen\ContentView.swift`
+- **ResultsTopBar** [client] — props: selectedVulnerability, isWelcome, scanManager, automated, passCount, failCount, warnCount, score, fixable, scoreColor — `mergen\ContentView.swift`
+- **WelcomeView** [client] — props: selectedVulnerability, isWelcome, scanManager, automated, passCount, failCount, warnCount, score, fixable, scoreColor — `mergen\ContentView.swift`
+- **FeatureCard** [client] — props: selectedVulnerability, isWelcome, scanManager, automated, passCount, failCount, warnCount, score, fixable, scoreColor — `mergen\ContentView.swift`
+- **FixAllSheet** [client] — props: scanManager, fixable, adminCount, userCount, isFixing, hasFailures, result, isFixed, isCancelled, rowIcon — `mergen\view\FixAllSheet.swift`
+- **FixRowItem** [client] — props: scanManager, fixable, adminCount, userCount, isFixing, hasFailures, result, isFixed, isCancelled, rowIcon — `mergen\view\FixAllSheet.swift`
+- **LogViewerSheet** [client] — props: lines, filter, keyword, color, filtered, lineColor, timestamp, body_ — `mergen\view\LogViewerSheet.swift`
+- **LogLine** [client] — props: lines, filter, keyword, color, filtered, lineColor, timestamp, body_ — `mergen\view\LogViewerSheet.swift`
+- **ResultsListView** [client] — props: id, icon, color, scanManager, selectedVulnerability, searchText, statusFilter, sortOrder, base, results — `mergen\view\ScanResultView.swift`
+- **FilterSortBar** [client] — props: id, icon, color, scanManager, selectedVulnerability, searchText, statusFilter, sortOrder, base, results — `mergen\view\ScanResultView.swift`
+- **FilterPill** [client] — props: id, icon, color, scanManager, selectedVulnerability, searchText, statusFilter, sortOrder, base, results — `mergen\view\ScanResultView.swift`
+- **ScanProgressBanner** [client] — props: id, icon, color, scanManager, selectedVulnerability, searchText, statusFilter, sortOrder, base, results — `mergen\view\ScanResultView.swift`
+- **ExportButtons** [client] — props: id, icon, color, scanManager, selectedVulnerability, searchText, statusFilter, sortOrder, base, results — `mergen\view\ScanResultView.swift`
+- **EmptyFilterView** [client] — props: id, icon, color, scanManager, selectedVulnerability, searchText, statusFilter, sortOrder, base, results — `mergen\view\ScanResultView.swift`
+- **SectionHeader** [client] — props: id, icon, color, scanManager, selectedVulnerability, searchText, statusFilter, sortOrder, base, results — `mergen\view\ScanResultView.swift`
+- **StatusBadge** [client] — props: id, icon, color, scanManager, selectedVulnerability, searchText, statusFilter, sortOrder, base, results — `mergen\view\ScanResultView.swift`
+- **VulnerabilityRow** [client] — props: id, icon, color, scanManager, selectedVulnerability, searchText, statusFilter, sortOrder, base, results — `mergen\view\ScanResultView.swift`
+- **SeverityDistributionBar** [client] — props: id, icon, color, scanManager, selectedVulnerability, searchText, statusFilter, sortOrder, base, results — `mergen\view\ScanResultView.swift`
+- **SevLegendDot** [client] — props: id, icon, color, scanManager, selectedVulnerability, searchText, statusFilter, sortOrder, base, results — `mergen\view\ScanResultView.swift`
+- **DetailPanelView** [client] — props: scanManager, statusColor, statusIcon, statusLabel, severityColor, hasShellCommands, isFixing, result, isFixed, isCancelled — `mergen\view\VulnerabilityDetailView.swift`
+- **EmptyDetailView** [client] — props: scanManager, statusColor, statusIcon, statusLabel, severityColor, hasShellCommands, isFixing, result, isFixed, isCancelled — `mergen\view\VulnerabilityDetailView.swift`
+- **VulnerabilityDetailView** [client] — props: scanManager, statusColor, statusIcon, statusLabel, severityColor, hasShellCommands, isFixing, result, isFixed, isCancelled — `mergen\view\VulnerabilityDetailView.swift`
+- **AutoFixButton** [client] — props: scanManager, statusColor, statusIcon, statusLabel, severityColor, hasShellCommands, isFixing, result, isFixed, isCancelled — `mergen\view\VulnerabilityDetailView.swift`
+- **BadgeView** [client] — props: scanManager, statusColor, statusIcon, statusLabel, severityColor, hasShellCommands, isFixing, result, isFixed, isCancelled — `mergen\view\VulnerabilityDetailView.swift`
+
+---
+
+# Libraries
+
+- `mergen-cli\cmd\root.go` — function SetVersion: (v string), function Execute: ()
+- `mergen-cli\internal\checks\registry.go`
+  - function Register: (c Check)
+  - function All: () []Check
+  - function ByCategory: (cat string) []Check
+  - function BySection: (sec string) []Check
+- `mergen-cli\internal\checks\types.go`
+  - class Result
+  - class FixInfo
+  - class CheckResult
+  - interface Check
+- `mergen-cli\internal\output\printer.go`
+  - function PrintBanner: ()
+  - function StatusBadge: (s checks.Status) string
+  - function StatusIcon: (s checks.Status) string
+  - function PrintCheckResult: (cr checks.CheckResult)
+  - function PrintSectionHeader: (section, title string, count int)
+  - function PrintProgress: (done, total int) string
+  - _...4 more_
+- `mergen-cli\internal\output\styles.go` — function SeverityColor: (sev string) lipgloss.Style
+- `mergen-cli\internal\report\report.go` — function JSON: (results []checks.CheckResult) ([]byte, error), function HTML: (results []checks.CheckResult) string
+- `mergen-cli\internal\runner\runner.go` — function Run: (cs []checks.Check, workers int) <-chan Progress, class Progress
+
+---
+
+# Dependency Graph
+
+## Most Imported Files (change these carefully)
+
+- `os/exec` — imported by **3** files
+- `unicode/utf8` — imported by **1** files
+- `encoding/json` — imported by **1** files
+
+## Import Map (who imports what)
+
+- `os/exec` ← `mergen-cli\cmd\fix.go`, `mergen-cli\cmd\tui.go`, `mergen-cli\internal\checks\helpers.go`
+- `unicode/utf8` ← `mergen-cli\internal\output\printer.go`
+- `encoding/json` ← `mergen-cli\internal\report\report.go`
+
+---
+
+_Generated by [codesight](https://github.com/Houseofmvps/codesight) — see your codebase clearly_

--- a/.codesight/CODESIGHT.md
+++ b/.codesight/CODESIGHT.md
@@ -5,7 +5,7 @@
 
 > 0 routes | 0 models | 24 components | 7 lib files | 0 env vars | 0 middleware
 > **Token savings:** this file is ~1,900 tokens. Without it, AI exploration would cost ~15,400 tokens. **Saves ~13,600 tokens per conversation.**
-> **Last scanned:** 2026-04-29 00:28 — re-run after significant changes
+> **Last scanned:** 2026-04-29 23:40 — re-run after significant changes
 
 ---
 

--- a/.codesight/components.md
+++ b/.codesight/components.md
@@ -1,0 +1,26 @@
+# Components
+
+- **ContentView** [client] — props: selectedVulnerability, isWelcome, scanManager, automated, passCount, failCount, warnCount, score, fixable, scoreColor — `mergen\ContentView.swift`
+- **ResultsTopBar** [client] — props: selectedVulnerability, isWelcome, scanManager, automated, passCount, failCount, warnCount, score, fixable, scoreColor — `mergen\ContentView.swift`
+- **WelcomeView** [client] — props: selectedVulnerability, isWelcome, scanManager, automated, passCount, failCount, warnCount, score, fixable, scoreColor — `mergen\ContentView.swift`
+- **FeatureCard** [client] — props: selectedVulnerability, isWelcome, scanManager, automated, passCount, failCount, warnCount, score, fixable, scoreColor — `mergen\ContentView.swift`
+- **FixAllSheet** [client] — props: scanManager, fixable, adminCount, userCount, isFixing, hasFailures, result, isFixed, isCancelled, rowIcon — `mergen\view\FixAllSheet.swift`
+- **FixRowItem** [client] — props: scanManager, fixable, adminCount, userCount, isFixing, hasFailures, result, isFixed, isCancelled, rowIcon — `mergen\view\FixAllSheet.swift`
+- **LogViewerSheet** [client] — props: lines, filter, keyword, color, filtered, lineColor, timestamp, body_ — `mergen\view\LogViewerSheet.swift`
+- **LogLine** [client] — props: lines, filter, keyword, color, filtered, lineColor, timestamp, body_ — `mergen\view\LogViewerSheet.swift`
+- **ResultsListView** [client] — props: id, icon, color, scanManager, selectedVulnerability, searchText, statusFilter, sortOrder, base, results — `mergen\view\ScanResultView.swift`
+- **FilterSortBar** [client] — props: id, icon, color, scanManager, selectedVulnerability, searchText, statusFilter, sortOrder, base, results — `mergen\view\ScanResultView.swift`
+- **FilterPill** [client] — props: id, icon, color, scanManager, selectedVulnerability, searchText, statusFilter, sortOrder, base, results — `mergen\view\ScanResultView.swift`
+- **ScanProgressBanner** [client] — props: id, icon, color, scanManager, selectedVulnerability, searchText, statusFilter, sortOrder, base, results — `mergen\view\ScanResultView.swift`
+- **ExportButtons** [client] — props: id, icon, color, scanManager, selectedVulnerability, searchText, statusFilter, sortOrder, base, results — `mergen\view\ScanResultView.swift`
+- **EmptyFilterView** [client] — props: id, icon, color, scanManager, selectedVulnerability, searchText, statusFilter, sortOrder, base, results — `mergen\view\ScanResultView.swift`
+- **SectionHeader** [client] — props: id, icon, color, scanManager, selectedVulnerability, searchText, statusFilter, sortOrder, base, results — `mergen\view\ScanResultView.swift`
+- **StatusBadge** [client] — props: id, icon, color, scanManager, selectedVulnerability, searchText, statusFilter, sortOrder, base, results — `mergen\view\ScanResultView.swift`
+- **VulnerabilityRow** [client] — props: id, icon, color, scanManager, selectedVulnerability, searchText, statusFilter, sortOrder, base, results — `mergen\view\ScanResultView.swift`
+- **SeverityDistributionBar** [client] — props: id, icon, color, scanManager, selectedVulnerability, searchText, statusFilter, sortOrder, base, results — `mergen\view\ScanResultView.swift`
+- **SevLegendDot** [client] — props: id, icon, color, scanManager, selectedVulnerability, searchText, statusFilter, sortOrder, base, results — `mergen\view\ScanResultView.swift`
+- **DetailPanelView** [client] — props: scanManager, statusColor, statusIcon, statusLabel, severityColor, hasShellCommands, isFixing, result, isFixed, isCancelled — `mergen\view\VulnerabilityDetailView.swift`
+- **EmptyDetailView** [client] — props: scanManager, statusColor, statusIcon, statusLabel, severityColor, hasShellCommands, isFixing, result, isFixed, isCancelled — `mergen\view\VulnerabilityDetailView.swift`
+- **VulnerabilityDetailView** [client] — props: scanManager, statusColor, statusIcon, statusLabel, severityColor, hasShellCommands, isFixing, result, isFixed, isCancelled — `mergen\view\VulnerabilityDetailView.swift`
+- **AutoFixButton** [client] — props: scanManager, statusColor, statusIcon, statusLabel, severityColor, hasShellCommands, isFixing, result, isFixed, isCancelled — `mergen\view\VulnerabilityDetailView.swift`
+- **BadgeView** [client] — props: scanManager, statusColor, statusIcon, statusLabel, severityColor, hasShellCommands, isFixing, result, isFixed, isCancelled — `mergen\view\VulnerabilityDetailView.swift`

--- a/.codesight/graph.md
+++ b/.codesight/graph.md
@@ -1,0 +1,13 @@
+# Dependency Graph
+
+## Most Imported Files (change these carefully)
+
+- `os/exec` — imported by **3** files
+- `unicode/utf8` — imported by **1** files
+- `encoding/json` — imported by **1** files
+
+## Import Map (who imports what)
+
+- `os/exec` ← `mergen-cli\cmd\fix.go`, `mergen-cli\cmd\tui.go`, `mergen-cli\internal\checks\helpers.go`
+- `unicode/utf8` ← `mergen-cli\internal\output\printer.go`
+- `encoding/json` ← `mergen-cli\internal\report\report.go`

--- a/.codesight/libs.md
+++ b/.codesight/libs.md
@@ -1,0 +1,24 @@
+# Libraries
+
+- `mergen-cli\cmd\root.go` — function SetVersion: (v string), function Execute: ()
+- `mergen-cli\internal\checks\registry.go`
+  - function Register: (c Check)
+  - function All: () []Check
+  - function ByCategory: (cat string) []Check
+  - function BySection: (sec string) []Check
+- `mergen-cli\internal\checks\types.go`
+  - class Result
+  - class FixInfo
+  - class CheckResult
+  - interface Check
+- `mergen-cli\internal\output\printer.go`
+  - function PrintBanner: ()
+  - function StatusBadge: (s checks.Status) string
+  - function StatusIcon: (s checks.Status) string
+  - function PrintCheckResult: (cr checks.CheckResult)
+  - function PrintSectionHeader: (section, title string, count int)
+  - function PrintProgress: (done, total int) string
+  - _...4 more_
+- `mergen-cli\internal\output\styles.go` — function SeverityColor: (sev string) lipgloss.Style
+- `mergen-cli\internal\report\report.go` — function JSON: (results []checks.CheckResult) ([]byte, error), function HTML: (results []checks.CheckResult) string
+- `mergen-cli\internal\runner\runner.go` — function Run: (cs []checks.Check, workers int) <-chan Progress, class Progress

--- a/.codesight/wiki/index.md
+++ b/.codesight/wiki/index.md
@@ -1,0 +1,44 @@
+# mergen — Wiki
+
+_Generated 2026-04-29 — re-run `npx codesight --wiki` if the codebase has changed._
+
+Structural map compiled from source code via AST. No LLM — deterministic, 200ms.
+
+> **How to use safely:** These articles tell you WHERE things live and WHAT exists. They do not show full implementation logic. Always read the actual source files before implementing new features or making changes. Never infer how a function works from the wiki alone.
+
+## Articles
+
+- [Overview](./overview.md)
+- [Ui](./ui.md)
+
+## Quick Stats
+
+- Routes: **0**
+- Models: **0**
+- Components: **24**
+- Env vars: **0** required, **0** with defaults
+
+## How to Use
+
+- **New session:** read `index.md` (this file) for orientation — WHERE things are
+- **Architecture question:** read `overview.md` (~500 tokens)
+- **Domain question:** read the relevant article, then **read those source files**
+- **Before implementing anything:** read the source files listed in the article
+- **Full source context:** read `.codesight/CODESIGHT.md`
+
+## What the Wiki Does Not Cover
+
+These exist in your codebase but are **not** reflected in wiki articles:
+- Routes registered dynamically at runtime (loops, plugin factories, `app.use(dynamicRouter)`)
+- Internal routes from npm packages (e.g. Better Auth's built-in `/api/auth/*` endpoints)
+- WebSocket and SSE handlers
+- Raw SQL tables not declared through an ORM
+- Computed or virtual fields absent from schema declarations
+- TypeScript types that are not actual database columns
+- Routes marked `[inferred]` were detected via regex and may have lower precision
+- gRPC, tRPC, and GraphQL resolvers may be partially captured
+
+When in doubt, search the source. The wiki is a starting point, not a complete inventory.
+
+---
+_Last compiled: 2026-04-29 · 3 articles · [codesight](https://github.com/Houseofmvps/codesight)_

--- a/.codesight/wiki/log.md
+++ b/.codesight/wiki/log.md
@@ -1,0 +1,7 @@
+# Wiki Log
+
+History of `npx codesight --wiki` runs. Capped at 20 entries.
+
+## [2026-04-29 00:21:40] scan | 0 routes, 0 models, 24 components → 3 articles
+
+## [2026-04-29 00:28:16] scan | 0 routes, 0 models, 24 components → 3 articles

--- a/.codesight/wiki/log.md
+++ b/.codesight/wiki/log.md
@@ -5,3 +5,5 @@ History of `npx codesight --wiki` runs. Capped at 20 entries.
 ## [2026-04-29 00:21:40] scan | 0 routes, 0 models, 24 components → 3 articles
 
 ## [2026-04-29 00:28:16] scan | 0 routes, 0 models, 24 components → 3 articles
+
+## [2026-04-29 23:40:30] scan | 0 routes, 0 models, 24 components → 3 articles

--- a/.codesight/wiki/overview.md
+++ b/.codesight/wiki/overview.md
@@ -1,0 +1,24 @@
+# mergen — Overview
+
+> **Navigation aid.** This article shows WHERE things live (routes, models, files). Read actual source files before implementing new features or making changes.
+
+**mergen** is a mixed project built with swiftui, go-net-http, organized as a monorepo.
+
+**Workspaces:** `mergen-cli` (`mergen-cli`), `mergen.xcodeproj` (`mergen.xcodeproj`)
+
+## Scale
+
+24 UI components · 7 library files
+
+**UI:** 24 components (unknown) — see [ui.md](./ui.md)
+
+## High-Impact Files
+
+Changes to these files have the widest blast radius across the codebase:
+
+- `os/exec` — imported by **3** files
+- `unicode/utf8` — imported by **1** files
+- `encoding/json` — imported by **1** files
+
+---
+_Back to [index.md](./index.md) · Generated 2026-04-29_

--- a/.codesight/wiki/ui.md
+++ b/.codesight/wiki/ui.md
@@ -1,0 +1,35 @@
+# UI
+
+> **Navigation aid.** Component inventory and prop signatures extracted via AST. Read the source files before adding props or modifying component logic.
+
+**24 components** (unknown)
+
+## Client Components
+
+- **ContentView** — props: selectedVulnerability, isWelcome, scanManager, automated, passCount, failCount, warnCount, score, fixable, scoreColor — `mergen\ContentView.swift`
+- **ResultsTopBar** — props: selectedVulnerability, isWelcome, scanManager, automated, passCount, failCount, warnCount, score, fixable, scoreColor — `mergen\ContentView.swift`
+- **WelcomeView** — props: selectedVulnerability, isWelcome, scanManager, automated, passCount, failCount, warnCount, score, fixable, scoreColor — `mergen\ContentView.swift`
+- **FeatureCard** — props: selectedVulnerability, isWelcome, scanManager, automated, passCount, failCount, warnCount, score, fixable, scoreColor — `mergen\ContentView.swift`
+- **FixAllSheet** — props: scanManager, fixable, adminCount, userCount, isFixing, hasFailures, result, isFixed, isCancelled, rowIcon — `mergen\view\FixAllSheet.swift`
+- **FixRowItem** — props: scanManager, fixable, adminCount, userCount, isFixing, hasFailures, result, isFixed, isCancelled, rowIcon — `mergen\view\FixAllSheet.swift`
+- **LogViewerSheet** — props: lines, filter, keyword, color, filtered, lineColor, timestamp, body_ — `mergen\view\LogViewerSheet.swift`
+- **LogLine** — props: lines, filter, keyword, color, filtered, lineColor, timestamp, body_ — `mergen\view\LogViewerSheet.swift`
+- **ResultsListView** — props: id, icon, color, scanManager, selectedVulnerability, searchText, statusFilter, sortOrder, base, results — `mergen\view\ScanResultView.swift`
+- **FilterSortBar** — props: id, icon, color, scanManager, selectedVulnerability, searchText, statusFilter, sortOrder, base, results — `mergen\view\ScanResultView.swift`
+- **FilterPill** — props: id, icon, color, scanManager, selectedVulnerability, searchText, statusFilter, sortOrder, base, results — `mergen\view\ScanResultView.swift`
+- **ScanProgressBanner** — props: id, icon, color, scanManager, selectedVulnerability, searchText, statusFilter, sortOrder, base, results — `mergen\view\ScanResultView.swift`
+- **ExportButtons** — props: id, icon, color, scanManager, selectedVulnerability, searchText, statusFilter, sortOrder, base, results — `mergen\view\ScanResultView.swift`
+- **EmptyFilterView** — props: id, icon, color, scanManager, selectedVulnerability, searchText, statusFilter, sortOrder, base, results — `mergen\view\ScanResultView.swift`
+- **SectionHeader** — props: id, icon, color, scanManager, selectedVulnerability, searchText, statusFilter, sortOrder, base, results — `mergen\view\ScanResultView.swift`
+- **StatusBadge** — props: id, icon, color, scanManager, selectedVulnerability, searchText, statusFilter, sortOrder, base, results — `mergen\view\ScanResultView.swift`
+- **VulnerabilityRow** — props: id, icon, color, scanManager, selectedVulnerability, searchText, statusFilter, sortOrder, base, results — `mergen\view\ScanResultView.swift`
+- **SeverityDistributionBar** — props: id, icon, color, scanManager, selectedVulnerability, searchText, statusFilter, sortOrder, base, results — `mergen\view\ScanResultView.swift`
+- **SevLegendDot** — props: id, icon, color, scanManager, selectedVulnerability, searchText, statusFilter, sortOrder, base, results — `mergen\view\ScanResultView.swift`
+- **DetailPanelView** — props: scanManager, statusColor, statusIcon, statusLabel, severityColor, hasShellCommands, isFixing, result, isFixed, isCancelled — `mergen\view\VulnerabilityDetailView.swift`
+- **EmptyDetailView** — props: scanManager, statusColor, statusIcon, statusLabel, severityColor, hasShellCommands, isFixing, result, isFixed, isCancelled — `mergen\view\VulnerabilityDetailView.swift`
+- **VulnerabilityDetailView** — props: scanManager, statusColor, statusIcon, statusLabel, severityColor, hasShellCommands, isFixing, result, isFixed, isCancelled — `mergen\view\VulnerabilityDetailView.swift`
+- **AutoFixButton** — props: scanManager, statusColor, statusIcon, statusLabel, severityColor, hasShellCommands, isFixing, result, isFixed, isCancelled — `mergen\view\VulnerabilityDetailView.swift`
+- **BadgeView** — props: scanManager, statusColor, statusIcon, statusLabel, severityColor, hasShellCommands, isFixing, result, isFixed, isCancelled — `mergen\view\VulnerabilityDetailView.swift`
+
+---
+_Back to [overview.md](./overview.md)_

--- a/.repomix/output.xml
+++ b/.repomix/output.xml
@@ -1,0 +1,17962 @@
+This file is a merged representation of the entire codebase, combined into a single document by Repomix.
+
+<file_summary>
+This section contains a summary of this file.
+
+<purpose>
+This file contains a packed representation of the entire repository's contents.
+It is designed to be easily consumable by AI systems for analysis, code review,
+or other automated processes.
+</purpose>
+
+<file_format>
+The content is organized as follows:
+1. This summary section
+2. Repository information
+3. Directory structure
+4. Repository files (if enabled)
+5. Multiple file entries, each consisting of:
+  - File path as an attribute
+  - Full contents of the file
+</file_format>
+
+<usage_guidelines>
+- This file should be treated as read-only. Any changes should be made to the
+  original repository files, not this packed version.
+- When processing this file, use the file path to distinguish
+  between different files in the repository.
+- Be aware that this file may contain sensitive information. Handle it with
+  the same level of security as you would the original repository.
+</usage_guidelines>
+
+<notes>
+- Some files may have been excluded based on .gitignore rules and Repomix's configuration
+- Binary files are not included in this packed representation. Please refer to the Repository Structure section for a complete list of file paths, including binary files
+- Files matching patterns in .gitignore are excluded
+- Files matching default ignore patterns are excluded
+- Files are sorted by Git change count (files with more changes are at the bottom)
+</notes>
+
+</file_summary>
+
+<directory_structure>
+.codesight/CODESIGHT.md
+.codesight/components.md
+.codesight/graph.md
+.codesight/libs.md
+.codesight/wiki/index.md
+.codesight/wiki/log.md
+.codesight/wiki/overview.md
+.codesight/wiki/ui.md
+.gitignore
+AppIcon.appiconset/Contents.json
+img/category.png
+img/darkmode.png
+img/detail.png
+img/main.png
+img/main2.png
+img/mergen-cli.png
+img/mergen-report.png
+img/report.png
+img/report1.png
+LICENSE
+MANUAL_AUDIT_GUIDE.md
+mergen-cli/cmd/fix.go
+mergen-cli/cmd/list.go
+mergen-cli/cmd/report.go
+mergen-cli/cmd/root.go
+mergen-cli/cmd/scan.go
+mergen-cli/cmd/tui.go
+mergen-cli/go.mod
+mergen-cli/internal/checks/airdrop.go
+mergen-cli/internal/checks/apache.go
+mergen-cli/internal/checks/audit_logging.go
+mergen-cli/internal/checks/base.go
+mergen-cli/internal/checks/bonjour.go
+mergen-cli/internal/checks/efi.go
+mergen-cli/internal/checks/fast_user_switching.go
+mergen-cli/internal/checks/file_sharing.go
+mergen-cli/internal/checks/filevault.go
+mergen-cli/internal/checks/finder.go
+mergen-cli/internal/checks/firewall.go
+mergen-cli/internal/checks/gatekeeper.go
+mergen-cli/internal/checks/helpers.go
+mergen-cli/internal/checks/icloud.go
+mergen-cli/internal/checks/internet_sharing.go
+mergen-cli/internal/checks/java.go
+mergen-cli/internal/checks/login_window.go
+mergen-cli/internal/checks/menubar.go
+mergen-cli/internal/checks/password_policy.go
+mergen-cli/internal/checks/power.go
+mergen-cli/internal/checks/printer_sharing.go
+mergen-cli/internal/checks/registry.go
+mergen-cli/internal/checks/remote_management.go
+mergen-cli/internal/checks/root_account.go
+mergen-cli/internal/checks/safari.go
+mergen-cli/internal/checks/screen_sharing.go
+mergen-cli/internal/checks/screensaver_corners.go
+mergen-cli/internal/checks/screensaver.go
+mergen-cli/internal/checks/sip.go
+mergen-cli/internal/checks/siri.go
+mergen-cli/internal/checks/software_updates.go
+mergen-cli/internal/checks/ssh.go
+mergen-cli/internal/checks/sudo.go
+mergen-cli/internal/checks/terminal.go
+mergen-cli/internal/checks/time_machine.go
+mergen-cli/internal/checks/time_sync.go
+mergen-cli/internal/checks/types.go
+mergen-cli/internal/output/printer.go
+mergen-cli/internal/output/styles.go
+mergen-cli/internal/report/report.go
+mergen-cli/internal/runner/runner.go
+mergen-cli/main.go
+mergen-cli/Makefile
+mergen-cli/mergen-report.json
+mergen.xcodeproj/project.pbxproj
+mergen.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+mergen.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+mergen/Assets.xcassets/AccentColor.colorset/Contents.json
+mergen/Assets.xcassets/AppIcon.appiconset/Contents.json
+mergen/Assets.xcassets/AppIcon.appiconset/mergelogo-64.png
+mergen/Assets.xcassets/AppIcon.appiconset/mergelongo-256 1.png
+mergen/Assets.xcassets/AppIcon.appiconset/mergelongo-256.png
+mergen/Assets.xcassets/AppIcon.appiconset/mergenlogo-1024.png
+mergen/Assets.xcassets/AppIcon.appiconset/mergenlogo-128.png
+mergen/Assets.xcassets/AppIcon.appiconset/mergenlogo-16.png
+mergen/Assets.xcassets/AppIcon.appiconset/mergenlogo-32 1.png
+mergen/Assets.xcassets/AppIcon.appiconset/mergenlogo-32.png
+mergen/Assets.xcassets/AppIcon.appiconset/mergenlogo-512 1.png
+mergen/Assets.xcassets/AppIcon.appiconset/mergenlogo-512.png
+mergen/Assets.xcassets/buttoncenter.colorset/Contents.json
+mergen/Assets.xcassets/buttoncolor.colorset/Contents.json
+mergen/Assets.xcassets/buttongradient1.colorset/Contents.json
+mergen/Assets.xcassets/buttongradient2.colorset/Contents.json
+mergen/Assets.xcassets/buttonhover.colorset/Contents.json
+mergen/Assets.xcassets/cisBenchmark.imageset/cisbench3.png
+mergen/Assets.xcassets/cisBenchmark.imageset/Contents.json
+mergen/Assets.xcassets/Color.colorset/Contents.json
+mergen/Assets.xcassets/Contents.json
+mergen/Assets.xcassets/detail.colorset/Contents.json
+mergen/Assets.xcassets/framebackground.colorset/Contents.json
+mergen/Assets.xcassets/Gradient.colorset/Contents.json
+mergen/Assets.xcassets/Gradient2.colorset/Contents.json
+mergen/Assets.xcassets/Gradient3.colorset/Contents.json
+mergen/Assets.xcassets/grayish.colorset/Contents.json
+mergen/Assets.xcassets/m1mini.imageset/Contents.json
+mergen/Assets.xcassets/m1mini.imageset/mergenlogo4.png
+mergen/Assets.xcassets/privacy.imageset/Contents.json
+mergen/Assets.xcassets/privacy.imageset/icon_1.png
+mergen/Assets.xcassets/privacymain.imageset/Contents.json
+mergen/Assets.xcassets/privacymain.imageset/mergenprivacy.png
+mergen/Assets.xcassets/progresscolor.colorset/Contents.json
+mergen/Assets.xcassets/scanresult.colorset/Contents.json
+mergen/Assets.xcassets/security.imageset/Contents.json
+mergen/Assets.xcassets/security.imageset/mergensecurity.png
+mergen/Assets.xcassets/toolcolor.colorset/Contents.json
+mergen/Assets.xcassets/welcome.colorset/Contents.json
+mergen/Assets.xcassets/welcometext.colorset/Contents.json
+mergen/Assets.xcassets/yellown.colorset/Contents.json
+mergen/checkmodules/ApacheHTTPCheck.swift
+mergen/checkmodules/AppSandboxCheck.swift
+mergen/checkmodules/BonjourCheck.swift
+mergen/checkmodules/CertificateTrustCheck.swift
+mergen/checkmodules/CISBenchmark/AdminPasswordForSystemPrefsCheck.swift
+mergen/checkmodules/CISBenchmark/AirDropDisabledCheck.swift
+mergen/checkmodules/CISBenchmark/AirPlayReceiverDisabledCheck.swift
+mergen/checkmodules/CISBenchmark/AMFIEnabledCheck.swift
+mergen/checkmodules/CISBenchmark/AppleSoftwareUpdateCheck.swift
+mergen/checkmodules/CISBenchmark/AppStoreUpdateCheck.swift
+mergen/checkmodules/CISBenchmark/AuditFlagsCheck.swift
+mergen/checkmodules/CISBenchmark/AutomaticLoginDisabledCheck.swift
+mergen/checkmodules/CISBenchmark/AutomaticSoftwareUpdateCheck.swift
+mergen/checkmodules/CISBenchmark/BackupAutomaticallyEnabledCheck.swift
+mergen/checkmodules/CISBenchmark/BluetoothMenuCheck.swift
+mergen/checkmodules/CISBenchmark/BluetoothSharingDisabledCheck.swift
+mergen/checkmodules/CISBenchmark/CheckAuditDisEnabled.swift
+mergen/checkmodules/CISBenchmark/CheckMediaSharingDisabled.swift
+mergen/checkmodules/CISBenchmark/CheckTimeMachineEnabled.swift
+mergen/checkmodules/CISBenchmark/ContentCachingDisabledCheck.swift
+mergen/checkmodules/CISBenchmark/CriticalUpdateInstallCheck.swift
+mergen/checkmodules/CISBenchmark/DVDOrCDSharingDisabledCheck.swift
+mergen/checkmodules/CISBenchmark/ExternalIntelligenceExtensionsCheck.swift
+mergen/checkmodules/CISBenchmark/FileSharingCheck.swift
+mergen/checkmodules/CISBenchmark/FileVaultCheck.swift
+mergen/checkmodules/CISBenchmark/FirewallCheck.swift
+mergen/checkmodules/CISBenchmark/FirewallStealthModeCheck.swift
+mergen/checkmodules/CISBenchmark/GatekeeperBypassCheck.swift
+mergen/checkmodules/CISBenchmark/GuestHomeFolderCheck.swift
+mergen/checkmodules/CISBenchmark/GuestLoginCheck.swift
+mergen/checkmodules/CISBenchmark/HomeFolderPermissionsCheck.swift
+mergen/checkmodules/CISBenchmark/IcloudEnabled.swift
+mergen/checkmodules/CISBenchmark/iCloudKeychainCheck.swift
+mergen/checkmodules/CISBenchmark/ImproveAssistiveVoiceCheck.swift
+mergen/checkmodules/CISBenchmark/ImproveSiriDictationCheck.swift
+mergen/checkmodules/CISBenchmark/InternetSharingDisabledCheck.swift
+mergen/checkmodules/CISBenchmark/LocationServicesCheck.swift
+mergen/checkmodules/CISBenchmark/LocationServicesMenuBarCheck.swift
+mergen/checkmodules/CISBenchmark/LockdownModeCheck.swift
+mergen/checkmodules/CISBenchmark/LoginScreenMessageCheck.swift
+mergen/checkmodules/CISBenchmark/LoginWindowNamePasswordCheck.swift
+mergen/checkmodules/CISBenchmark/MailSummarizationCheck.swift
+mergen/checkmodules/CISBenchmark/NotesSummarizationCheck.swift
+mergen/checkmodules/CISBenchmark/PasswordLockoutThresholdCheck.swift
+mergen/checkmodules/CISBenchmark/PasswordMinLengthCheck.swift
+mergen/checkmodules/CISBenchmark/PasswordOnWakeCheck.swift
+mergen/checkmodules/CISBenchmark/PersonalizedAds.swift
+mergen/checkmodules/CISBenchmark/PowerNapDisabledCheck.swift
+mergen/checkmodules/CISBenchmark/PrinterSharingDisabledCheck.swift
+mergen/checkmodules/CISBenchmark/RemoteAppleEventsCheck.swift
+mergen/checkmodules/CISBenchmark/RemoteLoginDisabledCheck.swift
+mergen/checkmodules/CISBenchmark/RemoteManagementCheck.swift
+mergen/checkmodules/CISBenchmark/RootAccountDisabledCheck.swift
+mergen/checkmodules/CISBenchmark/SafariAdvertisingPrivacyCheck.swift
+mergen/checkmodules/CISBenchmark/SafariCrossSiteTrackingCheck.swift
+mergen/checkmodules/CISBenchmark/SafariFraudWarningCheck.swift
+mergen/checkmodules/CISBenchmark/SafariStatusBarCheck.swift
+mergen/checkmodules/CISBenchmark/ScreenSaverCornersCheck.swift
+mergen/checkmodules/CISBenchmark/ScreenSaverIntervalCheck.swift
+mergen/checkmodules/CISBenchmark/ScreenSharingDisabledCheck.swift
+mergen/checkmodules/CISBenchmark/SecureKernelExtensionLoadingCheck.swift
+mergen/checkmodules/CISBenchmark/SecurityUpdateCheck.swift
+mergen/checkmodules/CISBenchmark/SetTimeAndDateAutomaticallyEnabledCheck.swift
+mergen/checkmodules/CISBenchmark/ShareMacAnalyticsCheck.swift
+mergen/checkmodules/CISBenchmark/ShareWithAppDevelopersCheck.swift
+mergen/checkmodules/CISBenchmark/ShowWifiMenuCheck.swift
+mergen/checkmodules/CISBenchmark/SleepEnabledAppleSiliconCheck.swift
+mergen/checkmodules/CISBenchmark/SlowModule.swift
+mergen/checkmodules/CISBenchmark/SoftwareUpdateDefermentCheck.swift
+mergen/checkmodules/CISBenchmark/SpotlightImprovementCheck.swift
+mergen/checkmodules/CISBenchmark/SshEnableCheck.swift
+mergen/checkmodules/CISBenchmark/SSVEnabledCheck.swift
+mergen/checkmodules/CISBenchmark/SudoLoggingCheck.swift
+mergen/checkmodules/CISBenchmark/SudoTimeoutCheck.swift
+mergen/checkmodules/CISBenchmark/SudoTTYTicketsCheck.swift
+mergen/checkmodules/CISBenchmark/TerminalSecureKeyboardCheck.swift
+mergen/checkmodules/CISBenchmark/TimeMachineVolumesEncryptedCheck.swift
+mergen/checkmodules/CISBenchmark/TimeWithinLimitsCheck.swift
+mergen/checkmodules/CISBenchmark/UniversalControlCheck.swift
+mergen/checkmodules/CISBenchmark/WakeForNetworkAccessCheck.swift
+mergen/checkmodules/CISBenchmark/WritingToolsCheck.swift
+mergen/checkmodules/CISBenchmark/XProtectStatusCheck.swift
+mergen/checkmodules/DiagnosticDataCheck.swift
+mergen/checkmodules/EfiCheck.swift
+mergen/checkmodules/FastUserSwitchingCheck.swift
+mergen/checkmodules/FileExtentionCheck.swift
+mergen/checkmodules/GuestConnectCheck.swift
+mergen/checkmodules/Java6Check.swift
+mergen/checkmodules/NfsServerCheck.swift
+mergen/checkmodules/PasswordHintsCheck.swift
+mergen/checkmodules/SafariInternetPluginCheck.swift
+mergen/checkmodules/SafariSafeFileChecks.swift
+mergen/checkmodules/SIPCheck.swift
+mergen/checkmodules/SiriStatusCheck.swift
+mergen/checkmodules/XProtectAndMRTCheck.swift
+mergen/ContentView.swift
+mergen/core/AuditLogger.swift
+mergen/core/FixCommands.swift
+mergen/core/FixManager.swift
+mergen/core/ScanManager.swift
+mergen/core/Scanner.swift
+mergen/core/Vulnerability.swift
+mergen/mergen.entitlements
+mergen/mergenApp.swift
+mergen/mergenRelease.entitlements
+mergen/Preview Content/..gitkeep
+mergen/Preview/.gitkeep
+mergen/Tests/TestPlan.xctestplan
+mergen/view/FixAllSheet.swift
+mergen/view/HTMLReportGenerator.swift
+mergen/view/JSONReportGenerator.swift
+mergen/view/LogViewerSheet.swift
+mergen/view/ScanResultView.swift
+mergen/view/VulnerabilityDetailView.swift
+README.md
+</directory_structure>
+
+<files>
+This section contains the contents of the repository's files.
+
+<file path=".codesight/CODESIGHT.md">
+# mergen — AI Context Map
+
+> **Stack:** swiftui, go-net-http | none | unknown | mixed
+> **Monorepo:** mergen-cli, mergen.xcodeproj
+
+> 0 routes | 0 models | 24 components | 7 lib files | 0 env vars | 0 middleware
+> **Token savings:** this file is ~1,900 tokens. Without it, AI exploration would cost ~15,400 tokens. **Saves ~13,600 tokens per conversation.**
+> **Last scanned:** 2026-04-29 00:28 — re-run after significant changes
+
+---
+
+# Components
+
+- **ContentView** [client] — props: selectedVulnerability, isWelcome, scanManager, automated, passCount, failCount, warnCount, score, fixable, scoreColor — `mergen\ContentView.swift`
+- **ResultsTopBar** [client] — props: selectedVulnerability, isWelcome, scanManager, automated, passCount, failCount, warnCount, score, fixable, scoreColor — `mergen\ContentView.swift`
+- **WelcomeView** [client] — props: selectedVulnerability, isWelcome, scanManager, automated, passCount, failCount, warnCount, score, fixable, scoreColor — `mergen\ContentView.swift`
+- **FeatureCard** [client] — props: selectedVulnerability, isWelcome, scanManager, automated, passCount, failCount, warnCount, score, fixable, scoreColor — `mergen\ContentView.swift`
+- **FixAllSheet** [client] — props: scanManager, fixable, adminCount, userCount, isFixing, hasFailures, result, isFixed, isCancelled, rowIcon — `mergen\view\FixAllSheet.swift`
+- **FixRowItem** [client] — props: scanManager, fixable, adminCount, userCount, isFixing, hasFailures, result, isFixed, isCancelled, rowIcon — `mergen\view\FixAllSheet.swift`
+- **LogViewerSheet** [client] — props: lines, filter, keyword, color, filtered, lineColor, timestamp, body_ — `mergen\view\LogViewerSheet.swift`
+- **LogLine** [client] — props: lines, filter, keyword, color, filtered, lineColor, timestamp, body_ — `mergen\view\LogViewerSheet.swift`
+- **ResultsListView** [client] — props: id, icon, color, scanManager, selectedVulnerability, searchText, statusFilter, sortOrder, base, results — `mergen\view\ScanResultView.swift`
+- **FilterSortBar** [client] — props: id, icon, color, scanManager, selectedVulnerability, searchText, statusFilter, sortOrder, base, results — `mergen\view\ScanResultView.swift`
+- **FilterPill** [client] — props: id, icon, color, scanManager, selectedVulnerability, searchText, statusFilter, sortOrder, base, results — `mergen\view\ScanResultView.swift`
+- **ScanProgressBanner** [client] — props: id, icon, color, scanManager, selectedVulnerability, searchText, statusFilter, sortOrder, base, results — `mergen\view\ScanResultView.swift`
+- **ExportButtons** [client] — props: id, icon, color, scanManager, selectedVulnerability, searchText, statusFilter, sortOrder, base, results — `mergen\view\ScanResultView.swift`
+- **EmptyFilterView** [client] — props: id, icon, color, scanManager, selectedVulnerability, searchText, statusFilter, sortOrder, base, results — `mergen\view\ScanResultView.swift`
+- **SectionHeader** [client] — props: id, icon, color, scanManager, selectedVulnerability, searchText, statusFilter, sortOrder, base, results — `mergen\view\ScanResultView.swift`
+- **StatusBadge** [client] — props: id, icon, color, scanManager, selectedVulnerability, searchText, statusFilter, sortOrder, base, results — `mergen\view\ScanResultView.swift`
+- **VulnerabilityRow** [client] — props: id, icon, color, scanManager, selectedVulnerability, searchText, statusFilter, sortOrder, base, results — `mergen\view\ScanResultView.swift`
+- **SeverityDistributionBar** [client] — props: id, icon, color, scanManager, selectedVulnerability, searchText, statusFilter, sortOrder, base, results — `mergen\view\ScanResultView.swift`
+- **SevLegendDot** [client] — props: id, icon, color, scanManager, selectedVulnerability, searchText, statusFilter, sortOrder, base, results — `mergen\view\ScanResultView.swift`
+- **DetailPanelView** [client] — props: scanManager, statusColor, statusIcon, statusLabel, severityColor, hasShellCommands, isFixing, result, isFixed, isCancelled — `mergen\view\VulnerabilityDetailView.swift`
+- **EmptyDetailView** [client] — props: scanManager, statusColor, statusIcon, statusLabel, severityColor, hasShellCommands, isFixing, result, isFixed, isCancelled — `mergen\view\VulnerabilityDetailView.swift`
+- **VulnerabilityDetailView** [client] — props: scanManager, statusColor, statusIcon, statusLabel, severityColor, hasShellCommands, isFixing, result, isFixed, isCancelled — `mergen\view\VulnerabilityDetailView.swift`
+- **AutoFixButton** [client] — props: scanManager, statusColor, statusIcon, statusLabel, severityColor, hasShellCommands, isFixing, result, isFixed, isCancelled — `mergen\view\VulnerabilityDetailView.swift`
+- **BadgeView** [client] — props: scanManager, statusColor, statusIcon, statusLabel, severityColor, hasShellCommands, isFixing, result, isFixed, isCancelled — `mergen\view\VulnerabilityDetailView.swift`
+
+---
+
+# Libraries
+
+- `mergen-cli\cmd\root.go` — function SetVersion: (v string), function Execute: ()
+- `mergen-cli\internal\checks\registry.go`
+  - function Register: (c Check)
+  - function All: () []Check
+  - function ByCategory: (cat string) []Check
+  - function BySection: (sec string) []Check
+- `mergen-cli\internal\checks\types.go`
+  - class Result
+  - class FixInfo
+  - class CheckResult
+  - interface Check
+- `mergen-cli\internal\output\printer.go`
+  - function PrintBanner: ()
+  - function StatusBadge: (s checks.Status) string
+  - function StatusIcon: (s checks.Status) string
+  - function PrintCheckResult: (cr checks.CheckResult)
+  - function PrintSectionHeader: (section, title string, count int)
+  - function PrintProgress: (done, total int) string
+  - _...4 more_
+- `mergen-cli\internal\output\styles.go` — function SeverityColor: (sev string) lipgloss.Style
+- `mergen-cli\internal\report\report.go` — function JSON: (results []checks.CheckResult) ([]byte, error), function HTML: (results []checks.CheckResult) string
+- `mergen-cli\internal\runner\runner.go` — function Run: (cs []checks.Check, workers int) <-chan Progress, class Progress
+
+---
+
+# Dependency Graph
+
+## Most Imported Files (change these carefully)
+
+- `os/exec` — imported by **3** files
+- `unicode/utf8` — imported by **1** files
+- `encoding/json` — imported by **1** files
+
+## Import Map (who imports what)
+
+- `os/exec` ← `mergen-cli\cmd\fix.go`, `mergen-cli\cmd\tui.go`, `mergen-cli\internal\checks\helpers.go`
+- `unicode/utf8` ← `mergen-cli\internal\output\printer.go`
+- `encoding/json` ← `mergen-cli\internal\report\report.go`
+
+---
+
+_Generated by [codesight](https://github.com/Houseofmvps/codesight) — see your codebase clearly_
+</file>
+
+<file path=".codesight/components.md">
+# Components
+
+- **ContentView** [client] — props: selectedVulnerability, isWelcome, scanManager, automated, passCount, failCount, warnCount, score, fixable, scoreColor — `mergen\ContentView.swift`
+- **ResultsTopBar** [client] — props: selectedVulnerability, isWelcome, scanManager, automated, passCount, failCount, warnCount, score, fixable, scoreColor — `mergen\ContentView.swift`
+- **WelcomeView** [client] — props: selectedVulnerability, isWelcome, scanManager, automated, passCount, failCount, warnCount, score, fixable, scoreColor — `mergen\ContentView.swift`
+- **FeatureCard** [client] — props: selectedVulnerability, isWelcome, scanManager, automated, passCount, failCount, warnCount, score, fixable, scoreColor — `mergen\ContentView.swift`
+- **FixAllSheet** [client] — props: scanManager, fixable, adminCount, userCount, isFixing, hasFailures, result, isFixed, isCancelled, rowIcon — `mergen\view\FixAllSheet.swift`
+- **FixRowItem** [client] — props: scanManager, fixable, adminCount, userCount, isFixing, hasFailures, result, isFixed, isCancelled, rowIcon — `mergen\view\FixAllSheet.swift`
+- **LogViewerSheet** [client] — props: lines, filter, keyword, color, filtered, lineColor, timestamp, body_ — `mergen\view\LogViewerSheet.swift`
+- **LogLine** [client] — props: lines, filter, keyword, color, filtered, lineColor, timestamp, body_ — `mergen\view\LogViewerSheet.swift`
+- **ResultsListView** [client] — props: id, icon, color, scanManager, selectedVulnerability, searchText, statusFilter, sortOrder, base, results — `mergen\view\ScanResultView.swift`
+- **FilterSortBar** [client] — props: id, icon, color, scanManager, selectedVulnerability, searchText, statusFilter, sortOrder, base, results — `mergen\view\ScanResultView.swift`
+- **FilterPill** [client] — props: id, icon, color, scanManager, selectedVulnerability, searchText, statusFilter, sortOrder, base, results — `mergen\view\ScanResultView.swift`
+- **ScanProgressBanner** [client] — props: id, icon, color, scanManager, selectedVulnerability, searchText, statusFilter, sortOrder, base, results — `mergen\view\ScanResultView.swift`
+- **ExportButtons** [client] — props: id, icon, color, scanManager, selectedVulnerability, searchText, statusFilter, sortOrder, base, results — `mergen\view\ScanResultView.swift`
+- **EmptyFilterView** [client] — props: id, icon, color, scanManager, selectedVulnerability, searchText, statusFilter, sortOrder, base, results — `mergen\view\ScanResultView.swift`
+- **SectionHeader** [client] — props: id, icon, color, scanManager, selectedVulnerability, searchText, statusFilter, sortOrder, base, results — `mergen\view\ScanResultView.swift`
+- **StatusBadge** [client] — props: id, icon, color, scanManager, selectedVulnerability, searchText, statusFilter, sortOrder, base, results — `mergen\view\ScanResultView.swift`
+- **VulnerabilityRow** [client] — props: id, icon, color, scanManager, selectedVulnerability, searchText, statusFilter, sortOrder, base, results — `mergen\view\ScanResultView.swift`
+- **SeverityDistributionBar** [client] — props: id, icon, color, scanManager, selectedVulnerability, searchText, statusFilter, sortOrder, base, results — `mergen\view\ScanResultView.swift`
+- **SevLegendDot** [client] — props: id, icon, color, scanManager, selectedVulnerability, searchText, statusFilter, sortOrder, base, results — `mergen\view\ScanResultView.swift`
+- **DetailPanelView** [client] — props: scanManager, statusColor, statusIcon, statusLabel, severityColor, hasShellCommands, isFixing, result, isFixed, isCancelled — `mergen\view\VulnerabilityDetailView.swift`
+- **EmptyDetailView** [client] — props: scanManager, statusColor, statusIcon, statusLabel, severityColor, hasShellCommands, isFixing, result, isFixed, isCancelled — `mergen\view\VulnerabilityDetailView.swift`
+- **VulnerabilityDetailView** [client] — props: scanManager, statusColor, statusIcon, statusLabel, severityColor, hasShellCommands, isFixing, result, isFixed, isCancelled — `mergen\view\VulnerabilityDetailView.swift`
+- **AutoFixButton** [client] — props: scanManager, statusColor, statusIcon, statusLabel, severityColor, hasShellCommands, isFixing, result, isFixed, isCancelled — `mergen\view\VulnerabilityDetailView.swift`
+- **BadgeView** [client] — props: scanManager, statusColor, statusIcon, statusLabel, severityColor, hasShellCommands, isFixing, result, isFixed, isCancelled — `mergen\view\VulnerabilityDetailView.swift`
+</file>
+
+<file path=".codesight/graph.md">
+# Dependency Graph
+
+## Most Imported Files (change these carefully)
+
+- `os/exec` — imported by **3** files
+- `unicode/utf8` — imported by **1** files
+- `encoding/json` — imported by **1** files
+
+## Import Map (who imports what)
+
+- `os/exec` ← `mergen-cli\cmd\fix.go`, `mergen-cli\cmd\tui.go`, `mergen-cli\internal\checks\helpers.go`
+- `unicode/utf8` ← `mergen-cli\internal\output\printer.go`
+- `encoding/json` ← `mergen-cli\internal\report\report.go`
+</file>
+
+<file path=".codesight/libs.md">
+# Libraries
+
+- `mergen-cli\cmd\root.go` — function SetVersion: (v string), function Execute: ()
+- `mergen-cli\internal\checks\registry.go`
+  - function Register: (c Check)
+  - function All: () []Check
+  - function ByCategory: (cat string) []Check
+  - function BySection: (sec string) []Check
+- `mergen-cli\internal\checks\types.go`
+  - class Result
+  - class FixInfo
+  - class CheckResult
+  - interface Check
+- `mergen-cli\internal\output\printer.go`
+  - function PrintBanner: ()
+  - function StatusBadge: (s checks.Status) string
+  - function StatusIcon: (s checks.Status) string
+  - function PrintCheckResult: (cr checks.CheckResult)
+  - function PrintSectionHeader: (section, title string, count int)
+  - function PrintProgress: (done, total int) string
+  - _...4 more_
+- `mergen-cli\internal\output\styles.go` — function SeverityColor: (sev string) lipgloss.Style
+- `mergen-cli\internal\report\report.go` — function JSON: (results []checks.CheckResult) ([]byte, error), function HTML: (results []checks.CheckResult) string
+- `mergen-cli\internal\runner\runner.go` — function Run: (cs []checks.Check, workers int) <-chan Progress, class Progress
+</file>
+
+<file path=".codesight/wiki/index.md">
+# mergen — Wiki
+
+_Generated 2026-04-29 — re-run `npx codesight --wiki` if the codebase has changed._
+
+Structural map compiled from source code via AST. No LLM — deterministic, 200ms.
+
+> **How to use safely:** These articles tell you WHERE things live and WHAT exists. They do not show full implementation logic. Always read the actual source files before implementing new features or making changes. Never infer how a function works from the wiki alone.
+
+## Articles
+
+- [Overview](./overview.md)
+- [Ui](./ui.md)
+
+## Quick Stats
+
+- Routes: **0**
+- Models: **0**
+- Components: **24**
+- Env vars: **0** required, **0** with defaults
+
+## How to Use
+
+- **New session:** read `index.md` (this file) for orientation — WHERE things are
+- **Architecture question:** read `overview.md` (~500 tokens)
+- **Domain question:** read the relevant article, then **read those source files**
+- **Before implementing anything:** read the source files listed in the article
+- **Full source context:** read `.codesight/CODESIGHT.md`
+
+## What the Wiki Does Not Cover
+
+These exist in your codebase but are **not** reflected in wiki articles:
+- Routes registered dynamically at runtime (loops, plugin factories, `app.use(dynamicRouter)`)
+- Internal routes from npm packages (e.g. Better Auth's built-in `/api/auth/*` endpoints)
+- WebSocket and SSE handlers
+- Raw SQL tables not declared through an ORM
+- Computed or virtual fields absent from schema declarations
+- TypeScript types that are not actual database columns
+- Routes marked `[inferred]` were detected via regex and may have lower precision
+- gRPC, tRPC, and GraphQL resolvers may be partially captured
+
+When in doubt, search the source. The wiki is a starting point, not a complete inventory.
+
+---
+_Last compiled: 2026-04-29 · 3 articles · [codesight](https://github.com/Houseofmvps/codesight)_
+</file>
+
+<file path=".codesight/wiki/log.md">
+# Wiki Log
+
+History of `npx codesight --wiki` runs. Capped at 20 entries.
+
+## [2026-04-29 00:21:40] scan | 0 routes, 0 models, 24 components → 3 articles
+
+## [2026-04-29 00:28:16] scan | 0 routes, 0 models, 24 components → 3 articles
+</file>
+
+<file path=".codesight/wiki/overview.md">
+# mergen — Overview
+
+> **Navigation aid.** This article shows WHERE things live (routes, models, files). Read actual source files before implementing new features or making changes.
+
+**mergen** is a mixed project built with swiftui, go-net-http, organized as a monorepo.
+
+**Workspaces:** `mergen-cli` (`mergen-cli`), `mergen.xcodeproj` (`mergen.xcodeproj`)
+
+## Scale
+
+24 UI components · 7 library files
+
+**UI:** 24 components (unknown) — see [ui.md](./ui.md)
+
+## High-Impact Files
+
+Changes to these files have the widest blast radius across the codebase:
+
+- `os/exec` — imported by **3** files
+- `unicode/utf8` — imported by **1** files
+- `encoding/json` — imported by **1** files
+
+---
+_Back to [index.md](./index.md) · Generated 2026-04-29_
+</file>
+
+<file path=".codesight/wiki/ui.md">
+# UI
+
+> **Navigation aid.** Component inventory and prop signatures extracted via AST. Read the source files before adding props or modifying component logic.
+
+**24 components** (unknown)
+
+## Client Components
+
+- **ContentView** — props: selectedVulnerability, isWelcome, scanManager, automated, passCount, failCount, warnCount, score, fixable, scoreColor — `mergen\ContentView.swift`
+- **ResultsTopBar** — props: selectedVulnerability, isWelcome, scanManager, automated, passCount, failCount, warnCount, score, fixable, scoreColor — `mergen\ContentView.swift`
+- **WelcomeView** — props: selectedVulnerability, isWelcome, scanManager, automated, passCount, failCount, warnCount, score, fixable, scoreColor — `mergen\ContentView.swift`
+- **FeatureCard** — props: selectedVulnerability, isWelcome, scanManager, automated, passCount, failCount, warnCount, score, fixable, scoreColor — `mergen\ContentView.swift`
+- **FixAllSheet** — props: scanManager, fixable, adminCount, userCount, isFixing, hasFailures, result, isFixed, isCancelled, rowIcon — `mergen\view\FixAllSheet.swift`
+- **FixRowItem** — props: scanManager, fixable, adminCount, userCount, isFixing, hasFailures, result, isFixed, isCancelled, rowIcon — `mergen\view\FixAllSheet.swift`
+- **LogViewerSheet** — props: lines, filter, keyword, color, filtered, lineColor, timestamp, body_ — `mergen\view\LogViewerSheet.swift`
+- **LogLine** — props: lines, filter, keyword, color, filtered, lineColor, timestamp, body_ — `mergen\view\LogViewerSheet.swift`
+- **ResultsListView** — props: id, icon, color, scanManager, selectedVulnerability, searchText, statusFilter, sortOrder, base, results — `mergen\view\ScanResultView.swift`
+- **FilterSortBar** — props: id, icon, color, scanManager, selectedVulnerability, searchText, statusFilter, sortOrder, base, results — `mergen\view\ScanResultView.swift`
+- **FilterPill** — props: id, icon, color, scanManager, selectedVulnerability, searchText, statusFilter, sortOrder, base, results — `mergen\view\ScanResultView.swift`
+- **ScanProgressBanner** — props: id, icon, color, scanManager, selectedVulnerability, searchText, statusFilter, sortOrder, base, results — `mergen\view\ScanResultView.swift`
+- **ExportButtons** — props: id, icon, color, scanManager, selectedVulnerability, searchText, statusFilter, sortOrder, base, results — `mergen\view\ScanResultView.swift`
+- **EmptyFilterView** — props: id, icon, color, scanManager, selectedVulnerability, searchText, statusFilter, sortOrder, base, results — `mergen\view\ScanResultView.swift`
+- **SectionHeader** — props: id, icon, color, scanManager, selectedVulnerability, searchText, statusFilter, sortOrder, base, results — `mergen\view\ScanResultView.swift`
+- **StatusBadge** — props: id, icon, color, scanManager, selectedVulnerability, searchText, statusFilter, sortOrder, base, results — `mergen\view\ScanResultView.swift`
+- **VulnerabilityRow** — props: id, icon, color, scanManager, selectedVulnerability, searchText, statusFilter, sortOrder, base, results — `mergen\view\ScanResultView.swift`
+- **SeverityDistributionBar** — props: id, icon, color, scanManager, selectedVulnerability, searchText, statusFilter, sortOrder, base, results — `mergen\view\ScanResultView.swift`
+- **SevLegendDot** — props: id, icon, color, scanManager, selectedVulnerability, searchText, statusFilter, sortOrder, base, results — `mergen\view\ScanResultView.swift`
+- **DetailPanelView** — props: scanManager, statusColor, statusIcon, statusLabel, severityColor, hasShellCommands, isFixing, result, isFixed, isCancelled — `mergen\view\VulnerabilityDetailView.swift`
+- **EmptyDetailView** — props: scanManager, statusColor, statusIcon, statusLabel, severityColor, hasShellCommands, isFixing, result, isFixed, isCancelled — `mergen\view\VulnerabilityDetailView.swift`
+- **VulnerabilityDetailView** — props: scanManager, statusColor, statusIcon, statusLabel, severityColor, hasShellCommands, isFixing, result, isFixed, isCancelled — `mergen\view\VulnerabilityDetailView.swift`
+- **AutoFixButton** — props: scanManager, statusColor, statusIcon, statusLabel, severityColor, hasShellCommands, isFixing, result, isFixed, isCancelled — `mergen\view\VulnerabilityDetailView.swift`
+- **BadgeView** — props: scanManager, statusColor, statusIcon, statusLabel, severityColor, hasShellCommands, isFixing, result, isFixed, isCancelled — `mergen\view\VulnerabilityDetailView.swift`
+
+---
+_Back to [overview.md](./overview.md)_
+</file>
+
+<file path="AppIcon.appiconset/Contents.json">
+{"images":[{"size":"128x128","expected-size":"128","filename":"128.png","folder":"Assets.xcassets/AppIcon.appiconset/","idiom":"mac","scale":"1x"},{"size":"256x256","expected-size":"256","filename":"256.png","folder":"Assets.xcassets/AppIcon.appiconset/","idiom":"mac","scale":"1x"},{"size":"128x128","expected-size":"256","filename":"256.png","folder":"Assets.xcassets/AppIcon.appiconset/","idiom":"mac","scale":"2x"},{"size":"256x256","expected-size":"512","filename":"512.png","folder":"Assets.xcassets/AppIcon.appiconset/","idiom":"mac","scale":"2x"},{"size":"32x32","expected-size":"32","filename":"32.png","folder":"Assets.xcassets/AppIcon.appiconset/","idiom":"mac","scale":"1x"},{"size":"512x512","expected-size":"512","filename":"512.png","folder":"Assets.xcassets/AppIcon.appiconset/","idiom":"mac","scale":"1x"},{"size":"16x16","expected-size":"16","filename":"16.png","folder":"Assets.xcassets/AppIcon.appiconset/","idiom":"mac","scale":"1x"},{"size":"16x16","expected-size":"32","filename":"32.png","folder":"Assets.xcassets/AppIcon.appiconset/","idiom":"mac","scale":"2x"},{"size":"32x32","expected-size":"64","filename":"64.png","folder":"Assets.xcassets/AppIcon.appiconset/","idiom":"mac","scale":"2x"},{"size":"512x512","expected-size":"1024","filename":"1024.png","folder":"Assets.xcassets/AppIcon.appiconset/","idiom":"mac","scale":"2x"}]}
+</file>
+
+<file path="LICENSE">
+MIT License
+
+Copyright (c) 2023 Samet Sazak
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+</file>
+
+<file path="MANUAL_AUDIT_GUIDE.md">
+# Manual macOS Security Audit Guide
+
+**Based on Mergen v2 (CIS Apple macOS 26 Tahoe Benchmark v1.0.0)**
+
+A walkthrough for running every check Mergen performs — by hand. GUI navigation where Tahoe exposes it, Terminal commands where it doesn't. Use this if you'd rather understand each control than install another auditor.
+
+> Source of truth: detection and fix commands extracted verbatim from `mergen-cli/internal/checks/*.go` (37 files) and `mergen/core/FixCommands.swift`. Severity ratings reflect the Go CLI's own ratings, which sometimes differ from the README — the code is authoritative.
+
+---
+
+## How to use this guide
+
+1. Open **Terminal** (Applications → Utilities → Terminal, or `Cmd+Space` → "Terminal").
+2. Confirm you're on a supported macOS:
+   ```bash
+   sw_vers
+   ```
+   This guide is calibrated for macOS 26 Tahoe; 13 Ventura and later are mostly compatible (Tahoe-specific differences are flagged inline).
+3. **Take a Time Machine backup before running any fix command** — System Settings → General → Time Machine → Back Up Now. Several fixes change auth policy, sharing services, or sudo behavior; rolling back is much easier with a snapshot.
+4. Work through each table top-to-bottom. For each row:
+   - Run the **Verify** command. Compare against the row's pass condition (described in the check's name and severity).
+   - If it fails: prefer the **GUI path** (left column inside System Settings); fall back to the **Fix** command if there's no GUI.
+   - Tick the **☐** checkbox once you've verified or fixed it.
+5. Re-run the verify command after a fix to confirm the change took effect.
+
+### Legend
+
+| Marker | Meaning |
+|---|---|
+| **Critical** | Exploitable without significant effort. Fix first. |
+| **High** | Significant exposure if not remediated. Fix in same session. |
+| **Medium** | Defense-in-depth. Fix when practical. |
+| **Low** | Privacy hardening / advisory. Fix at your convenience. |
+| **User** fix | No password needed. Run in a normal Terminal. |
+| **Admin** fix | Needs `sudo`. You'll be prompted for your password. |
+| **—** in Fix column | No automated remediation; the GUI path or note is the only way. |
+
+### Tahoe-specific gotchas (read once)
+
+- **`com.apple.alf` plist is gone.** All firewall queries use `socketfilterfw` directly.
+- **`com.apple.auditd` is gone.** §3 (Logging & Auditing) checks always WARN — not your fault, no fix.
+- **Screen saver keys live under `-currentHost`.** Verify commands try `-currentHost` first, fall back to user domain.
+- **Safari preferences are sandboxed by `cfprefsd`.** `defaults write com.apple.Safari …` may silently fail. Prefer the Safari → Settings GUI for §6.3 checks.
+- **Apple Intelligence (§2.5.1.x) controls require an MDM profile.** Without MDM, those checks can only return WARN. Manual GUI toggles in System Settings → Apple Intelligence & Siri are the practical workaround.
+
+---
+
+## §1 — Software Updates (6 checks)
+
+| ☐ | CIS | Name (Severity) | GUI path | Verify | Fix |
+|---|---|---|---|---|---|
+| ☐ | 1.1 | Apple software updated within 30 days (High) | System Settings → General → Software Update → Update All | `defaults read /Library/Preferences/com.apple.SoftwareUpdate LastFullSuccessfulDate` (date must be within 30 days) | — (use GUI) |
+| ☐ | 1.2 | Critical updates auto-install (Medium) | System Settings → General → Software Update → ⓘ → enable "Install Security Responses and system files" | `defaults read /Library/Preferences/com.apple.SoftwareUpdate CriticalUpdateInstall` (expect `1`) | Admin: `sudo defaults write /Library/Preferences/com.apple.SoftwareUpdate CriticalUpdateInstall -int 1` |
+| ☐ | 1.3 | Auto-update enabled (Medium) | (same panel as 1.2 → "Download new updates when available") | `defaults read /Library/Preferences/com.apple.SoftwareUpdate AutomaticDownload` (expect `1`) | Admin: `sudo defaults write /Library/Preferences/com.apple.SoftwareUpdate AutomaticDownload -bool true` |
+| ☐ | 1.4 | App Store auto-updates enabled (Medium) | App Store → Settings → "Automatic Updates" | `defaults read /Library/Preferences/com.apple.commerce AutoUpdate` (expect `1`) | Admin: `sudo defaults write /Library/Preferences/com.apple.commerce AutoUpdate -bool true` |
+| ☐ | 1.5 | Security responses auto-install (High) | (same panel as 1.2) | `defaults read /Library/Preferences/com.apple.SoftwareUpdate ConfigDataInstall` (expect `1`) | Admin: `sudo defaults write /Library/Preferences/com.apple.SoftwareUpdate ConfigDataInstall -bool true` |
+| ☐ | 1.6 | Update deferment policy (Low) | MDM only (Jamf / Mosyle / etc.) | `defaults read /Library/Preferences/com.apple.SoftwareUpdate enforcedSoftwareUpdateDelay` (expect non-zero integer) | — (MDM-managed) |
+
+---
+
+## §2 — System Settings
+
+### §2.1 — iCloud (2 checks)
+
+| ☐ | CIS | Name (Severity) | GUI path | Verify | Fix |
+|---|---|---|---|---|---|
+| ☐ | 2.1.1.1 | iCloud Keychain disabled (Medium, advisory) | System Settings → [Your Name] → iCloud → Passwords & Keychain → toggle off | `osascript -l JavaScript -e "$.NSUserDefaults.alloc.initWithSuiteName('com.apple.applicationaccess').objectForKey('allowCloudKeychainSync').js"` (expect `false`; blank = no MDM, decide manually) | — (use GUI) |
+| ☐ | 2.1.1.3 | iCloud Drive Desktop/Documents sync off (Medium) | System Settings → [Your Name] → iCloud → iCloud Drive → Options → uncheck "Desktop & Documents Folders" | `defaults read com.apple.finder FXICloudDriveDesktop; defaults read com.apple.finder FXICloudDriveDocuments` (both absent or `0`) | User: `defaults write com.apple.finder FXICloudDriveDesktop -bool false && defaults write com.apple.finder FXICloudDriveDocuments -bool false` |
+
+### §2.2 — Firewall (2 checks)
+
+> Tahoe: `com.apple.alf` plist removed; queries go through `socketfilterfw` only.
+
+| ☐ | CIS | Name (Severity) | GUI path | Verify | Fix |
+|---|---|---|---|---|---|
+| ☐ | 2.2.1 | Firewall enabled (High) | System Settings → Network → Firewall → toggle on | `/usr/libexec/ApplicationFirewall/socketfilterfw --getglobalstate` (output contains `enabled`) | Admin: `sudo /usr/libexec/ApplicationFirewall/socketfilterfw --setglobalstate on` |
+| ☐ | 2.2.2 | Firewall stealth mode (Medium) | System Settings → Network → Firewall → Options → enable "Stealth Mode" | `/usr/libexec/ApplicationFirewall/socketfilterfw --getstealthmode` (output contains `enabled`) | Admin: `sudo /usr/libexec/ApplicationFirewall/socketfilterfw --setstealthmode on` |
+
+### §2.3.1 — AirDrop / AirPlay (2 checks)
+
+| ☐ | CIS | Name (Severity) | GUI path | Verify | Fix |
+|---|---|---|---|---|---|
+| ☐ | 2.3.1.1 | AirDrop disabled (Medium) | Control Center → AirDrop → Off, or Finder → AirDrop window → "Allow me to be discovered by: No One" | `defaults read com.apple.NetworkBrowser DisableAirDrop` (expect `1`) | User: `defaults write com.apple.NetworkBrowser DisableAirDrop -bool YES` |
+| ☐ | 2.3.1.2 | AirPlay Receiver disabled (Low) | System Settings → General → AirDrop & Handoff → AirPlay Receiver → Off | `defaults read com.apple.controlcenter AirplayRecieverEnabled` (absent or `0`) | User: `defaults write com.apple.controlcenter AirplayRecieverEnabled -int 0` |
+
+### §2.3.2 — Date & Time (2 checks)
+
+| ☐ | CIS | Name (Severity) | GUI path | Verify | Fix |
+|---|---|---|---|---|---|
+| ☐ | 2.3.2.1 | Time set automatically (Medium) | System Settings → General → Date & Time → enable "Set time and date automatically" | `defaults read /Library/Preferences/com.apple.timezone.auto.plist Active` (expect `1`) | Admin: `sudo defaults write /Library/Preferences/com.apple.timezone.auto.plist Active -int 1` |
+| ☐ | 2.3.2.2 | Clock within reasonable bounds (Low) | (same panel — set time zone correctly) | `date` (compare against a known good source like `https://time.is/`) | — (enable 2.3.2.1) |
+
+### §2.3.3 — Sharing Services (10 checks)
+
+> Most of these can be confirmed in one place: **System Settings → General → Sharing**. Toggle off anything you don't actively need.
+
+| ☐ | CIS | Name (Severity) | GUI path | Verify | Fix |
+|---|---|---|---|---|---|
+| ☐ | 2.3.3.1 | Screen Sharing disabled (High) | System Settings → General → Sharing → Screen Sharing → off | `launchctl list com.apple.screensharing` (must error: "Could not find service") | Admin: `sudo launchctl disable system/com.apple.screensharing; sudo launchctl stop com.apple.screensharing 2>/dev/null; true` |
+| ☐ | 2.3.3.2 | File Sharing disabled (High) | (same panel → File Sharing → off) | `launchctl print-disabled system \| grep com.apple.smbd` (expect `"com.apple.smbd" => disabled`) | Admin: `sudo launchctl disable system/com.apple.smbd; sudo launchctl stop com.apple.smbd 2>/dev/null; true` |
+| ☐ | 2.3.3.3 | Printer Sharing disabled (Low) | (same panel → Printer Sharing → off) | `cupsctl 2>/dev/null \| grep _share_printers` (must NOT contain `_share_printers=1`) | Admin: `sudo cupsctl --no-share-printers` |
+| ☐ | 2.3.3.4 | Remote Login (SSH) disabled (High) | (same panel → Remote Login → off) | `launchctl print-disabled system \| grep com.openssh.sshd` (expect `"com.openssh.sshd" => disabled`) | Admin: `sudo launchctl disable system/com.openssh.sshd; sudo launchctl stop com.openssh.sshd 2>/dev/null; true` |
+| ☐ | 2.3.3.5 | Remote Management (ARD) disabled (High) | (same panel → Remote Management → off) | `launchctl list com.apple.RemoteDesktop.agent` (must error) | Admin: `sudo /System/Library/CoreServices/RemoteManagement/ARDAgent.app/Contents/Resources/kickstart -deactivate -stop 2>/dev/null; true` |
+| ☐ | 2.3.3.6 | Remote Apple Events disabled (Medium) | (same panel → Remote Apple Events → off) | `launchctl print-disabled system \| grep com.apple.AEServer` (expect `"com.apple.AEServer" => disabled`) | Admin: `sudo launchctl disable system/com.apple.AEServer; sudo launchctl stop com.apple.AEServer 2>/dev/null; true` |
+| ☐ | 2.3.3.7 | Internet Sharing disabled (High) | (same panel → Internet Sharing → off) | `defaults read /Library/Preferences/SystemConfiguration/com.apple.nat 2>/dev/null` (must NOT contain `Enabled = 1`) | Admin: `sudo defaults write /Library/Preferences/SystemConfiguration/com.apple.nat NAT -dict-add Enabled -int 0` |
+| ☐ | 2.3.3.8 | Content Caching disabled (Low) | (same panel → Content Caching → off) | `/usr/bin/AssetCacheManagerUtil status 2>&1` (must NOT contain `activated: true`) | Admin: `sudo /usr/bin/AssetCacheManagerUtil deactivate 2>/dev/null; true` |
+| ☐ | 2.3.3.9 | Media Sharing disabled (Low) | (same panel → Media Sharing → off) | `defaults read com.apple.amp.mediasharingd home-sharing-enabled` (absent or `0`) | Admin: `sudo defaults write com.apple.amp.mediasharingd home-sharing-enabled -int 0; sudo launchctl stop com.apple.amp.mediasharingd 2>/dev/null; true` |
+| ☐ | 2.3.3.10 | Bluetooth Sharing disabled (Medium) | System Settings → General → Sharing → Bluetooth Sharing → off | `defaults -currentHost read com.apple.Bluetooth PrefKeyServicesEnabled` (absent or `0`) | User: `defaults -currentHost write com.apple.Bluetooth PrefKeyServicesEnabled -bool false` |
+
+### §2.3.4 — Time Machine (1 check)
+
+| ☐ | CIS | Name (Severity) | GUI path | Verify | Fix |
+|---|---|---|---|---|---|
+| ☐ | 2.3.4.1 | Time Machine backup configured (Medium) | System Settings → General → Time Machine → Add Backup Disk | `tmutil destinationinfo` (output contains `Name` or `Kind`) | — (use GUI) |
+
+### §2.5 — Apple Intelligence & Siri (5 checks)
+
+> Tahoe: 2.5.1.x require an MDM configuration profile to enforce. Without MDM these checks can't be auto-fixed; toggle the matching feature off in System Settings → Apple Intelligence & Siri instead.
+
+| ☐ | CIS | Name (Severity) | GUI path | Verify | Fix |
+|---|---|---|---|---|---|
+| ☐ | 2.5.1.1 | External Intelligence Extensions disabled (Medium) | System Settings → Apple Intelligence & Siri → Extensions → off | `osascript -l JavaScript -e "$.NSUserDefaults.alloc.initWithSuiteName('com.apple.applicationaccess').objectForKey('allowExternalIntelligenceIntegrations').js"` (expect `false`) | — (MDM only) |
+| ☐ | 2.5.1.2 | Writing Tools disabled (Medium) | System Settings → Apple Intelligence & Siri → Writing Tools → off | `osascript -l JavaScript -e "$.NSUserDefaults.alloc.initWithSuiteName('com.apple.applicationaccess').objectForKey('allowWritingTools').js"` (expect `false`) | — (MDM only) |
+| ☐ | 2.5.1.3 | Mail Summarization disabled (Low) | Mail → Settings → "Summarize messages" → off | `osascript -l JavaScript -e "$.NSUserDefaults.alloc.initWithSuiteName('com.apple.applicationaccess').objectForKey('allowMailSummary').js"` (expect `false`) | — (MDM only) |
+| ☐ | 2.5.1.4 | Notes Summarization disabled (Low) | Notes → Settings → AI features → off | `osascript -l JavaScript -e "$.NSUserDefaults.alloc.initWithSuiteName('com.apple.applicationaccess').objectForKey('allowNotesTranscription').js"` (expect `false`) | — (MDM only) |
+| ☐ | 2.5.2.1 | Siri disabled (Low) | System Settings → Apple Intelligence & Siri → Siri → off | `defaults read com.apple.Siri SiriProfessionalEnabled` (absent or `0`) | User: `defaults write com.apple.Siri SiriProfessionalEnabled -bool false` |
+
+### §2.6 — Privacy & Security (10 checks)
+
+| ☐ | CIS | Name (Severity) | GUI path | Verify | Fix |
+|---|---|---|---|---|---|
+| ☐ | 2.6.1.1 | Location services enabled (Low) | System Settings → Privacy & Security → Location Services → toggle on | `launchctl list com.apple.locationd` (must succeed) | — (use GUI) |
+| ☐ | 2.6.1.2 | Location services menu bar icon (Low) | System Settings → Privacy & Security → Location Services → scroll to bottom → enable "Show location icon in menu bar when system services request your location" | `defaults read com.apple.systemuiserver menuExtras` (output contains `Location.menu`) | — (use GUI) |
+| ☐ | 2.6.3.1 | Diagnostic data sharing off (Low) | System Settings → Privacy & Security → Analytics & Improvements → "Share Mac Analytics" → off | `defaults read '/Library/Application Support/CrashReporter/DiagnosticMessagesHistory.plist' AutoSubmit 2>/dev/null` (absent or NOT `1`) | Admin: `sudo defaults write '/Library/Application Support/CrashReporter/DiagnosticMessagesHistory.plist' AutoSubmit -bool false` |
+| ☐ | 2.6.3.2 | Improve Siri & Dictation off (Low) | System Settings → Privacy & Security → Analytics & Improvements → "Improve Siri & Dictation" → off | `defaults read com.apple.assistant.support 'Siri Data Sharing Opt-In Status' 2>/dev/null` (absent or NOT `1`) | User: `defaults write com.apple.assistant.support 'Siri Data Sharing Opt-In Status' -int 2` |
+| ☐ | 2.6.3.3 | Improve assistive voice off (Low) | (same panel → "Improve Assistive Voice Features" → off) | `defaults read com.apple.Accessibility AXSAudioDonationSiriImprovementEnabled` (absent or `0`) | User: `defaults write com.apple.Accessibility AXSAudioDonationSiriImprovementEnabled -bool false` |
+| ☐ | 2.6.3.4 | Share with app developers off (Low) | (same panel → "Share with App Developers" → off) | `osascript -l JavaScript -e "$.NSUserDefaults.alloc.initWithSuiteName('com.apple.applicationaccess').objectForKey('allowDiagnosticSubmission').js" 2>/dev/null` (expect `false`) | — (MDM only; use GUI) |
+| ☐ | 2.6.4 | Personalized ads disabled (Low) | System Settings → Privacy & Security → Apple Advertising → "Personalized Ads" → off | `defaults read com.apple.AdLib allowApplePersonalizedAdvertising` (absent or `0`) | User: `defaults write com.apple.AdLib allowApplePersonalizedAdvertising -bool false` |
+| ☐ | 2.6.5 | Gatekeeper enabled (High) | System Settings → Privacy & Security → Security → "Allow applications from": App Store, or App Store and identified developers | `spctl --status 2>&1` (output contains `assessments enabled`) | Admin: `sudo spctl --master-enable` |
+| ☐ | 2.6.7 | Lockdown Mode (Low, advisory) | System Settings → Privacy & Security → Lockdown Mode → enable (only if you face elevated targeting) | `defaults read /Library/Preferences/com.apple.security.lockdown LockdownModeEnabled` (`1` = enabled) | — (use GUI; advisory) |
+| ☐ | 2.6.8 | Admin password required for System Settings (Medium) | (no GUI in Tahoe — manual edit of `/etc/authorization` required) | `security authorizationdb read system.preferences 2>/dev/null` (output contains `<false/>` AND `<string>admin</string>`) | — (advanced; see [Apple Authorization Services docs](https://developer.apple.com/documentation/security/authorization_services)) |
+
+### §2.7 — Hot Corners (1 check)
+
+| ☐ | CIS | Name (Severity) | GUI path | Verify | Fix |
+|---|---|---|---|---|---|
+| ☐ | 2.7.1 | No hot corner set to "Disable Screen Saver" (Low) | System Settings → Desktop & Dock → Hot Corners → ensure no corner = "Disable Screen Saver" | `defaults read com.apple.dock wvous-tl-corner; defaults read com.apple.dock wvous-tr-corner; defaults read com.apple.dock wvous-bl-corner; defaults read com.apple.dock wvous-br-corner` (none may output `6`) | — (use GUI) |
+
+### §2.8 — Continuity (1 check)
+
+| ☐ | CIS | Name (Severity) | GUI path | Verify | Fix |
+|---|---|---|---|---|---|
+| ☐ | 2.8.1 | Universal Control disabled (Low) | System Settings → Displays → Advanced → "Allow your pointer and keyboard to move between any nearby Mac or iPad" → off | `defaults -currentHost read com.apple.universalcontrol Disable` (expect `1`) | User: `defaults -currentHost write com.apple.universalcontrol Disable -int 1` |
+
+### §2.9 — Spotlight (1 check)
+
+| ☐ | CIS | Name (Severity) | GUI path | Verify | Fix |
+|---|---|---|---|---|---|
+| ☐ | 2.9.1 | Spotlight query sharing off (Low) | System Settings → Spotlight → "Help Apple improve Search" → off | `osascript -l JavaScript -e "$.NSUserDefaults.alloc.initWithSuiteName('com.apple.assistant.support').objectForKey('Search Queries Data Sharing Status').js" 2>/dev/null` (expect `2`) | User: `defaults write com.apple.assistant.support 'Search Queries Data Sharing Status' -int 2` |
+
+### §2.10 — Energy / Power (3 checks)
+
+| ☐ | CIS | Name (Severity) | GUI path | Verify | Fix |
+|---|---|---|---|---|---|
+| ☐ | 2.10.1.2 | Sleep enabled (Apple Silicon) (Medium) | System Settings → Lock Screen → "Turn display off when inactive" ≤ 20 min | `pmset -b -g 2>/dev/null \| grep -E '^ sleep\|^ displaysleep'` (non-empty) | Admin: `sudo pmset -a sleep 15 && sudo pmset -a displaysleep 10` |
+| ☐ | 2.10.2 | Power Nap disabled (Intel only) (Low) | System Settings → Energy Saver → "Enable Power Nap" → off (Intel Macs only; not present on Apple Silicon) | `pmset -g custom 2>/dev/null \| grep powernap` (must NOT contain `1`) | Admin: `sudo pmset -a powernap 0 && sudo pmset -a darkwakes 0` |
+| ☐ | 2.10.3 | Wake for network access disabled (Low) | System Settings → Energy Saver → "Wake for network access" → off | `pmset -g custom 2>/dev/null \| grep womp` (must NOT contain `1`) | Admin: `sudo pmset -a womp 0` |
+
+### §2.11 — Login & Screen Saver (5 checks)
+
+> Tahoe: screen saver keys live under `-currentHost`. The verify commands try `-currentHost` first.
+
+| ☐ | CIS | Name (Severity) | GUI path | Verify | Fix |
+|---|---|---|---|---|---|
+| ☐ | 2.11.1 | Screen saver activates ≤ 20 min (Medium) | System Settings → Lock Screen → "Start Screen Saver when inactive" ≤ 20 min | `defaults -currentHost read com.apple.screensaver idleTime` (expect 1–1200) | User: `defaults -currentHost write com.apple.screensaver idleTime -int 1200` |
+| ☐ | 2.11.2 | Password required on wake (High) | System Settings → Lock Screen → "Require password after screen saver begins or display is turned off" → Immediately | `defaults -currentHost read com.apple.screensaver askForPassword` (expect `1`) | User: `defaults -currentHost write com.apple.screensaver askForPassword -bool true && defaults -currentHost write com.apple.screensaver askForPasswordDelay -int 0` |
+| ☐ | 2.11.3 | Login window banner message (Low) | System Settings → Lock Screen → "Show message when locked" | `defaults read /Library/Preferences/com.apple.loginwindow LoginwindowText` (non-empty string) | Admin: `sudo defaults write /Library/Preferences/com.apple.loginwindow LoginwindowText 'Authorized use only'` |
+| ☐ | 2.11.4 | Login shows name + password fields (Low) | System Settings → Users & Groups → Edit (next to Automatic login as) → "Display login window as: Name and password" | `defaults read /Library/Preferences/com.apple.loginwindow SHOWFULLNAME` (expect `1`) | Admin: `sudo defaults write /Library/Preferences/com.apple.loginwindow SHOWFULLNAME -bool true` |
+| ☐ | 2.11.5 | Password hints disabled (Medium) | System Settings → Users & Groups → Edit → uncheck "Show password hints" | `defaults read /Library/Preferences/com.apple.loginwindow RetriesUntilHint` (absent or `0`) | Admin: `sudo defaults write /Library/Preferences/com.apple.loginwindow RetriesUntilHint -int 0` |
+
+### §2.13 — Guest & Auto-Login (3 checks)
+
+| ☐ | CIS | Name (Severity) | GUI path | Verify | Fix |
+|---|---|---|---|---|---|
+| ☐ | 2.13.1 | Guest login disabled (High) | System Settings → Users & Groups → Guest User → toggle off | `defaults read /Library/Preferences/com.apple.loginwindow.plist GuestEnabled` (absent or `0`) | Admin: `sudo defaults write /Library/Preferences/com.apple.loginwindow.plist GuestEnabled -bool false` |
+| ☐ | 2.13.2 | Guest shared-folder access off (Medium) | System Settings → Users & Groups → Guest User ⓘ → uncheck "Allow guests to connect to shared folders" | `defaults read /Library/Preferences/com.apple.AppleFileServer guestAccess` (absent or `0`) | Admin: `sudo defaults write /Library/Preferences/com.apple.AppleFileServer guestAccess -int 0` |
+| ☐ | 2.13.3 | Automatic login disabled (High) | System Settings → Users & Groups → "Automatic login as" → Off | `defaults read /Library/Preferences/com.apple.loginwindow autoLoginUser` (must error / empty) | Admin: `sudo defaults delete /Library/Preferences/com.apple.loginwindow autoLoginUser 2>/dev/null; true` |
+
+---
+
+## §3 — Logging & Auditing (2 checks)
+
+> **Tahoe note:** `com.apple.auditd` was removed by Apple. Both checks below report WARN on Tahoe — there is nothing you can do about it from userspace. Skip and tick the boxes.
+
+| ☐ | CIS | Name (Severity) | GUI path | Verify | Fix |
+|---|---|---|---|---|---|
+| ☐ | 3.1 | Security auditing enabled (Medium) | n/a (Tahoe) | `launchctl list com.apple.auditd` (succeed = pass; on Tahoe expect "Could not find" → WARN) | — (Tahoe: removed) |
+| ☐ | 3.2 | Audit flags configured (Medium) | n/a (Tahoe) | `grep ^flags /etc/security/audit_control 2>/dev/null` (expect `lo, aa, ad, fd, fm`; on Tahoe file is absent → WARN) | — (Tahoe: file removed; pre-Tahoe: `sudo vi /etc/security/audit_control` and set `flags=lo,aa,ad,fd,fm,-all`) |
+
+---
+
+## §4 — Network (3 checks)
+
+| ☐ | CIS | Name (Severity) | GUI path | Verify | Fix |
+|---|---|---|---|---|---|
+| ☐ | 4.1 | Bonjour multicast advertising disabled (Low) | (no GUI) | `defaults read /Library/Preferences/com.apple.mDNSResponder.plist NoMulticastAdvertisements` (expect `1`) | Admin: `sudo defaults write /Library/Preferences/com.apple.mDNSResponder.plist NoMulticastAdvertisements -bool true` |
+| ☐ | 4.2 | Apache HTTP server disabled (High) | (no GUI) | `launchctl list org.apache.httpd` (must error) | Admin: `sudo launchctl disable system/org.apache.httpd; sudo launchctl stop org.apache.httpd 2>/dev/null; true` |
+| ☐ | 4.3 | NFS server disabled (High) | (no GUI) | `launchctl print-disabled system \| grep com.apple.nfsd` (expect `"com.apple.nfsd" => disabled`) | Admin: `sudo launchctl disable system/com.apple.nfsd` |
+
+---
+
+## §5 — Authentication & Authorization (13 checks)
+
+### §5.1 — System Protections (3 checks, **all Recovery Mode only**)
+
+> See the **Recovery Mode procedure** at the bottom of this guide for how to boot into recovery and run these.
+
+| ☐ | CIS | Name (Severity) | Recovery Mode action | Verify (from regular Terminal) |
+|---|---|---|---|---|
+| ☐ | 5.1.1 | SIP enabled (Critical) | `csrutil enable` from Recovery Terminal, then restart | `csrutil status` (output contains `enabled`) |
+| ☐ | 5.1.3 | AMFI enabled (Critical) | `nvram boot-args=""` from Recovery Terminal (clears any disable flag), then restart | `nvram -p` (must NOT contain `amfi_get_out_of_my_way=1`) |
+| ☐ | 5.1.4 | Signed System Volume enabled (Critical) | `csrutil authenticated-root enable` from Recovery Terminal, then restart | `csrutil authenticated-root status` (output contains `enabled`) |
+
+### §5.2 — Password Policy (2 checks)
+
+| ☐ | CIS | Name (Severity) | GUI path | Verify | Fix |
+|---|---|---|---|---|---|
+| ☐ | 5.2.1 | Lockout after ≤ 5 failed attempts (High) | (no GUI; CLI only) | `pwpolicy -getaccountpolicies 2>/dev/null` (look for `policyAttributeMaximumFailedAuthentications` ≤ 5) | Admin: `sudo pwpolicy -n /Local/Default -setglobalpolicy maxFailedLoginAttempts=5` |
+| ☐ | 5.2.2 | Minimum password length ≥ 15 chars (High) | (no GUI; CLI only) | `pwpolicy -getaccountpolicies 2>/dev/null` (look for `minChars=15` or higher) | Admin: `sudo pwpolicy -n /Local/Default -setglobalpolicy minChars=15` |
+
+### §5.4 – §5.11 — Sudo, Root, Filesystem, XProtect (6 checks)
+
+| ☐ | CIS | Name (Severity) | GUI path | Verify | Fix |
+|---|---|---|---|---|---|
+| ☐ | 5.4 | Sudo timeout = 0 (Medium) | (no GUI) | `sudo -V 2>&1 \| grep 'Authentication timestamp timeout'` (expect `0.0 minutes`) | Admin: `echo 'Defaults timestamp_timeout=0' \| sudo tee /etc/sudoers.d/cis_timeout && sudo chmod 440 /etc/sudoers.d/cis_timeout` |
+| ☐ | 5.5 | Sudo TTY tickets enabled (Medium) | (no GUI) | `sudo -V` (output contains `Type of authentication timestamp record: tty`) | Admin: `echo 'Defaults timestamp_type=tty' \| sudo tee /etc/sudoers.d/cis_tty && sudo chmod 440 /etc/sudoers.d/cis_tty` |
+| ☐ | 5.6 | Root account disabled (High) | Directory Utility → Edit menu → Disable Root User | `dscl . -read /Users/root UserShell` (expect `/usr/bin/false` or `nologin`) | Admin: `sudo dscl . -create /Users/root UserShell /usr/bin/false` (or `sudo dsenableroot -d`) |
+| ☐ | 5.9 | Guest home folder removed (Low) | (no GUI) | `ls /Users/ 2>/dev/null` (must NOT contain `Guest`) | Admin: `sudo rm -rf /Users/Guest` (after disabling guest login per 2.13.1) |
+| ☐ | 5.10 | XProtect running (High) | (managed by Apple — keep Software Update enabled) | `xprotect status` (`enabled: true`) — fallback: `launchctl list com.apple.XProtect.daemon.scan` (succeeds) | — (do not disable; ensure §1 software updates are on) |
+| ☐ | 5.11 | Sudo logs allowed commands (Medium) | (no GUI) | `sudo -V` (output contains `Log when a command is allowed by sudoers`) | Admin: `echo 'Defaults log_allowed' \| sudo tee /etc/sudoers.d/cis_logging && sudo chmod 440 /etc/sudoers.d/cis_logging` |
+
+### §5 — Encryption / Cert Trust (2 checks; no CIS sub-ID in Mergen)
+
+| ☐ | Name (Severity) | GUI path | Verify | Fix |
+|---|---|---|---|---|
+| ☐ | FileVault full-disk encryption enabled (Critical) | System Settings → Privacy & Security → FileVault → Turn On FileVault | `fdesetup status` (output contains `FileVault is On`) | — (use GUI; safe-store the recovery key) |
+| ☐ | Certificate trust settings clean (High) | Keychain Access → System → Certificates — review any custom trust overrides | `security dump-trust-settings 2>&1` (expect `No Trust Settings were found`) | — (delete suspicious overrides in Keychain Access manually) |
+
+---
+
+## §6 — User Interface
+
+### §6.1 — Finder (2 checks)
+
+| ☐ | CIS | Name (Severity) | GUI path | Verify | Fix |
+|---|---|---|---|---|---|
+| ☐ | 6.1.1 | Show all filename extensions (Low) | Finder → Settings → Advanced → check "Show all filename extensions" | `defaults read NSGlobalDomain AppleShowAllExtensions` (expect `1`) | User: `defaults write NSGlobalDomain AppleShowAllExtensions -bool true` |
+| ☐ | 6.1.2 | Home folder permissions ≤ 750 (Medium) | (no GUI) | `ls -la /Users/ 2>/dev/null` (no home folder, except `Shared`, has `r` in the "others" position) | User: `chmod 700 ~/` (run for each affected user) |
+
+### §6.3 — Safari (6 checks)
+
+> Tahoe: Safari prefs are sandboxed by `cfprefsd`. The `defaults write` commands often silently no-op. **Use the Safari Settings GUI** as the primary fix path on Tahoe; the commands are kept here for verification and pre-Tahoe systems.
+
+| ☐ | CIS | Name (Severity) | GUI path | Verify | Fix |
+|---|---|---|---|---|---|
+| ☐ | 6.3.1 | Auto-open safe downloads off (Medium) | Safari → Settings → General → uncheck "Open 'safe' files after downloading" | `defaults read com.apple.Safari AutoOpenSafeDownloads` (absent or `0`) | User (may be sandboxed on Tahoe — prefer GUI): `defaults write com.apple.Safari AutoOpenSafeDownloads -bool false` |
+| ☐ | 6.3.3 | Fraudulent website warning on (Medium) | Safari → Settings → Security → check "Warn when visiting a fraudulent website" | `defaults read com.apple.Safari WarnAboutFraudulentWebsites` (expect `1`; absent = WARN, default is on) | User: `defaults write com.apple.Safari WarnAboutFraudulentWebsites -bool true` |
+| ☐ | 6.3.4 | Cross-site tracking prevention on (Medium) | Safari → Settings → Privacy → check "Prevent cross-site tracking" | `defaults read com.apple.Safari BlockStoragePolicy` (expect `2`) | User: `defaults write com.apple.Safari BlockStoragePolicy -int 2` |
+| ☐ | 6.3.6 | Private Click Measurement on (Low) | Safari → Settings → Privacy → check "Allow privacy-preserving measurement of ad effectiveness" | `defaults read com.apple.Safari WebKitPreferences.privateClickMeasurementEnabled` (absent or NOT `0`) | User: `defaults write com.apple.Safari WebKitPreferences.privateClickMeasurementEnabled -bool true` |
+| ☐ | 6.3.8 | Internet plugins blocked (Medium) | Safari → Settings → Websites → Plug-ins → set per-site to "Off" / "Ask" | `defaults read com.apple.Safari PlugInFirstVisitPolicy` (expect `2`) | User: `defaults write com.apple.Safari PlugInFirstVisitPolicy -int 2` |
+| ☐ | 6.3.10 | Status bar shown (Low) | Safari → View menu → Show Status Bar | `defaults read com.apple.Safari ShowOverlayStatusBar` (expect `1`) | User: `defaults write com.apple.Safari ShowOverlayStatusBar -bool true` |
+
+### §6.4 — Terminal (1 check)
+
+| ☐ | CIS | Name (Severity) | GUI path | Verify | Fix |
+|---|---|---|---|---|---|
+| ☐ | 6.4.1 | Secure Keyboard Entry on (Medium) | Terminal → Terminal menu → "Secure Keyboard Entry" | `osascript -l JavaScript -e "$.NSUserDefaults.alloc.initWithSuiteName('com.apple.Terminal').objectForKey('SecureKeyboardEntry').js"` (expect `true`) | User: `defaults write com.apple.Terminal SecureKeyboardEntry -bool true` |
+
+---
+
+## Additional Checks (5)
+
+These appear in Mergen without a CIS sub-ID assignment.
+
+| ☐ | Name (Severity) | GUI path | Verify | Fix |
+|---|---|---|---|---|
+| ☐ | Bluetooth status in menu bar (Low) | System Settings → Control Center → Bluetooth → "Show in Menu Bar" | `defaults read com.apple.controlcenter.plist 'NSStatusItem Visible Bluetooth'` (expect `1`) | — (use GUI) |
+| ☐ | Fast User Switching disabled (Medium) | System Settings → Control Center → Fast User Switching → off | `defaults read /Library/Preferences/.GlobalPreferences MultipleSessionEnabled` (absent or `0`) | Admin: `sudo defaults write /Library/Preferences/.GlobalPreferences MultipleSessionEnabled -bool false` |
+| ☐ | Time Machine volumes encrypted (High) | System Settings → General → Time Machine → select disk → Options → enable encryption | `defaults read /Library/Preferences/com.apple.TimeMachine.plist 2>/dev/null` (must NOT contain `NotEncrypted`) | — (use GUI; encryption can only be set when adding the disk) |
+| ☐ | EFI firmware up to date (Intel only) (High) | System Settings → General → Software Update — install all updates | If `sysctl -n machdep.cpu.brand_string` contains `Intel`: `system_profiler SPHardwareDataType \| grep 'Boot ROM'` (compare against [Apple's published versions](https://eclecticlight.co/2024/01/01/efi-and-firmware-versions/)). Skip if Apple Silicon. | — (run all Software Updates) |
+| ☐ | Java 6 runtime not present (High) | (no GUI) | `java -version 2>&1` (must NOT contain `1.6` or `version "1.6`; "command not found" = pass) | — (install a supported JDK like Temurin 21 from adoptium.net; remove Java 6 from `/Library/Java/JavaVirtualMachines/`) |
+
+---
+
+## Recovery Mode procedure (for §5.1.1, §5.1.3, §5.1.4)
+
+You only need this if SIP, AMFI, or SSV is currently disabled — which is unusual unless you intentionally turned them off for development.
+
+**Apple Silicon (M1/M2/M3/M4):**
+1. Shut the Mac down completely (Apple menu → Shut Down).
+2. Press and hold the **Power** button until you see "Loading startup options."
+3. Click **Options** → **Continue**.
+4. Authenticate as an admin user.
+5. Menu bar → **Utilities** → **Terminal**.
+6. Run the recovery command for the failing check (e.g. `csrutil enable`).
+7. Restart from the Apple menu.
+
+**Intel:**
+1. Shut down.
+2. Press the **Power** button, then immediately hold **Cmd+R** until the Apple logo appears.
+3. Authenticate, then **Utilities** → **Terminal**.
+4. Run the command, restart.
+
+After restart, run the **Verify** command from a normal Terminal session to confirm the change.
+
+---
+
+## Closing checklist
+
+- [ ] All §1–§6 boxes ticked or noted as WARN/skip
+- [ ] All Critical and High items either pass or have a documented reason for failing
+- [ ] Time Machine snapshot taken before any fix was applied
+- [ ] FileVault is on, recovery key stored somewhere safe (password manager, printed copy in a sealed envelope, etc.)
+- [ ] Software Update is set to download and install automatically (1.2–1.5)
+
+If something breaks after a fix:
+- `sudo defaults delete <plist> <key>` removes the write you made.
+- `sudo launchctl enable system/<service>; sudo launchctl start <service>` re-enables a service you disabled.
+- For sudoers rules added under `/etc/sudoers.d/cis_*`: `sudo rm /etc/sudoers.d/cis_*` to revert.
+- Restore from the Time Machine snapshot you took at step 3 if all else fails.
+
+---
+
+*Generated 2026-04-27 from `securesigner/mergen` (fork of `sametsazak/mergen`). Verify against upstream when CIS Benchmark version changes.*
+</file>
+
+<file path="mergen-cli/cmd/fix.go">
+package cmd
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/sametsazak/mergen-cli/internal/checks"
+	"github.com/sametsazak/mergen-cli/internal/output"
+	"github.com/sametsazak/mergen-cli/internal/runner"
+)
+
+var (
+	flagFixID    string
+	flagFixAll   bool
+	flagFixDryRun bool
+)
+
+var fixCmd = &cobra.Command{
+	Use:   "fix",
+	Short: "Auto-remediate failed checks",
+	Long: `Apply automatic fixes to failing checks.
+
+User-level fixes run immediately. Admin fixes require your password
+via the standard macOS authentication dialog.
+
+Examples:
+  mergen fix              # scan then fix all auto-fixable failures
+  mergen fix --id 2.2.1   # fix one specific check
+  mergen fix --dry-run    # show what would be fixed without applying`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		output.PrintBanner()
+
+		// Run a full scan first to find failures
+		fmt.Printf("  %s  Scanning to find fixable issues…\n\n", output.Accent.Render("→"))
+
+		cs := checks.All()
+		results := collectResults(cs)
+
+		var toFix []checks.CheckResult
+
+		if flagFixID != "" {
+			// Fix single check by CIS ID
+			for _, r := range results {
+				if r.Check.CISID() == flagFixID {
+					if r.Result.Status != checks.StatusFail {
+						fmt.Printf("  %s  Check %s is not failing (%s)\n",
+							output.PassTxt.Render("✓"),
+							flagFixID,
+							r.Result.Status.String(),
+						)
+						return nil
+					}
+					if r.Check.Fix() == nil {
+						return fmt.Errorf("check %s does not have an auto-fix", flagFixID)
+					}
+					toFix = append(toFix, r)
+					break
+				}
+			}
+			if len(toFix) == 0 {
+				return fmt.Errorf("check with CIS ID %q not found", flagFixID)
+			}
+		} else {
+			// All fixable failures
+			for _, r := range results {
+				if r.Result.Status == checks.StatusFail && r.Check.Fix() != nil {
+					toFix = append(toFix, r)
+				}
+			}
+		}
+
+		if len(toFix) == 0 {
+			fmt.Println(output.PassTxt.Render("  ✓ No auto-fixable issues found."))
+			return nil
+		}
+
+		// Show what will be fixed
+		fmt.Printf("  %s to fix:\n\n",
+			output.FailTxt.Bold(true).Render(fmt.Sprintf("%d issue(s)", len(toFix))),
+		)
+
+		var adminFixes []checks.CheckResult
+		var userFixes []checks.CheckResult
+
+		for _, r := range toFix {
+			fi := r.Check.Fix()
+			privTag := output.Muted.Render("[user] ")
+			if fi.RequiresAdmin {
+				privTag = output.WarnTxt.Render("[admin]")
+				adminFixes = append(adminFixes, r)
+			} else {
+				userFixes = append(userFixes, r)
+			}
+			fmt.Printf("  %s %s  %s\n",
+				output.FailTxt.Render("✗"), privTag, r.Check.Name(),
+			)
+			if fi.Description != "" {
+				fmt.Println(output.OutputTxt.Render("  → " + fi.Description))
+			}
+		}
+		fmt.Println()
+
+		if flagFixDryRun {
+			fmt.Println(output.WarnTxt.Render("  Dry run — no changes applied."))
+			return nil
+		}
+
+		// Confirm
+		if !flagFixAll {
+			fmt.Print(output.Muted.Render("  Apply fixes? [y/N] "))
+			reader := bufio.NewReader(os.Stdin)
+			answer, _ := reader.ReadString('\n')
+			if !strings.EqualFold(strings.TrimSpace(answer), "y") {
+				fmt.Println(output.Muted.Render("  Cancelled."))
+				return nil
+			}
+		}
+
+		// Apply user-level fixes
+		for _, r := range userFixes {
+			applyFix(r, false)
+		}
+
+		// Apply admin fixes (batched via osascript)
+		if len(adminFixes) > 0 {
+			applyAdminFixes(adminFixes)
+		}
+
+		// Re-verify
+		fmt.Printf("\n  %s  Re-running fixed checks…\n\n", output.Accent.Render("→"))
+		var fixed, stillFailing int
+		for _, r := range toFix {
+			newResult := r.Check.Run()
+			if newResult.Status == checks.StatusPass || newResult.Status == checks.StatusWarn {
+				fmt.Printf("  %s  %s\n", output.PassTxt.Render("✓"), r.Check.Name())
+				fixed++
+			} else {
+				fmt.Printf("  %s  %s\n", output.FailTxt.Render("✗"), r.Check.Name())
+				if newResult.Output != "" {
+					fmt.Println(output.OutputTxt.Render(newResult.Output))
+				}
+				stillFailing++
+			}
+		}
+
+		fmt.Println()
+		if stillFailing > 0 {
+			fmt.Printf("  %s  %d fixed · %s still failing\n",
+				output.WarnTxt.Render("⚠"),
+				fixed,
+				output.FailTxt.Render(fmt.Sprintf("%d", stillFailing)),
+			)
+		} else {
+			fmt.Printf("  %s  All %d issues fixed\n",
+				output.PassTxt.Render("✓"),
+				fixed,
+			)
+		}
+		fmt.Println()
+		return nil
+	},
+}
+
+func collectResults(cs []checks.Check) []checks.CheckResult {
+	var results []checks.CheckResult
+	total := len(cs)
+	ch := runner.Run(cs, 8)
+	for p := range ch {
+		results = append(results, p.Result)
+		fmt.Printf("\r%s", output.PrintProgress(p.Done, total))
+	}
+	fmt.Println()
+	return results
+}
+
+func applyFix(r checks.CheckResult, admin bool) {
+	fi := r.Check.Fix()
+	fmt.Printf("  %s  Fixing: %s\n", output.Accent.Render("→"), r.Check.Name())
+	cmd := exec.Command("/bin/sh", "-c", fi.Command)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		fmt.Printf("  %s  %s\n", output.FailTxt.Render("✗"), strings.TrimSpace(string(out)))
+	}
+}
+
+func applyAdminFixes(adminFixes []checks.CheckResult) {
+	fmt.Printf("\n  %s  Applying %d admin fix(es) — macOS will prompt for your password…\n\n",
+		output.WarnTxt.Render("⚠"),
+		len(adminFixes),
+	)
+
+	// Batch all admin commands into one osascript call
+	var cmds []string
+	for _, r := range adminFixes {
+		cmds = append(cmds, r.Check.Fix().Command)
+	}
+	batched := strings.Join(cmds, " && ")
+	script := fmt.Sprintf(`do shell script "%s" with administrator privileges`,
+		strings.ReplaceAll(batched, `"`, `\"`),
+	)
+
+	cmd := exec.Command("/usr/bin/osascript", "-e", script)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		fmt.Printf("  %s  Admin fix failed: %s\n",
+			output.FailTxt.Render("✗"),
+			strings.TrimSpace(string(out)),
+		)
+	}
+}
+
+func init() {
+	fixCmd.Flags().StringVar(&flagFixID, "id", "", "Fix a single check by CIS ID (e.g. 2.2.1)")
+	fixCmd.Flags().BoolVarP(&flagFixAll, "yes", "y", false, "Apply all fixes without confirmation prompt")
+	fixCmd.Flags().BoolVar(&flagFixDryRun, "dry-run", false, "Show what would be fixed without applying")
+	rootCmd.AddCommand(fixCmd)
+}
+</file>
+
+<file path="mergen-cli/cmd/list.go">
+package cmd
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/sametsazak/mergen-cli/internal/checks"
+	"github.com/sametsazak/mergen-cli/internal/output"
+)
+
+var flagListSection string
+
+var listCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List all available checks",
+	Long: `Display all registered security checks with their CIS ID, severity, and fix availability.
+
+Examples:
+  mergen list               # list all checks
+  mergen list --section 5   # list only Section 5 checks`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		output.PrintBanner()
+
+		var cs []checks.Check
+		if flagListSection != "" {
+			cs = checks.BySection(flagListSection)
+			if len(cs) == 0 {
+				return fmt.Errorf("no checks found for section %q", flagListSection)
+			}
+		} else {
+			cs = checks.All()
+		}
+
+		sectionNames := map[string]string{
+			"1": "Software Updates",
+			"2": "System Settings",
+			"3": "Logging & Auditing",
+			"4": "Network",
+			"5": "Auth & Authorization",
+			"6": "User Interface",
+			"":  "Additional Checks",
+		}
+		sectionOrder := []string{"1", "2", "3", "4", "5", "6", ""}
+
+		// Group by section
+		bySection := map[string][]checks.Check{}
+		for _, c := range cs {
+			id := c.CISID()
+			sec := ""
+			if id != "" {
+				parts := strings.SplitN(id, ".", 2)
+				sec = parts[0]
+			}
+			bySection[sec] = append(bySection[sec], c)
+		}
+
+		total := len(cs)
+		fmt.Printf("  %s\n\n",
+			output.Muted.Render(fmt.Sprintf("%d checks registered", total)),
+		)
+
+		for _, sec := range sectionOrder {
+			items, ok := bySection[sec]
+			if !ok || len(items) == 0 {
+				continue
+			}
+			name := sectionNames[sec]
+			if sec == "" {
+				sec = "—"
+			}
+			output.PrintSectionHeader(sec, name, len(items))
+			fmt.Println()
+
+			for _, c := range items {
+				cisTag := output.CISTag.Render(fmt.Sprintf("%-8s", c.CISID()))
+
+				fixTag := output.Muted.Render("       ")
+				if c.Fix() != nil {
+					if c.Fix().RequiresAdmin {
+						fixTag = output.WarnTxt.Render("[admin]")
+					} else {
+						fixTag = output.ManTxt.Render("[user] ")
+					}
+				}
+
+				manualTag := ""
+				if c.IsManual() {
+					manualTag = output.Muted.Render(" [manual]")
+				}
+
+				sevStyle := output.SeverityColor(c.Severity())
+
+				fmt.Printf("  %s  %s  %s  %s%s\n",
+					cisTag,
+					sevStyle.Render(fmt.Sprintf("%-8s", c.Severity())),
+					fixTag,
+					c.Name(),
+					manualTag,
+				)
+			}
+		}
+
+		// Stats footer
+		var autoFixable, manual int
+		for _, c := range cs {
+			if c.Fix() != nil {
+				autoFixable++
+			}
+			if c.IsManual() {
+				manual++
+			}
+		}
+		fmt.Printf("\n  %s · %s auto-fixable · %s advisory\n\n",
+			output.Muted.Render(fmt.Sprintf("%d total", total)),
+			output.PassTxt.Render(fmt.Sprintf("%d", autoFixable)),
+			output.ManTxt.Render(fmt.Sprintf("%d", manual)),
+		)
+		return nil
+	},
+}
+
+func init() {
+	listCmd.Flags().StringVarP(&flagListSection, "section", "s", "", "Filter by section number (1-6)")
+	rootCmd.AddCommand(listCmd)
+}
+</file>
+
+<file path="mergen-cli/cmd/report.go">
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+
+	"github.com/sametsazak/mergen-cli/internal/checks"
+	"github.com/sametsazak/mergen-cli/internal/output"
+	"github.com/sametsazak/mergen-cli/internal/report"
+	"github.com/sametsazak/mergen-cli/internal/runner"
+)
+
+var (
+	flagReportFormat string
+	flagReportOutput string
+)
+
+var reportCmd = &cobra.Command{
+	Use:   "report",
+	Short: "Run scan and export an HTML or JSON report",
+	Long: `Runs a full scan and exports the results.
+
+Examples:
+  mergen report                           # HTML to ./mergen-report.html
+  mergen report --format json             # JSON to ./mergen-report.json
+  mergen report --format html -o out.html # custom output path`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		output.PrintBanner()
+
+		fmt.Printf("  %s  Scanning for report…\n\n", output.Accent.Render("→"))
+
+		cs := checks.All()
+		total := len(cs)
+
+		var results []checks.CheckResult
+		ch := runner.Run(cs, 8)
+		for p := range ch {
+			results = append(results, p.Result)
+			fmt.Printf("\r%s", output.PrintProgress(p.Done, total))
+		}
+		fmt.Println()
+
+		output.PrintSummary(results)
+
+		// Determine output path
+		outPath := flagReportOutput
+		format := flagReportFormat
+
+		if outPath == "" {
+			switch format {
+			case "json":
+				outPath = "mergen-report.json"
+			default:
+				outPath = "mergen-report.html"
+				format = "html"
+			}
+		}
+		if format == "" {
+			format = "html"
+		}
+
+		switch format {
+		case "json":
+			data, err := report.JSON(results)
+			if err != nil {
+				return fmt.Errorf("JSON generation failed: %w", err)
+			}
+			if err := os.WriteFile(outPath, data, 0644); err != nil {
+				return fmt.Errorf("could not write %s: %w", outPath, err)
+			}
+		case "html":
+			html := report.HTML(results)
+			if err := os.WriteFile(outPath, []byte(html), 0644); err != nil {
+				return fmt.Errorf("could not write %s: %w", outPath, err)
+			}
+		default:
+			return fmt.Errorf("unknown format %q — use 'html' or 'json'", format)
+		}
+
+		fmt.Printf("  %s  Report saved to %s\n\n",
+			output.PassTxt.Render("✓"),
+			output.Accent.Render(outPath),
+		)
+		return nil
+	},
+}
+
+func init() {
+	reportCmd.Flags().StringVarP(&flagReportFormat, "format", "F", "html", "Output format: html or json")
+	reportCmd.Flags().StringVarP(&flagReportOutput, "output", "o", "", "Output file path (default: mergen-report.[html|json])")
+	rootCmd.AddCommand(reportCmd)
+}
+</file>
+
+<file path="mergen-cli/cmd/root.go">
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+var rootCmd = &cobra.Command{
+	Use:   "mergen",
+	Short: "macOS security audit — CIS Apple macOS 26 Tahoe Benchmark",
+	Long: `Mergen audits your Mac against 90+ CIS Benchmark controls.
+
+  mergen              Launch interactive menu
+  mergen scan         Run all security checks
+  mergen fix          Fix all auto-fixable failures
+  mergen list         List all available checks
+  mergen report       Generate HTML or JSON report`,
+	SilenceUsage: true,
+	// When called with no subcommand, launch the interactive TUI
+	RunE: func(cmd *cobra.Command, args []string) error {
+		runTUI()
+		return nil
+	},
+}
+
+func SetVersion(v string) {
+	rootCmd.Version = v
+}
+
+func Execute() {
+	if err := rootCmd.Execute(); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+}
+</file>
+
+<file path="mergen-cli/cmd/scan.go">
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/sametsazak/mergen-cli/internal/checks"
+	"github.com/sametsazak/mergen-cli/internal/output"
+	"github.com/sametsazak/mergen-cli/internal/runner"
+)
+
+var (
+	flagSection  string
+	flagCategory string
+	flagFailed   bool
+	flagWorkers  int
+	flagQuiet    bool
+	flagJSON     bool
+)
+
+var scanCmd = &cobra.Command{
+	Use:   "scan",
+	Short: "Run security checks",
+	Long: `Audit your Mac against CIS Benchmark controls.
+
+Examples:
+  mergen scan                   # run all checks
+  mergen scan --section 2       # only section 2 (System Settings)
+  mergen scan --failed          # print only failures
+  mergen scan --quiet           # summary only, no per-check output
+  mergen scan --json            # machine-readable output`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		output.PrintBanner()
+
+		// Select checks
+		var cs []checks.Check
+		switch {
+		case flagSection != "":
+			cs = checks.BySection(flagSection)
+			if len(cs) == 0 {
+				return fmt.Errorf("no checks found for section %q", flagSection)
+			}
+		case flagCategory != "":
+			cs = checks.ByCategory(flagCategory)
+			if len(cs) == 0 {
+				return fmt.Errorf("no checks found for category %q", flagCategory)
+			}
+		default:
+			cs = checks.All()
+		}
+
+		total := len(cs)
+		fmt.Printf("  %s  Running %s checks on macOS…\n\n",
+			output.Accent.Render("→"),
+			output.Bold.Render(fmt.Sprintf("%d", total)),
+		)
+
+		// Print section header tracker
+		currentSection := ""
+		sectionNames := map[string]string{
+			"1": "Software Updates",
+			"2": "System Settings",
+			"3": "Logging & Auditing",
+			"4": "Network",
+			"5": "Auth & Authorization",
+			"6": "User Interface",
+			"":  "Additional Checks",
+		}
+
+		results := make([]checks.CheckResult, 0, total)
+		progress := runner.Run(cs, flagWorkers)
+
+		// Collect and display results as they arrive
+		// Buffer by section for ordered output
+		buf := map[string][]checks.CheckResult{}
+		sectionOrder := []string{"1", "2", "3", "4", "5", "6", ""}
+
+		for p := range progress {
+			id := p.Result.Check.CISID()
+			sec := ""
+			if id != "" {
+				parts := strings.SplitN(id, ".", 2)
+				if len(parts) > 0 {
+					sec = parts[0]
+				}
+			}
+			buf[sec] = append(buf[sec], p.Result)
+			results = append(results, p.Result)
+
+			if !flagQuiet && !flagJSON {
+				fmt.Printf("\r\033[K%s", output.PrintProgress(p.Done, p.Total))
+			}
+		}
+		fmt.Print("\r\033[K") // clear progress line
+
+		if flagJSON {
+			printJSONResults(results)
+			return nil
+		}
+
+		if !flagQuiet {
+			// Print results ordered by section
+			for _, sec := range sectionOrder {
+				items, ok := buf[sec]
+				if !ok || len(items) == 0 {
+					continue
+				}
+				// Sort items within section by CIS ID
+				sort.Slice(items, func(i, j int) bool {
+					return items[i].Check.CISID() < items[j].Check.CISID()
+				})
+
+				name := sectionNames[sec]
+				if sec == "" {
+					name = "Additional Checks"
+				}
+				output.PrintSectionHeader(sec, name, len(items))
+
+				for _, r := range items {
+					if flagFailed && r.Result.Status != checks.StatusFail {
+						continue
+					}
+					output.PrintCheckResult(r)
+				}
+				if sec == currentSection {
+					_ = currentSection
+				}
+				currentSection = sec
+			}
+		}
+
+		output.PrintSummary(results)
+
+		// Exit code 1 if any failures
+		for _, r := range results {
+			if r.Result.Status == checks.StatusFail {
+				os.Exit(1)
+			}
+		}
+		return nil
+	},
+}
+
+func printJSONResults(results []checks.CheckResult) {
+	fmt.Println("[")
+	for i, r := range results {
+		comma := ","
+		if i == len(results)-1 {
+			comma = ""
+		}
+		fmt.Printf(`  {"cis_id":%q,"name":%q,"status":%q,"output":%q}%s`+"\n",
+			r.Check.CISID(), r.Check.Name(), r.Result.Status.String(), r.Result.Output, comma)
+	}
+	fmt.Println("]")
+}
+
+func init() {
+	scanCmd.Flags().StringVarP(&flagSection, "section", "s", "", "Run only checks in a specific section (1-6)")
+	scanCmd.Flags().StringVarP(&flagCategory, "category", "c", "", "Run only checks in a category (e.g. 'CIS Benchmark')")
+	scanCmd.Flags().BoolVarP(&flagFailed, "failed", "f", false, "Show only failed checks")
+	scanCmd.Flags().IntVarP(&flagWorkers, "workers", "w", 8, "Number of parallel check workers")
+	scanCmd.Flags().BoolVarP(&flagQuiet, "quiet", "q", false, "Print summary only")
+	scanCmd.Flags().BoolVar(&flagJSON, "json", false, "Output results as JSON")
+	rootCmd.AddCommand(scanCmd)
+}
+</file>
+
+<file path="mergen-cli/cmd/tui.go">
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+)
+
+// ── Styles ────────────────────────────────────────────────────────────────────
+
+var (
+	tuiAccent  = lipgloss.Color("#a78bfa")
+	tuiMuted   = lipgloss.Color("#6b7280")
+	tuiSelected = lipgloss.Color("#f9fafb")
+	tuiBorder  = lipgloss.Color("#374151")
+	tuiGreen   = lipgloss.Color("#22c55e")
+	tuiRed     = lipgloss.Color("#ef4444")
+	tuiOrange  = lipgloss.Color("#f97316")
+
+	styleBanner = lipgloss.NewStyle().
+			Foreground(tuiAccent).
+			Bold(true)
+
+	styleSubtitle = lipgloss.NewStyle().
+			Foreground(tuiMuted)
+
+	styleMenuCursor = lipgloss.NewStyle().
+			Foreground(tuiAccent).
+			Bold(true)
+
+	styleMenuSelected = lipgloss.NewStyle().
+				Bold(true).
+				Foreground(tuiSelected).
+				Background(lipgloss.Color("#1e1b4b")).
+				PaddingLeft(1).
+				PaddingRight(1)
+
+	styleMenuNormal = lipgloss.NewStyle().
+			Foreground(lipgloss.Color("#d1d5db")).
+			PaddingLeft(1).
+			PaddingRight(1)
+
+	styleMenuDesc = lipgloss.NewStyle().
+			Foreground(tuiMuted)
+
+	styleShortcut = lipgloss.NewStyle().
+			Foreground(tuiAccent)
+
+	styleHelp = lipgloss.NewStyle().
+			Foreground(tuiMuted).
+			MarginTop(1)
+
+	styleSectionSelected = lipgloss.NewStyle().
+				Bold(true).
+				Foreground(tuiSelected).
+				Background(lipgloss.Color("#1e1b4b")).
+				Padding(0, 2)
+
+	styleSectionNormal = lipgloss.NewStyle().
+				Foreground(lipgloss.Color("#9ca3af")).
+				Padding(0, 2)
+
+	styleBox = lipgloss.NewStyle().
+			Border(lipgloss.RoundedBorder()).
+			BorderForeground(tuiBorder).
+			Padding(1, 3)
+
+	styleTitle = lipgloss.NewStyle().
+			Foreground(tuiAccent).
+			Bold(true).
+			MarginBottom(1)
+)
+
+// ── Data ──────────────────────────────────────────────────────────────────────
+
+type menuEntry struct {
+	icon    string
+	label   string
+	desc    string
+	shortcut string
+	action  string // cobra subcommand or special key
+}
+
+var mainMenu = []menuEntry{
+	{"⚡", "Scan All Checks", "Run all 85 security checks concurrently", "a", "scan"},
+	{"§", "Scan by Section", "Choose a specific CIS section to audit", "s", "section"},
+	{"✗", "Show Only Failures", "Scan and display only failing checks", "f", "scan --failed"},
+	{"⚙", "Fix Issues", "Auto-remediate all fixable failures", "x", "fix"},
+	{"☑", "Dry Run Fix", "Preview fixes without applying them", "d", "fix --dry-run"},
+	{"≡", "List All Checks", "Browse every registered check", "l", "list"},
+	{"⎘", "Generate HTML Report", "Run scan and export a styled HTML report", "h", "report --format html"},
+	{"⎘", "Generate JSON Report", "Run scan and export machine-readable JSON", "j", "report --format json"},
+	{"✕", "Quit", "Exit mergen", "q", "quit"},
+}
+
+var sections = []struct{ num, label string }{
+	{"1", "§1  Software Updates"},
+	{"2", "§2  System Settings"},
+	{"3", "§3  Logging & Auditing"},
+	{"4", "§4  Network"},
+	{"5", "§5  Auth & Authorization"},
+	{"6", "§6  User Interface"},
+}
+
+// ── Model ─────────────────────────────────────────────────────────────────────
+
+type screen int
+
+const (
+	screenMain screen = iota
+	screenSection
+)
+
+type tuiModel struct {
+	screen      screen
+	cursor      int
+	secCursor   int
+	chosen      string // set when user makes a selection
+	quitting    bool
+}
+
+func initialModel() tuiModel {
+	return tuiModel{screen: screenMain}
+}
+
+func (m tuiModel) Init() tea.Cmd {
+	return nil
+}
+
+func (m tuiModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.KeyMsg:
+		key := msg.String()
+
+		// ── Section picker ────────────────────────────────────
+		if m.screen == screenSection {
+			switch key {
+			case "up", "k":
+				if m.secCursor > 0 {
+					m.secCursor--
+				}
+			case "down", "j":
+				if m.secCursor < len(sections)-1 {
+					m.secCursor++
+				}
+			case "enter", " ":
+				m.chosen = "scan --section " + sections[m.secCursor].num
+				return m, tea.Quit
+			case "esc", "b":
+				m.screen = screenMain
+			case "q", "ctrl+c":
+				m.quitting = true
+				return m, tea.Quit
+			}
+			return m, nil
+		}
+
+		// ── Main menu ─────────────────────────────────────────
+		switch key {
+		case "up", "k":
+			if m.cursor > 0 {
+				m.cursor--
+			}
+		case "down", "j":
+			if m.cursor < len(mainMenu)-1 {
+				m.cursor++
+			}
+		case "enter", " ":
+			item := mainMenu[m.cursor]
+			if item.action == "quit" {
+				m.quitting = true
+				return m, tea.Quit
+			}
+			if item.action == "section" {
+				m.screen = screenSection
+				return m, nil
+			}
+			m.chosen = item.action
+			return m, tea.Quit
+
+		case "q", "ctrl+c":
+			m.quitting = true
+			return m, tea.Quit
+
+		default:
+			// Shortcut keys
+			for _, item := range mainMenu {
+				if key == item.shortcut {
+					if item.action == "quit" {
+						m.quitting = true
+						return m, tea.Quit
+					}
+					if item.action == "section" {
+						m.screen = screenSection
+						return m, nil
+					}
+					m.chosen = item.action
+					return m, tea.Quit
+				}
+			}
+		}
+	}
+	return m, nil
+}
+
+func (m tuiModel) View() string {
+	if m.chosen != "" || m.quitting {
+		return ""
+	}
+
+	var b strings.Builder
+
+	// Banner
+	b.WriteString(styleBanner.Render(`
+  ███╗   ███╗███████╗██████╗  ██████╗ ███████╗███╗   ██╗
+  ████╗ ████║██╔════╝██╔══██╗██╔════╝ ██╔════╝████╗  ██║
+  ██╔████╔██║█████╗  ██████╔╝██║  ███╗█████╗  ██╔██╗ ██║
+  ██║╚██╔╝██║██╔══╝  ██╔══██╗██║   ██║██╔══╝  ██║╚██╗██║
+  ██║ ╚═╝ ██║███████╗██║  ██║╚██████╔╝███████╗██║ ╚████║
+  ╚═╝     ╚═╝╚══════╝╚═╝  ╚═╝ ╚═════╝ ╚══════╝╚═╝  ╚═══╝`))
+	b.WriteString("\n")
+	b.WriteString(styleSubtitle.Render("  macOS Security Audit  ·  CIS Apple macOS 26 Tahoe Benchmark v1.0.0"))
+	b.WriteString("\n\n")
+
+	if m.screen == screenSection {
+		return b.String() + m.sectionView()
+	}
+	return b.String() + m.mainMenuView()
+}
+
+func (m tuiModel) mainMenuView() string {
+	var b strings.Builder
+
+	b.WriteString(styleTitle.Render("  What would you like to do?\n"))
+
+	for i, item := range mainMenu {
+		cursor := "  "
+		var label string
+
+		if i == m.cursor {
+			cursor = styleMenuCursor.Render(" ▶")
+			label = styleMenuSelected.Render(
+				fmt.Sprintf("%s  %-28s", item.icon, item.label),
+			)
+		} else {
+			label = styleMenuNormal.Render(
+				fmt.Sprintf("%s  %-28s", item.icon, item.label),
+			)
+		}
+
+		shortcut := styleShortcut.Render("[" + item.shortcut + "]")
+		desc := styleMenuDesc.Render(item.desc)
+
+		b.WriteString(fmt.Sprintf("%s %s  %s  %s\n", cursor, label, shortcut, desc))
+	}
+
+	b.WriteString(styleHelp.Render("\n  ↑↓ / jk navigate  ·  enter select  ·  shortcut key  ·  q quit"))
+	b.WriteString("\n")
+	return b.String()
+}
+
+func (m tuiModel) sectionView() string {
+	var b strings.Builder
+
+	b.WriteString(styleTitle.Render("  Select a section to scan:\n"))
+
+	for i, sec := range sections {
+		cursor := "  "
+		var label string
+
+		if i == m.secCursor {
+			cursor = styleMenuCursor.Render(" ▶")
+			label = styleSectionSelected.Render(sec.label)
+		} else {
+			label = styleSectionNormal.Render(sec.label)
+		}
+		b.WriteString(fmt.Sprintf("%s %s\n", cursor, label))
+	}
+
+	b.WriteString(styleHelp.Render("\n  ↑↓ navigate  ·  enter select  ·  esc / b back  ·  q quit"))
+	b.WriteString("\n")
+	return b.String()
+}
+
+// ── Entry point ───────────────────────────────────────────────────────────────
+
+func runTUI() {
+	p := tea.NewProgram(initialModel())
+	result, err := p.Run()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "TUI error:", err)
+		os.Exit(1)
+	}
+
+	m, ok := result.(tuiModel)
+	if !ok || m.quitting || m.chosen == "" {
+		return
+	}
+
+	// Re-exec ourselves with the chosen subcommand args
+	args := strings.Fields(m.chosen)
+	self, _ := os.Executable()
+	cmd := exec.Command(self, args...)
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			os.Exit(exitErr.ExitCode())
+		}
+		os.Exit(1)
+	}
+}
+</file>
+
+<file path="mergen-cli/go.mod">
+module github.com/sametsazak/mergen-cli
+
+go 1.24.0
+
+require (
+	github.com/charmbracelet/bubbletea v1.3.10
+	github.com/charmbracelet/lipgloss v1.1.0
+	github.com/spf13/cobra v1.8.1
+)
+
+require (
+	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
+	github.com/charmbracelet/colorprofile v0.2.3-0.20250311203215-f60798e515dc // indirect
+	github.com/charmbracelet/x/ansi v0.10.1 // indirect
+	github.com/charmbracelet/x/cellbuf v0.0.13-0.20250311204145-2c3ea96c31dd // indirect
+	github.com/charmbracelet/x/term v0.2.1 // indirect
+	github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f // indirect
+	github.com/inconshreveable/mousetrap v1.1.0 // indirect
+	github.com/lucasb-eyer/go-colorful v1.2.0 // indirect
+	github.com/mattn/go-isatty v0.0.20 // indirect
+	github.com/mattn/go-localereader v0.0.1 // indirect
+	github.com/mattn/go-runewidth v0.0.16 // indirect
+	github.com/muesli/ansi v0.0.0-20230316100256-276c6243b2f6 // indirect
+	github.com/muesli/cancelreader v0.2.2 // indirect
+	github.com/muesli/termenv v0.16.0 // indirect
+	github.com/rivo/uniseg v0.4.7 // indirect
+	github.com/spf13/pflag v1.0.5 // indirect
+	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect
+	golang.org/x/sys v0.36.0 // indirect
+	golang.org/x/text v0.3.8 // indirect
+)
+</file>
+
+<file path="mergen-cli/internal/checks/airdrop.go">
+package checks
+
+// CIS 2.3.1.1 — AirDrop disabled
+// CIS 2.3.1.2 — AirPlay Receiver disabled
+
+func init() {
+	Register(newCheck(
+		"2.3.1.1", "AirDrop disabled",
+		"2", "CIS Benchmark", "Medium",
+		"AirDrop can expose files to nearby devices without authentication.",
+		"defaults write com.apple.NetworkBrowser DisableAirDrop -bool YES",
+		false,
+		userFix(
+			"defaults write com.apple.NetworkBrowser DisableAirDrop -bool YES",
+			"AirDrop will be disabled for all networks.",
+		),
+		func() Result {
+			out, err := defaultsRead("com.apple.NetworkBrowser", "DisableAirDrop")
+			if err != nil || trim(out) != "1" {
+				return Result{StatusFail, "AirDrop is enabled (DisableAirDrop = " + out + ")"}
+			}
+			return Result{StatusPass, "AirDrop is disabled"}
+		},
+	))
+
+	Register(newCheck(
+		"2.3.1.2", "AirPlay Receiver disabled",
+		"2", "CIS Benchmark", "Low",
+		"AirPlay Receiver allows other devices to cast content to this Mac.",
+		"defaults write com.apple.controlcenter AirplayRecieverEnabled -int 0",
+		false,
+		userFix(
+			"defaults write com.apple.controlcenter AirplayRecieverEnabled -int 0",
+			"AirPlay Receiver will be off — other devices can no longer cast to this Mac.",
+		),
+		func() Result {
+			out, err := defaultsRead("com.apple.controlcenter", "AirplayRecieverEnabled")
+			if err == nil && trim(out) == "1" {
+				return Result{StatusFail, "AirPlay Receiver is enabled"}
+			}
+			return Result{StatusPass, "AirPlay Receiver is disabled"}
+		},
+	))
+}
+</file>
+
+<file path="mergen-cli/internal/checks/apache.go">
+package checks
+
+// CIS 4.2 — Apache HTTP server disabled
+// CIS 4.3 — NFS server disabled
+
+func init() {
+	Register(newCheck(
+		"4.2", "Apache HTTP server disabled",
+		"4", "CIS Benchmark", "High",
+		"The built-in Apache web server should be disabled unless explicitly required.",
+		"sudo launchctl disable system/org.apache.httpd",
+		false,
+		adminFix(
+			"launchctl disable system/org.apache.httpd; launchctl stop org.apache.httpd 2>/dev/null; true",
+			"Apache HTTP Server will be disabled and stopped.",
+		),
+		func() Result {
+			if launchctlRunning("org.apache.httpd") {
+				return Result{StatusFail, "Apache HTTP server is running"}
+			}
+			return Result{StatusPass, "Apache HTTP server is not running"}
+		},
+	))
+
+	Register(newCheck(
+		"4.3", "NFS server disabled",
+		"4", "CIS Benchmark", "High",
+		"The NFS daemon exposes the filesystem over the network and should be disabled.",
+		"sudo launchctl disable system/com.apple.nfsd",
+		false,
+		adminFix(
+			"launchctl disable system/com.apple.nfsd",
+			"NFS file server will be disabled.",
+		),
+		func() Result {
+			if !launchctlDisabled("com.apple.nfsd") {
+				return Result{StatusFail, "NFS server is not disabled"}
+			}
+			return Result{StatusPass, "NFS server is disabled"}
+		},
+	))
+}
+</file>
+
+<file path="mergen-cli/internal/checks/audit_logging.go">
+package checks
+
+import "strings"
+
+// CIS 3.1 — Security auditing enabled
+// CIS 3.2 — Audit flags configured
+
+func init() {
+	Register(newCheck(
+		"3.1", "Security auditing enabled",
+		"3", "CIS Benchmark", "Medium",
+		"The macOS audit daemon (auditd) records security-relevant events for forensic analysis.",
+		"sudo launchctl load -w /System/Library/LaunchDaemons/com.apple.auditd.plist",
+		false, nil,
+		func() Result {
+			out, err := run("/bin/launchctl", "list", "com.apple.auditd")
+			if err != nil || strings.Contains(out, "Could not find") {
+				return Result{StatusWarn, "auditd is not running (may be removed in macOS Tahoe)"}
+			}
+			return Result{StatusPass, "auditd is running"}
+		},
+	))
+
+	Register(newCheck(
+		"3.2", "Audit flags configured",
+		"3", "CIS Benchmark", "Medium",
+		"Audit flags should capture login/logout (lo), auth (aa), admin (ad), file deletion (fd, fm).",
+		"Edit /etc/security/audit_control and set: flags=lo,aa,ad,fd,fm,-all",
+		false, nil,
+		func() Result {
+			out, err := shell("grep ^flags /etc/security/audit_control 2>/dev/null")
+			if err != nil || out == "" {
+				return Result{StatusWarn, "audit_control not found or flags line missing"}
+			}
+			required := []string{"lo", "aa", "ad", "fd", "fm"}
+			var missing []string
+			for _, flag := range required {
+				if !strings.Contains(out, flag) {
+					missing = append(missing, flag)
+				}
+			}
+			if len(missing) > 0 {
+				return Result{StatusFail, "Missing audit flags: " + strings.Join(missing, ", ") + " (current: " + out + ")"}
+			}
+			return Result{StatusPass, "Audit flags configured: " + out}
+		},
+	))
+}
+</file>
+
+<file path="mergen-cli/internal/checks/base.go">
+package checks
+
+// base is embedded by every concrete check.
+type base struct {
+	cisID       string
+	name        string
+	section     string
+	category    string
+	severity    string
+	description string
+	remediation string
+	manual      bool
+	fix         *FixInfo
+}
+
+func (b *base) CISID() string       { return b.cisID }
+func (b *base) Name() string        { return b.name }
+func (b *base) Section() string     { return b.section }
+func (b *base) Category() string    { return b.category }
+func (b *base) Severity() string    { return b.severity }
+func (b *base) Description() string { return b.description }
+func (b *base) Remediation() string { return b.remediation }
+func (b *base) IsManual() bool      { return b.manual }
+func (b *base) Fix() *FixInfo       { return b.fix }
+
+// checkFn wraps a base + a run function — the standard way to define checks.
+type checkFn struct {
+	base
+	runFn func() Result
+}
+
+func (c *checkFn) Run() Result { return c.runFn() }
+
+// newCheck is the constructor used in every section file.
+func newCheck(
+	cisID, name, section, category, severity, description, remediation string,
+	manual bool,
+	fix *FixInfo,
+	runFn func() Result,
+) Check {
+	return &checkFn{
+		base: base{
+			cisID:       cisID,
+			name:        name,
+			section:     section,
+			category:    category,
+			severity:    severity,
+			description: description,
+			remediation: remediation,
+			manual:      manual,
+			fix:         fix,
+		},
+		runFn: runFn,
+	}
+}
+
+// adminFix is a helper to build a FixInfo that needs sudo/admin privileges.
+func adminFix(cmd, desc string) *FixInfo {
+	return &FixInfo{Command: cmd, RequiresAdmin: true, Description: desc}
+}
+
+// userFix is a helper for fixes that run as the current user.
+func userFix(cmd, desc string) *FixInfo {
+	return &FixInfo{Command: cmd, RequiresAdmin: false, Description: desc}
+}
+</file>
+
+<file path="mergen-cli/internal/checks/bonjour.go">
+package checks
+
+// CIS 4.1 — Bonjour advertising disabled
+
+func init() {
+	Register(newCheck(
+		"4.1", "Bonjour advertising disabled",
+		"4", "CIS Benchmark", "Low",
+		"Bonjour multicast advertising broadcasts service presence to the local network.",
+		"sudo defaults write /Library/Preferences/com.apple.mDNSResponder.plist NoMulticastAdvertisements -bool true",
+		false,
+		adminFix(
+			"defaults write /Library/Preferences/com.apple.mDNSResponder.plist NoMulticastAdvertisements -bool true",
+			"Bonjour multicast advertising will be disabled.",
+		),
+		func() Result {
+			out, err := defaultsRead("/Library/Preferences/com.apple.mDNSResponder.plist", "NoMulticastAdvertisements")
+			if err == nil && trim(out) == "1" {
+				return Result{StatusPass, "Bonjour advertising is disabled"}
+			}
+			return Result{StatusFail, "Bonjour advertising is enabled"}
+		},
+	))
+}
+</file>
+
+<file path="mergen-cli/internal/checks/efi.go">
+package checks
+
+import "strings"
+
+// EFI firmware version check (Intel only)
+
+func init() {
+	Register(newCheck(
+		"", "EFI firmware version valid",
+		"5", "CIS Benchmark", "Medium",
+		"Outdated EFI firmware exposes the system to firmware-level attacks that persist across OS reinstalls.",
+		"Apply all available firmware updates via Software Update.",
+		false, nil,
+		func() Result {
+			cpu, _ := run("/usr/sbin/sysctl", "-n", "machdep.cpu.brand_string")
+			if strings.Contains(cpu, "Apple") || !strings.Contains(cpu, "Intel") {
+				return Result{StatusWarn, "EFI check applies to Intel Macs only (detected Apple Silicon)"}
+			}
+			out, err := run("/usr/sbin/system_profiler", "SPHardwareDataType")
+			if err != nil {
+				return Result{StatusWarn, "Could not query system hardware information"}
+			}
+			if strings.Contains(out, "boot_rom_version") || strings.Contains(out, "Boot ROM Version") {
+				if strings.Contains(strings.ToUpper(out), "MM71") || strings.Contains(strings.ToUpper(out), "MM81") {
+					return Result{StatusFail, "EFI firmware version may be outdated — apply all firmware updates"}
+				}
+				return Result{StatusPass, "EFI firmware version appears current"}
+			}
+			return Result{StatusWarn, "Could not determine EFI firmware version"}
+		},
+	))
+}
+</file>
+
+<file path="mergen-cli/internal/checks/fast_user_switching.go">
+package checks
+
+// Fast User Switching disabled
+
+func init() {
+	Register(newCheck(
+		"", "Fast user switching disabled",
+		"2", "CIS Benchmark", "Medium",
+		"Fast User Switching lets users switch accounts without logging out, which can leave sessions exposed.",
+		"sudo defaults write /Library/Preferences/.GlobalPreferences MultipleSessionEnabled -bool false",
+		false,
+		adminFix(
+			"defaults write /Library/Preferences/.GlobalPreferences MultipleSessionEnabled -bool false",
+			"Fast User Switching will be disabled.",
+		),
+		func() Result {
+			out, err := defaultsRead("/Library/Preferences/.GlobalPreferences", "MultipleSessionEnabled")
+			if err == nil && trim(out) == "1" {
+				return Result{StatusFail, "Fast User Switching is enabled"}
+			}
+			return Result{StatusPass, "Fast User Switching is disabled"}
+		},
+	))
+}
+</file>
+
+<file path="mergen-cli/internal/checks/file_sharing.go">
+package checks
+
+// CIS 2.3.3.2 — File sharing disabled
+
+func init() {
+	Register(newCheck(
+		"2.3.3.2", "File sharing disabled",
+		"2", "CIS Benchmark", "High",
+		"SMB/AFP file sharing exposes the filesystem to the network.",
+		"sudo launchctl disable system/com.apple.smbd",
+		false,
+		adminFix(
+			"launchctl disable system/com.apple.smbd; launchctl stop com.apple.smbd 2>/dev/null; true",
+			"File Sharing (SMB/AFP) service will be disabled and stopped.",
+		),
+		func() Result {
+			if !launchctlDisabled("com.apple.smbd") {
+				return Result{StatusFail, "File sharing (smbd) is not disabled"}
+			}
+			return Result{StatusPass, "File sharing is disabled"}
+		},
+	))
+}
+</file>
+
+<file path="mergen-cli/internal/checks/filevault.go">
+package checks
+
+// FileVault full-disk encryption
+// XProtect malware detection
+// CIS 5.10 — XProtect enabled
+
+func init() {
+	Register(newCheck(
+		"", "FileVault enabled",
+		"5", "CIS Benchmark", "Critical",
+		"FileVault full-disk encryption protects all data if the device is lost or stolen.",
+		"Enable in System Settings > Privacy & Security > FileVault.",
+		false, nil,
+		func() Result {
+			out, err := run("/usr/bin/fdesetup", "status")
+			if err != nil {
+				return Result{StatusWarn, "Could not query FileVault: " + out}
+			}
+			if contains(out, "FileVault is On") {
+				return Result{StatusPass, "FileVault is enabled"}
+			}
+			return Result{StatusFail, "FileVault is OFF — disk is not encrypted"}
+		},
+	))
+
+	Register(newCheck(
+		"5.10", "XProtect is running and updated",
+		"5", "CIS Benchmark", "High",
+		"XProtect is macOS's built-in malware detection and blocking system.",
+		"XProtect is managed automatically by Apple and should not be disabled.",
+		false, nil,
+		func() Result {
+			out, err := run("/usr/bin/xprotect", "status")
+			if err == nil && contains(out, "enabled: true") {
+				return Result{StatusPass, "XProtect is running and up to date"}
+			}
+			// Fall back to checking launchctl service
+			svc, serr := run("/bin/launchctl", "list", "com.apple.XProtect.daemon.scan")
+			if serr == nil && contains(svc, "com.apple.XProtect") {
+				return Result{StatusPass, "XProtect daemon is running"}
+			}
+			return Result{StatusWarn, "Could not verify XProtect status"}
+		},
+	))
+
+	Register(newCheck(
+		"", "Certificate trust settings valid",
+		"5", "Security", "High",
+		"Untrusted root certificates can enable man-in-the-middle attacks.",
+		"Review certificate trust settings in Keychain Access > System Roots.",
+		false, nil,
+		func() Result {
+			out, err := shell("security dump-trust-settings 2>&1")
+			if err != nil {
+				return Result{StatusWarn, "Could not query certificate trust settings"}
+			}
+			if contains(out, "No Trust Settings were found") {
+				return Result{StatusPass, "No custom certificate trust overrides found"}
+			}
+			return Result{StatusFail, "Custom certificate trust settings exist — review in Keychain Access"}
+		},
+	))
+}
+</file>
+
+<file path="mergen-cli/internal/checks/finder.go">
+package checks
+
+import "strings"
+
+// CIS 5.9   — Guest home folder does not exist
+// CIS 6.1.1 — Filename extensions shown in Finder
+// CIS 6.1.2 — Home folder permissions
+
+func init() {
+	Register(newCheck(
+		"5.9", "Guest home folder does not exist",
+		"5", "CIS Benchmark", "Low",
+		"After disabling the Guest account, the legacy /Users/Guest folder may remain and can be misused.",
+		"sudo rm -rf /Users/Guest",
+		false, nil,
+		func() Result {
+			out, err := shell("ls /Users/ 2>/dev/null")
+			if err == nil && contains(out, "Guest") {
+				return Result{StatusFail, "Guest home folder exists at /Users/Guest"}
+			}
+			return Result{StatusPass, "Guest home folder does not exist"}
+		},
+	))
+
+	Register(newCheck(
+		"6.1.1", "Filename extensions shown",
+		"6", "CIS Benchmark", "Low",
+		"Hidden extensions can trick users into running malicious executables disguised as documents.",
+		"defaults write NSGlobalDomain AppleShowAllExtensions -bool true",
+		false,
+		userFix(
+			"defaults write NSGlobalDomain AppleShowAllExtensions -bool true",
+			"All file extensions will be visible in Finder.",
+		),
+		func() Result {
+			out, err := defaultsRead("NSGlobalDomain", "AppleShowAllExtensions")
+			if err != nil || trim(out) != "1" {
+				return Result{StatusFail, "File extensions are hidden (AppleShowAllExtensions = " + out + ")"}
+			}
+			return Result{StatusPass, "File extensions are shown"}
+		},
+	))
+
+	Register(newCheck(
+		"6.1.2", "Home folder permissions",
+		"6", "CIS Benchmark", "Medium",
+		"Home folder permissions should prevent other local users from reading your files.",
+		"chmod 700 ~/",
+		false, nil,
+		func() Result {
+			out, err := shell("ls -la /Users/ 2>/dev/null")
+			if err != nil {
+				return Result{StatusWarn, "Could not read /Users/ directory permissions"}
+			}
+			for _, line := range strings.Split(out, "\n") {
+				if len(line) < 10 {
+					continue
+				}
+				perms := line[:10]
+				if !strings.HasPrefix(perms, "d") {
+					continue
+				}
+				// Skip . and .. entries and the Shared folder
+				if strings.HasSuffix(strings.TrimSpace(line), ".") ||
+					strings.HasSuffix(strings.TrimSpace(line), "..") ||
+					strings.Contains(line, "Shared") {
+					continue
+				}
+				// Check if 'others' have read bit (position 7, 0-indexed)
+				if len(perms) >= 8 && string(perms[7]) == "r" {
+					return Result{StatusWarn, "Some home folders may have world-readable permissions. Manual review recommended."}
+				}
+			}
+			return Result{StatusPass, "Home folder permissions appear restrictive"}
+		},
+	))
+}
+</file>
+
+<file path="mergen-cli/internal/checks/firewall.go">
+package checks
+
+// CIS 2.2.1 — Firewall enabled
+// CIS 2.2.2 — Firewall stealth mode enabled
+
+func init() {
+	Register(newCheck(
+		"2.2.1", "Firewall enabled",
+		"2", "CIS Benchmark", "High",
+		"The macOS Application Firewall blocks unauthorized incoming connections.",
+		"sudo /usr/libexec/ApplicationFirewall/socketfilterfw --setglobalstate on",
+		false,
+		adminFix(
+			"/usr/libexec/ApplicationFirewall/socketfilterfw --setglobalstate on",
+			"macOS Application Firewall will be turned on.",
+		),
+		func() Result {
+			out, err := run("/usr/libexec/ApplicationFirewall/socketfilterfw", "--getglobalstate")
+			if err != nil {
+				return Result{StatusWarn, "Could not query firewall state: " + out}
+			}
+			if contains(out, "enabled") {
+				return Result{StatusPass, "Firewall is enabled"}
+			}
+			return Result{StatusFail, "Firewall is disabled"}
+		},
+	))
+
+	Register(newCheck(
+		"2.2.2", "Firewall stealth mode enabled",
+		"2", "CIS Benchmark", "Medium",
+		"Stealth mode prevents the Mac from responding to ping and port scan probes.",
+		"sudo /usr/libexec/ApplicationFirewall/socketfilterfw --setstealthmode on",
+		false,
+		adminFix(
+			"/usr/libexec/ApplicationFirewall/socketfilterfw --setstealthmode on",
+			"Firewall stealth mode will be enabled — your Mac will not respond to ping or port scans.",
+		),
+		func() Result {
+			out, err := run("/usr/libexec/ApplicationFirewall/socketfilterfw", "--getstealthmode")
+			if err != nil {
+				return Result{StatusWarn, "Could not query stealth mode: " + out}
+			}
+			if contains(out, "enabled") {
+				return Result{StatusPass, "Stealth mode is enabled"}
+			}
+			return Result{StatusFail, "Stealth mode is disabled"}
+		},
+	))
+}
+</file>
+
+<file path="mergen-cli/internal/checks/gatekeeper.go">
+package checks
+
+// CIS 2.6.3.1 — Diagnostic data sharing disabled
+// CIS 2.6.3.2 — Improve Siri & Dictation disabled
+// CIS 2.6.3.3 — Improve assistive voice disabled
+// CIS 2.6.3.4 — Share with app developers (advisory)
+// CIS 2.6.4   — Personalized ads disabled
+// CIS 2.6.5   — Gatekeeper enabled
+// CIS 2.6.7   — Lockdown Mode (advisory)
+// CIS 2.6.8   — Admin password for System Settings (advisory)
+
+func init() {
+	Register(newCheck(
+		"2.6.3.1", "Diagnostic data sharing disabled",
+		"2", "CIS Benchmark", "Low",
+		"Sending diagnostics to Apple may reveal sensitive system information.",
+		"sudo defaults write '/Library/Application Support/CrashReporter/DiagnosticMessagesHistory.plist' AutoSubmit -bool false",
+		false,
+		adminFix(
+			"defaults write '/Library/Application Support/CrashReporter/DiagnosticMessagesHistory.plist' AutoSubmit -bool false",
+			"Sending diagnostic and usage data to Apple will be turned off.",
+		),
+		func() Result {
+			out, err := shell("defaults read '/Library/Application Support/CrashReporter/DiagnosticMessagesHistory.plist' AutoSubmit 2>/dev/null")
+			if err == nil && trim(out) == "1" {
+				return Result{StatusFail, "Diagnostic data sharing is enabled"}
+			}
+			return Result{StatusPass, "Diagnostic data sharing is disabled"}
+		},
+	))
+
+	Register(newCheck(
+		"2.6.3.2", "Improve Siri & Dictation disabled",
+		"2", "CIS Benchmark", "Low",
+		"This setting shares Siri interaction recordings with Apple for model improvement.",
+		"defaults write com.apple.assistant.support 'Siri Data Sharing Opt-In Status' -int 2",
+		false,
+		userFix(
+			"defaults write com.apple.assistant.support 'Siri Data Sharing Opt-In Status' -int 2",
+			"Siri & Dictation improvement data sharing will be turned off.",
+		),
+		func() Result {
+			out, err := shell("defaults read com.apple.assistant.support 'Siri Data Sharing Opt-In Status' 2>/dev/null")
+			if err == nil && trim(out) == "1" {
+				return Result{StatusFail, "Siri data sharing opt-in is enabled"}
+			}
+			return Result{StatusPass, "Siri data sharing is disabled"}
+		},
+	))
+
+	Register(newCheck(
+		"2.6.3.3", "Improve assistive voice features disabled",
+		"2", "CIS Benchmark", "Low",
+		"Shares voice recordings with Apple for accessibility model improvement.",
+		"defaults write com.apple.Accessibility AXSAudioDonationSiriImprovementEnabled -bool false",
+		false,
+		userFix(
+			"defaults write com.apple.Accessibility AXSAudioDonationSiriImprovementEnabled -bool false",
+			"Assistive Voice improvement data sharing will be disabled.",
+		),
+		func() Result {
+			out, err := defaultsRead("com.apple.Accessibility", "AXSAudioDonationSiriImprovementEnabled")
+			if err == nil && trim(out) == "1" {
+				return Result{StatusFail, "Assistive voice improvement sharing is enabled"}
+			}
+			return Result{StatusPass, "Assistive voice improvement sharing is disabled"}
+		},
+	))
+
+	Register(newCheck(
+		"2.6.3.4", "Share with app developers disabled",
+		"2", "CIS Benchmark", "Low",
+		"Sharing crash data with app developers may expose system details.",
+		"Deploy MDM profile with allowDiagnosticSubmission = false.",
+		false, nil,
+		func() Result {
+			out, err := shell("osascript -l JavaScript -e \"$.NSUserDefaults.alloc.initWithSuiteName('com.apple.applicationaccess').objectForKey('allowDiagnosticSubmission').js\" 2>/dev/null")
+			if err == nil && trim(out) == "false" {
+				return Result{StatusPass, "Share with App Developers is disabled via MDM"}
+			}
+			if err == nil && trim(out) == "true" {
+				return Result{StatusFail, "Share with App Developers is enabled via MDM"}
+			}
+			return Result{StatusWarn, "Share with App Developers state unknown — no MDM profile installed"}
+		},
+	))
+
+	Register(newCheck(
+		"2.6.4", "Personalized ads disabled",
+		"2", "CIS Benchmark", "Low",
+		"Apple personalized advertising builds a profile using your usage data.",
+		"defaults write com.apple.AdLib allowApplePersonalizedAdvertising -bool false",
+		false,
+		userFix(
+			"defaults write com.apple.AdLib allowApplePersonalizedAdvertising -bool false",
+			"Apple personalized advertising will be disabled.",
+		),
+		func() Result {
+			out, err := defaultsRead("com.apple.AdLib", "allowApplePersonalizedAdvertising")
+			if err == nil && trim(out) == "1" {
+				return Result{StatusFail, "Personalized advertising is enabled"}
+			}
+			return Result{StatusPass, "Personalized advertising is disabled"}
+		},
+	))
+
+	Register(newCheck(
+		"2.6.5", "Gatekeeper enabled",
+		"2", "CIS Benchmark", "High",
+		"Gatekeeper ensures only code-signed, trusted apps can run on this Mac.",
+		"sudo spctl --master-enable",
+		false,
+		adminFix(
+			"spctl --master-enable",
+			"Gatekeeper will be re-enabled — only apps from identified developers will run.",
+		),
+		func() Result {
+			out, err := shell("spctl --status 2>&1")
+			if err == nil && contains(out, "assessments enabled") {
+				return Result{StatusPass, "Gatekeeper is enabled"}
+			}
+			if contains(out, "disabled") {
+				return Result{StatusFail, "Gatekeeper is disabled"}
+			}
+			return Result{StatusWarn, "Could not determine Gatekeeper status: " + out}
+		},
+	))
+
+	Register(newCheck(
+		"2.6.7", "Lockdown Mode status",
+		"2", "CIS Benchmark", "Low",
+		"Lockdown Mode provides extreme protection for high-risk individuals.",
+		"Enable in System Settings > Privacy & Security > Lockdown Mode.",
+		true, nil,
+		func() Result {
+			out, err := defaultsRead("/Library/Preferences/com.apple.security.lockdown", "LockdownModeEnabled")
+			if err == nil && trim(out) == "1" {
+				return Result{StatusPass, "Lockdown Mode is enabled"}
+			}
+			return Result{StatusManual, "Lockdown Mode is disabled — advisory: only required for high-risk users"}
+		},
+	))
+
+	Register(newCheck(
+		"2.6.8", "Admin password required for System Settings",
+		"2", "CIS Benchmark", "Medium",
+		"Requiring admin authentication prevents unauthorized changes to system preferences.",
+		"security authorizationdb write system.preferences allow-root false",
+		false, nil,
+		func() Result {
+			out, err := shell("security authorizationdb read system.preferences 2>/dev/null")
+			if err != nil {
+				return Result{StatusWarn, "Could not read authorization database"}
+			}
+			if contains(out, "<false/>") && contains(out, "<string>admin</string>") {
+				return Result{StatusPass, "Admin password is required for system-wide preferences"}
+			}
+			return Result{StatusFail, "Admin password may not be required for system-wide preferences"}
+		},
+	))
+}
+</file>
+
+<file path="mergen-cli/internal/checks/helpers.go">
+package checks
+
+import (
+	"os/exec"
+	"strings"
+)
+
+// shell runs a shell command and returns combined stdout+stderr, trimmed.
+func shell(command string) (string, error) {
+	cmd := exec.Command("/bin/sh", "-c", command)
+	out, err := cmd.CombinedOutput()
+	return strings.TrimSpace(string(out)), err
+}
+
+// run executes a binary with args and returns combined output, trimmed.
+func run(name string, args ...string) (string, error) {
+	cmd := exec.Command(name, args...)
+	out, err := cmd.CombinedOutput()
+	return strings.TrimSpace(string(out)), err
+}
+
+// defaultsRead reads a single defaults key. Returns ("", error) if key absent.
+// Uses stdout-only so that "domain/default pair does not exist" stderr messages
+// never leak into check output strings.
+func defaultsRead(domain, key string) (string, error) {
+	cmd := exec.Command("/usr/bin/defaults", "read", domain, key)
+	out, err := cmd.Output()
+	return strings.TrimSpace(string(out)), err
+}
+
+// defaultsReadHost reads a -currentHost defaults key.
+func defaultsReadHost(domain, key string) (string, error) {
+	cmd := exec.Command("/usr/bin/defaults", "-currentHost", "read", domain, key)
+	out, err := cmd.Output()
+	return strings.TrimSpace(string(out)), err
+}
+
+// launchctlDisabled returns true when the given service label is listed as
+// disabled in `launchctl print-disabled system`.
+func launchctlDisabled(label string) bool {
+	out, err := run("/bin/launchctl", "print-disabled", "system")
+	if err != nil {
+		return false
+	}
+	needle := `"` + label + `" => disabled`
+	return strings.Contains(out, needle)
+}
+
+// launchctlRunning returns true when the service is currently loaded/running.
+func launchctlRunning(label string) bool {
+	_, err := run("/bin/launchctl", "list", label)
+	return err == nil
+}
+
+// contains is a case-insensitive substring check.
+func contains(s, substr string) bool {
+	return strings.Contains(strings.ToLower(s), strings.ToLower(substr))
+}
+
+// trim strips whitespace and newlines.
+func trim(s string) string {
+	return strings.TrimSpace(s)
+}
+
+// unknownWarn returns a StatusWarn result when a check can't determine status
+// due to a command error — matches the Swift app's Yellow-on-exception behaviour.
+func unknownWarn(context string) Result {
+	return Result{StatusWarn, "Could not determine: " + context}
+}
+
+// join joins a slice of strings with a separator.
+func join(parts []string, sep string) string {
+	return strings.Join(parts, sep)
+}
+</file>
+
+<file path="mergen-cli/internal/checks/icloud.go">
+package checks
+
+// CIS 2.1.1.1 — iCloud Keychain disabled (advisory)
+// CIS 2.1.1.3 — iCloud Drive Desktop and Documents sync disabled
+
+func init() {
+	Register(newCheck(
+		"2.1.1.1", "iCloud Keychain disabled",
+		"2", "CIS Benchmark", "Medium",
+		"iCloud Keychain syncs passwords and credentials across Apple devices, which may violate data residency requirements.",
+		"Disable via MDM profile (allowCloudKeychainSync = false) or System Settings > Apple ID > iCloud > Passwords & Keychain.",
+		true, nil,
+		func() Result {
+			out, err := shell("osascript -l JavaScript -e \"$.NSUserDefaults.alloc.initWithSuiteName('com.apple.applicationaccess').objectForKey('allowCloudKeychainSync').js\" 2>/dev/null")
+			if err == nil && trim(out) == "false" {
+				return Result{StatusPass, "iCloud Keychain sync is disabled via MDM profile"}
+			}
+			if err == nil && trim(out) == "true" {
+				return Result{StatusFail, "iCloud Keychain sync is enabled via MDM profile"}
+			}
+			return Result{StatusManual, "Manual review required: check System Settings > Apple ID > iCloud > Passwords & Keychain"}
+		},
+	))
+
+	Register(newCheck(
+		"2.1.1.3", "iCloud Drive Desktop and Documents sync disabled",
+		"2", "CIS Benchmark", "Medium",
+		"iCloud Drive Desktop/Documents sync automatically uploads sensitive files to cloud storage.",
+		"defaults write com.apple.finder FXICloudDriveDesktop -bool false && defaults write com.apple.finder FXICloudDriveDocuments -bool false",
+		false,
+		userFix(
+			"defaults write com.apple.finder FXICloudDriveDesktop -bool false && defaults write com.apple.finder FXICloudDriveDocuments -bool false",
+			"iCloud Drive Desktop and Documents sync will be disabled.",
+		),
+		func() Result {
+			desktop, _ := defaultsRead("com.apple.finder", "FXICloudDriveDesktop")
+			docs, _ := defaultsRead("com.apple.finder", "FXICloudDriveDocuments")
+			if trim(desktop) == "1" || trim(docs) == "1" {
+				var which []string
+				if trim(desktop) == "1" {
+					which = append(which, "Desktop")
+				}
+				if trim(docs) == "1" {
+					which = append(which, "Documents")
+				}
+				return Result{StatusFail, "iCloud Drive sync enabled for: " + join(which, ", ")}
+			}
+			return Result{StatusPass, "iCloud Drive Desktop and Documents sync is disabled"}
+		},
+	))
+}
+</file>
+
+<file path="mergen-cli/internal/checks/internet_sharing.go">
+package checks
+
+// CIS 2.3.3.7 — Internet sharing disabled
+// CIS 2.3.3.8 — Content caching disabled
+// CIS 2.3.3.9 — Media sharing disabled
+// CIS 2.3.3.10 — Bluetooth sharing disabled
+
+func init() {
+	Register(newCheck(
+		"2.3.3.7", "Internet sharing disabled",
+		"2", "CIS Benchmark", "High",
+		"Internet sharing turns the Mac into a router, exposing internal network services.",
+		"sudo defaults write /Library/Preferences/SystemConfiguration/com.apple.nat NAT -dict-add Enabled -int 0",
+		false,
+		adminFix(
+			"defaults write /Library/Preferences/SystemConfiguration/com.apple.nat NAT -dict-add Enabled -int 0",
+			"Internet Sharing will be disabled.",
+		),
+		func() Result {
+			out, err := shell("defaults read /Library/Preferences/SystemConfiguration/com.apple.nat 2>/dev/null")
+			if err == nil && contains(out, "Enabled = 1") {
+				return Result{StatusFail, "Internet sharing is enabled"}
+			}
+			return Result{StatusPass, "Internet sharing is disabled"}
+		},
+	))
+
+	Register(newCheck(
+		"2.3.3.8", "Content caching disabled",
+		"2", "CIS Benchmark", "Low",
+		"Content caching serves Apple content to other network devices. Disable unless needed.",
+		"sudo /usr/bin/AssetCacheManagerUtil deactivate",
+		false,
+		adminFix(
+			"/usr/bin/AssetCacheManagerUtil deactivate 2>/dev/null; true",
+			"Content Caching service will be deactivated.",
+		),
+		func() Result {
+			out, err := shell("/usr/bin/AssetCacheManagerUtil status 2>&1")
+			if err == nil && contains(out, "activated: true") {
+				return Result{StatusFail, "Content caching is active"}
+			}
+			return Result{StatusPass, "Content caching is not active"}
+		},
+	))
+
+	Register(newCheck(
+		"2.3.3.9", "Media sharing disabled",
+		"2", "CIS Benchmark", "Low",
+		"Media sharing (Home Sharing) exposes your media library to the local network.",
+		"defaults write com.apple.amp.mediasharingd home-sharing-enabled -int 0",
+		false,
+		adminFix(
+			"defaults write com.apple.amp.mediasharingd home-sharing-enabled -int 0; launchctl stop com.apple.amp.mediasharingd 2>/dev/null; true",
+			"Media Sharing service will be disabled.",
+		),
+		func() Result {
+			out, err := defaultsRead("com.apple.amp.mediasharingd", "home-sharing-enabled")
+			if err == nil && trim(out) == "1" {
+				return Result{StatusFail, "Media sharing (Home Sharing) is enabled"}
+			}
+			return Result{StatusPass, "Media sharing is disabled"}
+		},
+	))
+
+	Register(newCheck(
+		"2.3.3.10", "Bluetooth sharing disabled",
+		"2", "CIS Benchmark", "Medium",
+		"Bluetooth sharing can expose files to nearby devices without a password.",
+		"defaults -currentHost write com.apple.Bluetooth PrefKeyServicesEnabled -bool false",
+		false,
+		userFix(
+			"defaults -currentHost write com.apple.Bluetooth PrefKeyServicesEnabled -bool false",
+			"Bluetooth Sharing will be disabled.",
+		),
+		func() Result {
+			out, err := defaultsReadHost("com.apple.Bluetooth", "PrefKeyServicesEnabled")
+			if err != nil {
+				return Result{StatusWarn, "Could not determine Bluetooth Sharing status"}
+			}
+			if trim(out) == "1" {
+				return Result{StatusFail, "Bluetooth Sharing is enabled"}
+			}
+			return Result{StatusPass, "Bluetooth Sharing is disabled"}
+		},
+	))
+}
+</file>
+
+<file path="mergen-cli/internal/checks/java.go">
+package checks
+
+import "strings"
+
+// Java 6 runtime disabled
+
+func init() {
+	Register(newCheck(
+		"", "Java 6 runtime disabled",
+		"5", "Security", "High",
+		"Java 6 is end-of-life and contains unpatched security vulnerabilities. It should not be the active runtime.",
+		"Install a supported Java version and remove Java 6.",
+		false, nil,
+		func() Result {
+			out, err := shell("/usr/bin/java -version 2>&1")
+			if err != nil || trim(out) == "" {
+				return Result{StatusPass, "Java is not installed or not in PATH"}
+			}
+			if strings.Contains(strings.ToLower(out), "java 1.6") || strings.Contains(strings.ToLower(out), "version \"1.6") {
+				return Result{StatusFail, "Java 6 is the active runtime — upgrade immediately: " + trim(out)}
+			}
+			return Result{StatusPass, "Java version is not 6: " + trim(out)}
+		},
+	))
+}
+</file>
+
+<file path="mergen-cli/internal/checks/login_window.go">
+package checks
+
+// CIS 2.11.3 — Login window message (advisory)
+// CIS 2.11.4 — Login window shows name and password fields
+// CIS 2.11.5 — Password hints disabled
+// CIS 2.13.1 — Guest login disabled
+// CIS 2.13.2 — Guest access to shared folders disabled
+// CIS 2.13.3 — Automatic login disabled
+
+func init() {
+	Register(newCheck(
+		"2.11.3", "Login window message configured",
+		"2", "CIS Benchmark", "Low",
+		"A login window message communicates security policy to users at the login screen.",
+		"sudo defaults write /Library/Preferences/com.apple.loginwindow LoginwindowText 'Authorized use only'",
+		false, nil,
+		func() Result {
+			out, err := defaultsRead("/Library/Preferences/com.apple.loginwindow", "LoginwindowText")
+			if err != nil || trim(out) == "" {
+				return Result{StatusWarn, "No login window message is configured"}
+			}
+			return Result{StatusPass, "Login window message: " + out}
+		},
+	))
+
+	Register(newCheck(
+		"2.11.4", "Login window shows name and password fields",
+		"2", "CIS Benchmark", "Low",
+		"Showing the user list at login leaks account names to anyone at the keyboard.",
+		"sudo defaults write /Library/Preferences/com.apple.loginwindow SHOWFULLNAME -bool true",
+		false,
+		adminFix(
+			"defaults write /Library/Preferences/com.apple.loginwindow SHOWFULLNAME -bool true",
+			"Login window will show username and password fields instead of a user list.",
+		),
+		func() Result {
+			out, err := defaultsRead("/Library/Preferences/com.apple.loginwindow", "SHOWFULLNAME")
+			if err != nil || trim(out) != "1" {
+				return Result{StatusFail, "Login window shows user list (SHOWFULLNAME = " + out + ")"}
+			}
+			return Result{StatusPass, "Login window shows name and password fields"}
+		},
+	))
+
+	Register(newCheck(
+		"2.11.5", "Password hints disabled",
+		"2", "CIS Benchmark", "Medium",
+		"Password hints after failed logins can help an attacker guess the password.",
+		"sudo defaults write /Library/Preferences/com.apple.loginwindow RetriesUntilHint -int 0",
+		false,
+		adminFix(
+			"defaults write /Library/Preferences/com.apple.loginwindow RetriesUntilHint -int 0",
+			"Password hints will no longer appear after failed login attempts.",
+		),
+		func() Result {
+			out, err := defaultsRead("/Library/Preferences/com.apple.loginwindow", "RetriesUntilHint")
+			if err == nil && trim(out) != "0" && trim(out) != "" {
+				return Result{StatusFail, "Password hints shown after " + out + " failed attempts"}
+			}
+			return Result{StatusPass, "Password hints are disabled"}
+		},
+	))
+
+	Register(newCheck(
+		"2.13.1", "Guest login disabled",
+		"2", "CIS Benchmark", "High",
+		"The Guest account allows login without credentials, bypassing all authentication.",
+		"sudo defaults write /Library/Preferences/com.apple.loginwindow.plist GuestEnabled -bool false",
+		false,
+		adminFix(
+			"defaults write /Library/Preferences/com.apple.loginwindow.plist GuestEnabled -bool false",
+			"Guest account will be disabled.",
+		),
+		func() Result {
+			out, err := defaultsRead("/Library/Preferences/com.apple.loginwindow.plist", "GuestEnabled")
+			if err == nil && trim(out) == "1" {
+				return Result{StatusFail, "Guest login is enabled"}
+			}
+			return Result{StatusPass, "Guest login is disabled"}
+		},
+	))
+
+	Register(newCheck(
+		"2.13.2", "Guest access to shared folders disabled",
+		"2", "CIS Benchmark", "Medium",
+		"Guests can read shared folders without any authentication when this is enabled.",
+		"sudo defaults write /Library/Preferences/com.apple.AppleFileServer guestAccess -int 0",
+		false,
+		adminFix(
+			"defaults write /Library/Preferences/com.apple.AppleFileServer guestAccess -int 0",
+			"Guest access to shared folders will be disabled.",
+		),
+		func() Result {
+			out, err := defaultsRead("/Library/Preferences/com.apple.AppleFileServer", "guestAccess")
+			if err == nil && trim(out) == "1" {
+				return Result{StatusFail, "Guest access to shared folders is enabled"}
+			}
+			return Result{StatusPass, "Guest access to shared folders is disabled"}
+		},
+	))
+
+	Register(newCheck(
+		"2.13.3", "Automatic login disabled",
+		"2", "CIS Benchmark", "High",
+		"Automatic login bypasses the password requirement entirely at startup.",
+		"sudo defaults delete /Library/Preferences/com.apple.loginwindow autoLoginUser",
+		false,
+		adminFix(
+			"defaults delete /Library/Preferences/com.apple.loginwindow autoLoginUser 2>/dev/null; true",
+			"Automatic login will be disabled — a password will be required at every startup.",
+		),
+		func() Result {
+			out, err := defaultsRead("/Library/Preferences/com.apple.loginwindow", "autoLoginUser")
+			if err == nil && trim(out) != "" {
+				return Result{StatusFail, "Automatic login is enabled for: " + out}
+			}
+			return Result{StatusPass, "Automatic login is disabled"}
+		},
+	))
+}
+</file>
+
+<file path="mergen-cli/internal/checks/menubar.go">
+package checks
+
+// CIS 2.6.1.1 — Location services enabled
+// CIS 2.6.1.2 — Location services shown in menu bar
+// Bluetooth status shown in menu bar
+
+func init() {
+	Register(newCheck(
+		"2.6.1.1", "Location services enabled",
+		"2", "CIS Benchmark", "Low",
+		"Location Services are required for time zone accuracy and Find My. This check verifies the location daemon is running.",
+		"Enable in System Settings > Privacy & Security > Location Services.",
+		false, nil,
+		func() Result {
+			if launchctlRunning("com.apple.locationd") {
+				return Result{StatusPass, "Location Services (locationd) is running"}
+			}
+			return Result{StatusFail, "Location Services is not running"}
+		},
+	))
+
+	Register(newCheck(
+		"2.6.1.2", "Location services shown in menu bar",
+		"2", "CIS Benchmark", "Low",
+		"Showing the Location Services icon lets users see when apps are using their location.",
+		"Enable in System Settings > Privacy & Security > Location Services > Show in menu bar.",
+		false, nil,
+		func() Result {
+			out, err := defaultsRead("com.apple.systemuiserver", "menuExtras")
+			if err == nil && contains(out, "Location.menu") {
+				return Result{StatusPass, "Location Services icon is visible in the menu bar"}
+			}
+			return Result{StatusFail, "Location Services icon is not shown in the menu bar"}
+		},
+	))
+
+	Register(newCheck(
+		"", "Bluetooth status shown in menu bar",
+		"2", "CIS Benchmark", "Low",
+		"Showing Bluetooth in the menu bar helps users notice unexpected Bluetooth activity.",
+		"Enable in System Settings > Control Center > Bluetooth > Show in Menu Bar.",
+		false, nil,
+		func() Result {
+			out, err := defaultsRead("com.apple.controlcenter.plist", "NSStatusItem Visible Bluetooth")
+			if err == nil && trim(out) == "1" {
+				return Result{StatusPass, "Bluetooth status is shown in the menu bar"}
+			}
+			return Result{StatusFail, "Bluetooth status is not shown in the menu bar"}
+		},
+	))
+}
+</file>
+
+<file path="mergen-cli/internal/checks/password_policy.go">
+package checks
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// CIS 5.2.1 — Password lockout threshold ≤ 5
+// CIS 5.2.2 — Minimum password length ≥ 15
+
+func init() {
+	Register(newCheck(
+		"5.2.1", "Password lockout threshold ≤ 5 attempts",
+		"5", "CIS Benchmark", "High",
+		"Accounts should lock after no more than 5 consecutive failed login attempts.",
+		"sudo pwpolicy -n /Local/Default -setglobalpolicy maxFailedLoginAttempts=5",
+		false,
+		adminFix(
+			"pwpolicy -n /Local/Default -setglobalpolicy maxFailedLoginAttempts=5",
+			"Account will lock after 5 consecutive failed password attempts.",
+		),
+		func() Result {
+			out, err := shell("pwpolicy -getaccountpolicies 2>/dev/null")
+			if err != nil || out == "" {
+				return Result{StatusWarn, "Could not read password policy (may require admin)"}
+			}
+			if !contains(out, "policyAttributeMaximumFailedAuthentications") {
+				return Result{StatusFail, "No login failure lockout policy is configured"}
+			}
+			lines := strings.Split(out, "\n")
+			for i, line := range lines {
+				if strings.Contains(line, "policyAttributeMaximumFailedAuthentications") && i+1 < len(lines) {
+					next := strings.TrimSpace(lines[i+1])
+					next = strings.TrimPrefix(next, "<integer>")
+					next = strings.TrimSuffix(next, "</integer>")
+					if n, parseErr := strconv.Atoi(next); parseErr == nil {
+						if n <= 5 {
+							return Result{StatusPass, fmt.Sprintf("Lockout after %d failed attempts", n)}
+						}
+						return Result{StatusFail, fmt.Sprintf("Lockout threshold is %d (should be ≤ 5)", n)}
+					}
+				}
+			}
+			return Result{StatusPass, "Lockout policy is configured"}
+		},
+	))
+
+	Register(newCheck(
+		"5.2.2", "Minimum password length ≥ 15 characters",
+		"5", "CIS Benchmark", "High",
+		"Longer passwords are exponentially harder to brute-force.",
+		"sudo pwpolicy -n /Local/Default -setglobalpolicy minChars=15",
+		false,
+		adminFix(
+			"pwpolicy -n /Local/Default -setglobalpolicy minChars=15",
+			"Minimum password length will be set to 15 characters.",
+		),
+		func() Result {
+			out, err := shell("pwpolicy -getaccountpolicies 2>/dev/null")
+			if err != nil || out == "" {
+				return Result{StatusWarn, "Could not read password policy (may require admin)"}
+			}
+			if !contains(out, "minChars") {
+				return Result{StatusFail, "No minimum password length policy is configured"}
+			}
+			return Result{StatusPass, "Minimum password length policy is configured"}
+		},
+	))
+}
+</file>
+
+<file path="mergen-cli/internal/checks/power.go">
+package checks
+
+import "strings"
+
+// CIS 2.8.1   — Universal Control disabled
+// CIS 2.9.1   — Spotlight suggestions (advisory)
+// CIS 2.10.1.2 — Sleep enabled (Apple Silicon)
+// CIS 2.10.2  — Power Nap disabled
+// CIS 2.10.3  — Wake for network access disabled
+
+func init() {
+	Register(newCheck(
+		"2.8.1", "Universal Control disabled",
+		"2", "CIS Benchmark", "Low",
+		"Universal Control shares keyboard and mouse across nearby Apple devices.",
+		"defaults -currentHost write com.apple.universalcontrol Disable -int 1",
+		false,
+		userFix(
+			"defaults -currentHost write com.apple.universalcontrol Disable -int 1",
+			"Universal Control will be disabled.",
+		),
+		func() Result {
+			out, err := defaultsReadHost("com.apple.universalcontrol", "Disable")
+			if err != nil || trim(out) != "1" {
+				return Result{StatusFail, "Universal Control is not disabled"}
+			}
+			return Result{StatusPass, "Universal Control is disabled"}
+		},
+	))
+
+	Register(newCheck(
+		"2.9.1", "Spotlight search query sharing disabled",
+		"2", "CIS Benchmark", "Low",
+		"Spotlight can send search queries to Apple servers for improved suggestions.",
+		"Deploy MDM profile with 'Search Queries Data Sharing Status' = 2, or disable in System Settings > Siri & Spotlight.",
+		false,
+		userFix(
+			"defaults write com.apple.assistant.support 'Search Queries Data Sharing Status' -int 2",
+			"Spotlight search query sharing will be disabled.",
+		),
+		func() Result {
+			out, err := shell("osascript -l JavaScript -e \"$.NSUserDefaults.alloc.initWithSuiteName('com.apple.assistant.support').objectForKey('Search Queries Data Sharing Status').js\" 2>/dev/null")
+			if err == nil && trim(out) == "2" {
+				return Result{StatusPass, "Spotlight search query sharing is disabled"}
+			}
+			// Fall back to direct defaults read
+			out2, _ := defaultsRead("com.apple.assistant.support", "Search Queries Data Sharing Status")
+			if trim(out2) == "2" {
+				return Result{StatusPass, "Spotlight search query sharing is disabled"}
+			}
+			if trim(out2) == "1" || trim(out) == "1" {
+				return Result{StatusFail, "Spotlight search query sharing is enabled"}
+			}
+			return Result{StatusWarn, "Spotlight search query sharing status could not be determined"}
+		},
+	))
+
+	Register(newCheck(
+		"2.10.1.2", "Sleep enabled (Apple Silicon)",
+		"2", "CIS Benchmark", "Medium",
+		"Sleep should be enabled so the screen locks automatically during inactivity.",
+		"sudo pmset -a sleep 15 && sudo pmset -a displaysleep 10",
+		false,
+		adminFix(
+			"pmset -a sleep 15 && pmset -a displaysleep 10",
+			"Sleep will be set to 15 min and display sleep to 10 min.",
+		),
+		func() Result {
+			cpu, _ := run("/usr/sbin/sysctl", "-n", "machdep.cpu.brand_string")
+			if strings.Contains(cpu, "Intel") {
+				return Result{StatusPass, "Not applicable — Apple Silicon only (detected Intel CPU)"}
+			}
+			out, err := shell("pmset -b -g 2>/dev/null | grep -E '^ sleep|^ displaysleep'")
+			if err != nil || out == "" {
+				return Result{StatusFail, "Sleep and display sleep are not configured"}
+			}
+			return Result{StatusPass, "Power settings: " + strings.ReplaceAll(out, "\n", ", ")}
+		},
+	))
+
+	Register(newCheck(
+		"2.10.2", "Power Nap disabled (Intel Macs only)",
+		"2", "CIS Benchmark", "Low",
+		"Power Nap allows the Mac to perform tasks while asleep, increasing the attack surface. This setting only applies to Intel Macs.",
+		"sudo pmset -a powernap 0",
+		false,
+		adminFix(
+			"pmset -a powernap 0 && pmset -a darkwakes 0",
+			"Power Nap and dark wake will be disabled.",
+		),
+		func() Result {
+			cpu, _ := run("/usr/sbin/sysctl", "-n", "machdep.cpu.brand_string")
+			if !strings.Contains(cpu, "Intel") {
+				return Result{StatusPass, "Not applicable — this check is for Intel Macs only"}
+			}
+			out, err := shell("pmset -g custom 2>/dev/null | grep powernap")
+			if err != nil {
+				return Result{StatusWarn, "Could not read power settings"}
+			}
+			if contains(out, "1") {
+				return Result{StatusFail, "Power Nap is enabled"}
+			}
+			return Result{StatusPass, "Power Nap is disabled"}
+		},
+	))
+
+	Register(newCheck(
+		"2.10.3", "Wake for network access disabled",
+		"2", "CIS Benchmark", "Low",
+		"Wake for network access allows remote power-on which can be exploited.",
+		"sudo pmset -a womp 0",
+		false,
+		adminFix(
+			"pmset -a womp 0",
+			"Wake for network access will be disabled.",
+		),
+		func() Result {
+			out, err := shell("pmset -g custom 2>/dev/null | grep womp")
+			if err != nil || trim(out) == "" {
+				return Result{StatusWarn, "Could not determine wake for network access setting"}
+			}
+			if contains(out, "1") {
+				return Result{StatusFail, "Wake for network access is enabled"}
+			}
+			return Result{StatusPass, "Wake for network access is disabled"}
+		},
+	))
+}
+</file>
+
+<file path="mergen-cli/internal/checks/printer_sharing.go">
+package checks
+
+// CIS 2.3.3.3 — Printer sharing disabled
+
+func init() {
+	Register(newCheck(
+		"2.3.3.3", "Printer sharing disabled",
+		"2", "CIS Benchmark", "Low",
+		"Printer sharing exposes CUPS to the network and should be off unless required.",
+		"sudo cupsctl --no-share-printers",
+		false,
+		adminFix(
+			"cupsctl --no-share-printers",
+			"Printer Sharing will be turned off.",
+		),
+		func() Result {
+			out, err := shell("cupsctl 2>/dev/null | grep _share_printers")
+			if err == nil && contains(out, "_share_printers=1") {
+				return Result{StatusFail, "Printer sharing is enabled"}
+			}
+			return Result{StatusPass, "Printer sharing is disabled"}
+		},
+	))
+}
+</file>
+
+<file path="mergen-cli/internal/checks/registry.go">
+package checks
+
+import (
+	"sort"
+	"strings"
+)
+
+var registry []Check
+
+// Register adds a check to the global registry.
+// Called from each section's init().
+func Register(c Check) {
+	registry = append(registry, c)
+}
+
+// All returns every registered check, sorted by CIS ID then name.
+func All() []Check {
+	sorted := make([]Check, len(registry))
+	copy(sorted, registry)
+	sort.Slice(sorted, func(i, j int) bool {
+		ai, aj := sorted[i].CISID(), sorted[j].CISID()
+		if ai == "" && aj == "" {
+			return sorted[i].Name() < sorted[j].Name()
+		}
+		if ai == "" {
+			return false
+		}
+		if aj == "" {
+			return true
+		}
+		return ai < aj
+	})
+	return sorted
+}
+
+// ByCategory returns checks whose Category() matches cat (case-insensitive).
+func ByCategory(cat string) []Check {
+	if cat == "" {
+		return All()
+	}
+	var out []Check
+	for _, c := range All() {
+		if strings.EqualFold(c.Category(), cat) {
+			out = append(out, c)
+		}
+	}
+	return out
+}
+
+// BySection returns checks for a given section number prefix (e.g. "1", "2").
+func BySection(sec string) []Check {
+	var out []Check
+	prefix := sec + "."
+	for _, c := range All() {
+		if strings.HasPrefix(c.CISID(), prefix) || c.CISID() == sec {
+			out = append(out, c)
+		}
+	}
+	return out
+}
+</file>
+
+<file path="mergen-cli/internal/checks/remote_management.go">
+package checks
+
+// CIS 2.3.3.5 — Remote Management (ARD) disabled
+// CIS 2.3.3.6 — Remote Apple Events disabled
+
+func init() {
+	Register(newCheck(
+		"2.3.3.5", "Remote management disabled",
+		"2", "CIS Benchmark", "High",
+		"Remote Management (ARD/VNC) provides privileged remote access. Disable unless needed.",
+		"sudo /System/Library/CoreServices/RemoteManagement/ARDAgent.app/Contents/Resources/kickstart -deactivate -stop",
+		false,
+		adminFix(
+			"/System/Library/CoreServices/RemoteManagement/ARDAgent.app/Contents/Resources/kickstart -deactivate -stop 2>/dev/null; true",
+			"Remote Management (ARD) will be deactivated and stopped.",
+		),
+		func() Result {
+			if launchctlRunning("com.apple.RemoteDesktop.agent") {
+				return Result{StatusFail, "Remote Management (ARD) is running"}
+			}
+			return Result{StatusPass, "Remote Management is not running"}
+		},
+	))
+
+	Register(newCheck(
+		"2.3.3.6", "Remote Apple Events disabled",
+		"2", "CIS Benchmark", "Medium",
+		"Remote Apple Events allows other machines to control this Mac via AppleScript.",
+		"sudo launchctl disable system/com.apple.AEServer",
+		false,
+		adminFix(
+			"launchctl disable system/com.apple.AEServer; launchctl stop com.apple.AEServer 2>/dev/null; true",
+			"Remote Apple Events will be disabled.",
+		),
+		func() Result {
+			if !launchctlDisabled("com.apple.AEServer") {
+				return Result{StatusFail, "Remote Apple Events (AEServer) is not disabled"}
+			}
+			return Result{StatusPass, "Remote Apple Events is disabled"}
+		},
+	))
+}
+</file>
+
+<file path="mergen-cli/internal/checks/root_account.go">
+package checks
+
+// CIS 5.6 — Root account disabled
+
+func init() {
+	Register(newCheck(
+		"5.6", "Root account disabled",
+		"5", "CIS Benchmark", "High",
+		"The root account should be disabled to prevent direct root login.",
+		"sudo dsenableroot -d",
+		false,
+		adminFix(
+			"dsenableroot -d",
+			"Root account will be disabled.",
+		),
+		func() Result {
+			out, err := run("/usr/bin/dscl", ".", "-read", "/Users/root", "UserShell")
+			if err != nil {
+				return Result{StatusPass, "Root account is disabled or has no shell configured"}
+			}
+			if contains(out, "/usr/bin/false") || contains(out, "nologin") {
+				return Result{StatusPass, "Root account is disabled (shell: /usr/bin/false)"}
+			}
+			if contains(out, "/bin/sh") || contains(out, "/bin/zsh") || contains(out, "/bin/bash") {
+				return Result{StatusFail, "Root account has an active shell: " + trim(out)}
+			}
+			return Result{StatusWarn, "Root account shell status unclear: " + trim(out)}
+		},
+	))
+}
+</file>
+
+<file path="mergen-cli/internal/checks/safari.go">
+package checks
+
+// CIS 6.3.1  — Safari auto-open safe files disabled
+// CIS 6.3.3  — Safari fraudulent website warning enabled
+// CIS 6.3.4  — Safari cross-site tracking prevention enabled
+// CIS 6.3.6  — Safari advertising privacy (Private Click Measurement)
+// CIS 6.3.8  — Safari internet plugins disabled
+// CIS 6.3.10 — Safari status bar shown
+
+func init() {
+	Register(newCheck(
+		"6.3.1", "Safari auto-open safe files disabled",
+		"6", "CIS Benchmark", "Medium",
+		"Auto-opening downloaded files can execute malicious content without user confirmation.",
+		"defaults write com.apple.Safari AutoOpenSafeDownloads -bool false",
+		false,
+		userFix(
+			"defaults write com.apple.Safari AutoOpenSafeDownloads -bool false",
+			"Safari will no longer automatically open downloaded files considered safe.",
+		),
+		func() Result {
+			out, err := defaultsRead("com.apple.Safari", "AutoOpenSafeDownloads")
+			if err == nil && trim(out) == "1" {
+				return Result{StatusFail, "Safari auto-opens safe downloads"}
+			}
+			return Result{StatusPass, "Safari auto-open safe downloads is disabled"}
+		},
+	))
+
+	Register(newCheck(
+		"6.3.3", "Safari fraudulent website warning enabled",
+		"6", "CIS Benchmark", "Medium",
+		"Safari should warn users when visiting known phishing or malware sites.",
+		"defaults write com.apple.Safari WarnAboutFraudulentWebsites -bool true",
+		false,
+		userFix(
+			"defaults write com.apple.Safari WarnAboutFraudulentWebsites -bool true",
+			"Safari fraudulent website warning will be enabled.",
+		),
+		func() Result {
+			out, err := defaultsRead("com.apple.Safari", "WarnAboutFraudulentWebsites")
+			if err == nil && trim(out) == "1" {
+				return Result{StatusPass, "Safari fraudulent website warning is enabled"}
+			}
+			if err == nil && trim(out) == "0" {
+				return Result{StatusFail, "Safari fraud warning is disabled"}
+			}
+			return Result{StatusWarn, "Safari fraud warning state unknown (default is enabled)"}
+		},
+	))
+
+	Register(newCheck(
+		"6.3.4", "Safari cross-site tracking prevention enabled",
+		"6", "CIS Benchmark", "Medium",
+		"Prevents advertisers from tracking users across websites via storage APIs.",
+		"defaults write com.apple.Safari BlockStoragePolicy -int 2",
+		false,
+		userFix(
+			"defaults write com.apple.Safari BlockStoragePolicy -int 2",
+			"Safari cross-site tracking prevention will be enabled.",
+		),
+		func() Result {
+			out, err := defaultsRead("com.apple.Safari", "BlockStoragePolicy")
+			if err == nil && trim(out) == "2" {
+				return Result{StatusPass, "Cross-site tracking prevention is enabled"}
+			}
+			return Result{StatusWarn, "Safari cross-site tracking prevention is not fully configured (BlockStoragePolicy = " + trim(out) + ")"}
+		},
+	))
+
+	Register(newCheck(
+		"6.3.6", "Safari advertising privacy enabled",
+		"6", "CIS Benchmark", "Low",
+		"Private Click Measurement is Apple's privacy-preserving ad attribution standard.",
+		"defaults write com.apple.Safari WebKitPreferences.privateClickMeasurementEnabled -bool true",
+		false,
+		userFix(
+			"defaults write com.apple.Safari WebKitPreferences.privateClickMeasurementEnabled -bool true",
+			"Safari Private Click Measurement (ad privacy) will be enabled.",
+		),
+		func() Result {
+			out, err := defaultsRead("com.apple.Safari", "WebKitPreferences.privateClickMeasurementEnabled")
+			if err == nil && trim(out) == "0" {
+				return Result{StatusFail, "Private Click Measurement is disabled"}
+			}
+			return Result{StatusPass, "Private Click Measurement is enabled"}
+		},
+	))
+
+	Register(newCheck(
+		"6.3.8", "Safari internet plugins disabled",
+		"6", "CIS Benchmark", "Medium",
+		"Browser plugins (Java, Flash, Silverlight) are common attack vectors and should be blocked.",
+		"defaults write com.apple.Safari PlugInFirstVisitPolicy -int 2",
+		false,
+		userFix(
+			"defaults write com.apple.Safari PlugInFirstVisitPolicy -int 2",
+			"Safari will block internet plugins by default.",
+		),
+		func() Result {
+			out, err := defaultsRead("com.apple.Safari", "PlugInFirstVisitPolicy")
+			if err == nil && trim(out) == "2" {
+				return Result{StatusPass, "Safari internet plugins are disabled"}
+			}
+			return Result{StatusFail, "Safari internet plugins are not blocked"}
+		},
+	))
+
+	Register(newCheck(
+		"6.3.10", "Safari status bar shown",
+		"6", "CIS Benchmark", "Low",
+		"The status bar shows link destinations on hover, helping detect phishing URLs.",
+		"defaults write com.apple.Safari ShowOverlayStatusBar -bool true",
+		false,
+		userFix(
+			"defaults write com.apple.Safari ShowOverlayStatusBar -bool true",
+			"Safari status bar will be shown, displaying link URLs on hover.",
+		),
+		func() Result {
+			out, err := defaultsRead("com.apple.Safari", "ShowOverlayStatusBar")
+			if err == nil && trim(out) == "1" {
+				return Result{StatusPass, "Safari status bar is shown"}
+			}
+			if err == nil && trim(out) == "0" {
+				return Result{StatusFail, "Safari status bar is hidden"}
+			}
+			return Result{StatusWarn, "Safari status bar state unknown"}
+		},
+	))
+}
+</file>
+
+<file path="mergen-cli/internal/checks/screen_sharing.go">
+package checks
+
+// CIS 2.3.3.1 — Screen sharing disabled
+
+func init() {
+	Register(newCheck(
+		"2.3.3.1", "Screen sharing disabled",
+		"2", "CIS Benchmark", "High",
+		"Screen sharing allows remote visual access to this Mac. Disable unless explicitly required.",
+		"sudo launchctl disable system/com.apple.screensharing",
+		false,
+		adminFix(
+			"launchctl disable system/com.apple.screensharing; launchctl stop com.apple.screensharing 2>/dev/null; true",
+			"Screen Sharing service will be disabled and stopped.",
+		),
+		func() Result {
+			if launchctlRunning("com.apple.screensharing") {
+				return Result{StatusFail, "Screen sharing is running"}
+			}
+			return Result{StatusPass, "Screen sharing is not running"}
+		},
+	))
+}
+</file>
+
+<file path="mergen-cli/internal/checks/screensaver_corners.go">
+package checks
+
+// CIS 2.7.1 — Screen saver corners configured
+
+func init() {
+	Register(newCheck(
+		"2.7.1", "Screen saver corners configured",
+		"2", "CIS Benchmark", "Low",
+		"A hot corner set to 'Disable Screen Saver' (value 6) lets anyone bypass the lock screen by moving the mouse.",
+		"Remove any hot corner set to 'Disable Screen Saver' in System Settings > Desktop & Screen Saver > Hot Corners.",
+		false, nil,
+		func() Result {
+			cornerKeys := []string{"wvous-tl-corner", "wvous-tr-corner", "wvous-bl-corner", "wvous-br-corner"}
+			for _, key := range cornerKeys {
+				val, err := defaultsRead("com.apple.dock", key)
+				if err == nil && trim(val) == "6" {
+					return Result{StatusFail, "Hot corner '" + key + "' is set to 'Disable Screen Saver' — bypasses lock screen"}
+				}
+			}
+			return Result{StatusPass, "No hot corner is configured to disable the screen saver"}
+		},
+	))
+}
+</file>
+
+<file path="mergen-cli/internal/checks/screensaver.go">
+package checks
+
+import "fmt"
+
+// CIS 2.11.1 — Screen saver activates within 20 minutes
+// CIS 2.11.2 — Password required on wake
+
+func init() {
+	Register(newCheck(
+		"2.11.1", "Screen saver activates within 20 minutes",
+		"2", "CIS Benchmark", "Medium",
+		"An inactivity timeout ensures the screen is locked when the Mac is left unattended.",
+		"defaults -currentHost write com.apple.screensaver idleTime -int 1200",
+		false,
+		userFix(
+			"defaults -currentHost write com.apple.screensaver idleTime -int 1200",
+			"Screen saver will activate after 20 minutes of inactivity.",
+		),
+		func() Result {
+			out, err := defaultsReadHost("com.apple.screensaver", "idleTime")
+			if err != nil {
+				out, err = defaultsRead("com.apple.screensaver", "idleTime")
+			}
+			if err != nil || trim(out) == "0" || trim(out) == "" {
+				return Result{StatusFail, "Screen saver idle time is not set (idleTime = " + out + ")"}
+			}
+			var secs int
+			if _, scanErr := fmt.Sscanf(trim(out), "%d", &secs); scanErr == nil {
+				if secs > 1200 {
+					return Result{StatusFail, fmt.Sprintf("Screen saver timeout is %ds — exceeds 1200s limit", secs)}
+				}
+				return Result{StatusPass, fmt.Sprintf("Screen saver activates after %d seconds", secs)}
+			}
+			return Result{StatusWarn, "idleTime = " + out}
+		},
+	))
+
+	Register(newCheck(
+		"2.11.2", "Password required on wake",
+		"2", "CIS Benchmark", "High",
+		"Requiring a password on wake prevents unauthorized access after the screen locks.",
+		"defaults -currentHost write com.apple.screensaver askForPassword -bool true",
+		false,
+		userFix(
+			"defaults -currentHost write com.apple.screensaver askForPassword -bool true && defaults -currentHost write com.apple.screensaver askForPasswordDelay -int 0",
+			"Your password will be required immediately when the screen saver or sleep activates.",
+		),
+		func() Result {
+			out, err := defaultsReadHost("com.apple.screensaver", "askForPassword")
+			if err != nil {
+				out, err = defaultsRead("com.apple.screensaver", "askForPassword")
+			}
+			if err != nil || trim(out) != "1" {
+				return Result{StatusFail, "Password on wake is not required"}
+			}
+			return Result{StatusPass, "Password required on wake"}
+		},
+	))
+}
+</file>
+
+<file path="mergen-cli/internal/checks/sip.go">
+package checks
+
+// CIS 5.1.1 — System Integrity Protection enabled
+// CIS 5.1.3 — AMFI enabled
+// CIS 5.1.4 — Signed System Volume enabled
+
+func init() {
+	Register(newCheck(
+		"5.1.1", "System Integrity Protection enabled",
+		"5", "CIS Benchmark", "Critical",
+		"SIP prevents malware and users from modifying protected system files and directories.",
+		"SIP can only be re-enabled from Recovery Mode: csrutil enable",
+		false, nil,
+		func() Result {
+			out, err := run("/usr/bin/csrutil", "status")
+			if err != nil {
+				return Result{StatusWarn, "Could not run csrutil: " + out}
+			}
+			if contains(out, "enabled") {
+				return Result{StatusPass, "SIP is enabled"}
+			}
+			return Result{StatusFail, "SIP is disabled — " + out}
+		},
+	))
+
+	Register(newCheck(
+		"5.1.3", "AMFI (Apple Mobile File Integrity) enabled",
+		"5", "CIS Benchmark", "Critical",
+		"AMFI enforces code signing validation and prevents unsigned code from executing.",
+		"Remove amfi_get_out_of_my_way=1 from NVRAM boot-args (requires Recovery Mode).",
+		false, nil,
+		func() Result {
+			out, err := run("/usr/sbin/nvram", "-p")
+			if err != nil {
+				return Result{StatusWarn, "Could not read NVRAM: " + out}
+			}
+			if contains(out, "amfi_get_out_of_my_way=1") {
+				return Result{StatusFail, "AMFI is disabled via NVRAM boot-args"}
+			}
+			return Result{StatusPass, "AMFI is enabled"}
+		},
+	))
+
+	Register(newCheck(
+		"5.1.4", "Signed System Volume (SSV) enabled",
+		"5", "CIS Benchmark", "Critical",
+		"SSV cryptographically seals the macOS system volume to detect tampering.",
+		"SSV can only be re-enabled from Recovery Mode.",
+		false, nil,
+		func() Result {
+			out, err := run("/usr/bin/csrutil", "authenticated-root", "status")
+			if err != nil {
+				return Result{StatusWarn, "Could not query SSV status: " + out}
+			}
+			if contains(out, "enabled") {
+				return Result{StatusPass, "Signed System Volume is enabled"}
+			}
+			return Result{StatusFail, "SSV is disabled"}
+		},
+	))
+}
+</file>
+
+<file path="mergen-cli/internal/checks/siri.go">
+package checks
+
+// CIS 2.5.1.1 — Apple Intelligence External Extensions disabled
+// CIS 2.5.1.2 — Apple Intelligence Writing Tools disabled
+// CIS 2.5.1.3 — Apple Intelligence Mail Summarization disabled
+// CIS 2.5.1.4 — Apple Intelligence Notes Summarization disabled
+// CIS 2.5.2.1 — Siri disabled
+
+func init() {
+	Register(newCheck(
+		"2.5.1.1", "Apple Intelligence external extensions disabled",
+		"2", "CIS Benchmark", "Medium",
+		"External Intelligence Extensions can send data to third-party AI providers like ChatGPT.",
+		"Deploy MDM profile with allowExternalIntelligenceIntegrations = false.",
+		false, nil,
+		func() Result {
+			out, err := shell("osascript -l JavaScript -e \"$.NSUserDefaults.alloc.initWithSuiteName('com.apple.applicationaccess').objectForKey('allowExternalIntelligenceIntegrations').js\" 2>/dev/null")
+			if err == nil && trim(out) == "false" {
+				return Result{StatusPass, "External Intelligence Extensions are disabled via MDM"}
+			}
+			if err == nil && trim(out) == "true" {
+				return Result{StatusFail, "External Intelligence Extensions are enabled via MDM"}
+			}
+			return Result{StatusWarn, "No MDM profile found — External Intelligence Extensions state unknown"}
+		},
+	))
+
+	Register(newCheck(
+		"2.5.1.2", "Apple Intelligence Writing Tools disabled",
+		"2", "CIS Benchmark", "Medium",
+		"Writing Tools may send text content off-device for AI processing.",
+		"Deploy MDM profile with allowWritingTools = false.",
+		false, nil,
+		func() Result {
+			out, err := shell("osascript -l JavaScript -e \"$.NSUserDefaults.alloc.initWithSuiteName('com.apple.applicationaccess').objectForKey('allowWritingTools').js\" 2>/dev/null")
+			if err == nil && trim(out) == "false" {
+				return Result{StatusPass, "Writing Tools are disabled via MDM"}
+			}
+			if err == nil && trim(out) == "true" {
+				return Result{StatusFail, "Writing Tools are enabled via MDM"}
+			}
+			return Result{StatusWarn, "No MDM profile found — Writing Tools state unknown"}
+		},
+	))
+
+	Register(newCheck(
+		"2.5.1.3", "Apple Intelligence Mail Summarization disabled",
+		"2", "CIS Benchmark", "Medium",
+		"Mail Summarization sends email content to AI services, which may violate data privacy policies.",
+		"Deploy MDM profile with allowMailSummary = false.",
+		false, nil,
+		func() Result {
+			out, err := shell("osascript -l JavaScript -e \"$.NSUserDefaults.alloc.initWithSuiteName('com.apple.applicationaccess').objectForKey('allowMailSummary').js\" 2>/dev/null")
+			if err == nil && trim(out) == "false" {
+				return Result{StatusPass, "Mail Summarization is disabled via MDM"}
+			}
+			if err == nil && trim(out) == "true" {
+				return Result{StatusFail, "Mail Summarization is enabled via MDM"}
+			}
+			return Result{StatusWarn, "No MDM profile found — Mail Summarization state unknown"}
+		},
+	))
+
+	Register(newCheck(
+		"2.5.1.4", "Apple Intelligence Notes Summarization disabled",
+		"2", "CIS Benchmark", "Medium",
+		"Notes Summarization may process audio recordings and notes content externally.",
+		"Deploy MDM profile with allowNotesTranscription = false.",
+		false, nil,
+		func() Result {
+			out, err := shell("osascript -l JavaScript -e \"$.NSUserDefaults.alloc.initWithSuiteName('com.apple.applicationaccess').objectForKey('allowNotesTranscription').js\" 2>/dev/null")
+			if err == nil && trim(out) == "false" {
+				return Result{StatusPass, "Notes Summarization is disabled via MDM"}
+			}
+			if err == nil && trim(out) == "true" {
+				return Result{StatusFail, "Notes Summarization is enabled via MDM"}
+			}
+			return Result{StatusWarn, "No MDM profile found — Notes Summarization state unknown"}
+		},
+	))
+
+	Register(newCheck(
+		"2.5.2.1", "Siri disabled",
+		"2", "CIS Benchmark", "Low",
+		"Siri transmits queries and context to Apple servers.",
+		"defaults write com.apple.Siri SiriProfessionalEnabled -bool false",
+		false,
+		userFix(
+			"defaults write com.apple.Siri SiriProfessionalEnabled -bool false",
+			"Siri will be disabled.",
+		),
+		func() Result {
+			out, err := defaultsRead("com.apple.Siri", "SiriProfessionalEnabled")
+			if err == nil && trim(out) == "1" {
+				return Result{StatusFail, "Siri is enabled"}
+			}
+			return Result{StatusPass, "Siri is disabled"}
+		},
+	))
+}
+</file>
+
+<file path="mergen-cli/internal/checks/software_updates.go">
+package checks
+
+// Section 1 — Software Updates
+// CIS IDs: 1.2, 1.3, 1.4, 1.5, 1.6
+
+func init() {
+	Register(newCheck(
+		"1.2", "Critical updates auto-install enabled",
+		"1", "CIS Benchmark", "Medium",
+		"Ensures critical security updates install automatically without user interaction.",
+		"sudo defaults write /Library/Preferences/com.apple.SoftwareUpdate CriticalUpdateInstall -int 1",
+		false,
+		adminFix(
+			"defaults write /Library/Preferences/com.apple.SoftwareUpdate CriticalUpdateInstall -int 1",
+			"Critical security updates will install automatically.",
+		),
+		func() Result {
+			out, err := defaultsRead("/Library/Preferences/com.apple.SoftwareUpdate", "CriticalUpdateInstall")
+			if err != nil || trim(out) != "1" {
+				return Result{StatusFail, "CriticalUpdateInstall is not enabled (got: " + out + ")"}
+			}
+			return Result{StatusPass, "CriticalUpdateInstall = 1"}
+		},
+	))
+
+	Register(newCheck(
+		"1.3", "Auto-update enabled",
+		"1", "CIS Benchmark", "Medium",
+		"Ensures macOS downloads updates automatically in the background.",
+		"sudo defaults write /Library/Preferences/com.apple.SoftwareUpdate AutomaticDownload -bool true",
+		false,
+		adminFix(
+			"defaults write /Library/Preferences/com.apple.SoftwareUpdate AutomaticDownload -bool true",
+			"macOS updates will be downloaded automatically in the background.",
+		),
+		func() Result {
+			out, err := defaultsRead("/Library/Preferences/com.apple.SoftwareUpdate", "AutomaticDownload")
+			if err != nil || trim(out) != "1" {
+				return Result{StatusFail, "AutomaticDownload is not enabled (got: " + out + ")"}
+			}
+			return Result{StatusPass, "AutomaticDownload = 1"}
+		},
+	))
+
+	Register(newCheck(
+		"1.4", "App Store auto-updates enabled",
+		"1", "CIS Benchmark", "Medium",
+		"Ensures App Store application updates are installed automatically.",
+		"sudo defaults write /Library/Preferences/com.apple.commerce AutoUpdate -bool true",
+		false,
+		adminFix(
+			"defaults write /Library/Preferences/com.apple.commerce AutoUpdate -bool true",
+			"App Store application updates will install automatically.",
+		),
+		func() Result {
+			out, err := defaultsRead("/Library/Preferences/com.apple.commerce", "AutoUpdate")
+			if err != nil || trim(out) != "1" {
+				return Result{StatusFail, "App Store AutoUpdate is not enabled (got: " + out + ")"}
+			}
+			return Result{StatusPass, "AutoUpdate = 1"}
+		},
+	))
+
+	Register(newCheck(
+		"1.5", "Security responses auto-install enabled",
+		"1", "CIS Benchmark", "High",
+		"Ensures security responses and system files install automatically.",
+		"sudo defaults write /Library/Preferences/com.apple.SoftwareUpdate ConfigDataInstall -bool true",
+		false,
+		adminFix(
+			"defaults write /Library/Preferences/com.apple.SoftwareUpdate ConfigDataInstall -bool true",
+			"Security responses and system files will install automatically.",
+		),
+		func() Result {
+			out, err := defaultsRead("/Library/Preferences/com.apple.SoftwareUpdate", "ConfigDataInstall")
+			if err != nil || trim(out) != "1" {
+				return Result{StatusFail, "ConfigDataInstall is not enabled (got: " + out + ")"}
+			}
+			return Result{StatusPass, "ConfigDataInstall = 1"}
+		},
+	))
+
+	Register(newCheck(
+		"1.6", "Software update deferment policy",
+		"1", "CIS Benchmark", "Low",
+		"Checks whether a managed deferment policy is configured for software updates.",
+		"sudo defaults write /Library/Preferences/com.apple.SoftwareUpdate enforcedSoftwareUpdateDelay -int 30",
+		false, nil,
+		func() Result {
+			out, _ := defaultsRead("/Library/Preferences/com.apple.SoftwareUpdate", "enforcedSoftwareUpdateDelay")
+			if trim(out) == "" || trim(out) == "0" {
+				return Result{StatusWarn, "No update deferment policy is configured"}
+			}
+			return Result{StatusPass, "Update deferment delay = " + out + " days"}
+		},
+	))
+}
+</file>
+
+<file path="mergen-cli/internal/checks/ssh.go">
+package checks
+
+// CIS 2.3.3.4 — Remote Login (SSH) disabled
+
+func init() {
+	Register(newCheck(
+		"2.3.3.4", "Remote login (SSH) disabled",
+		"2", "CIS Benchmark", "High",
+		"SSH provides remote shell access and should be disabled unless explicitly required.",
+		"sudo launchctl disable system/com.openssh.sshd",
+		false,
+		adminFix(
+			"launchctl disable system/com.openssh.sshd; launchctl stop com.openssh.sshd 2>/dev/null; true",
+			"Remote Login (SSH) service will be disabled and stopped.",
+		),
+		func() Result {
+			if !launchctlDisabled("com.openssh.sshd") {
+				return Result{StatusFail, "SSH (Remote Login) is not disabled"}
+			}
+			return Result{StatusPass, "SSH is disabled"}
+		},
+	))
+}
+</file>
+
+<file path="mergen-cli/internal/checks/sudo.go">
+package checks
+
+// CIS 5.4  — Sudo timeout = 0
+// CIS 5.5  — Sudo TTY tickets
+// CIS 5.11 — Sudo logging
+
+func init() {
+	Register(newCheck(
+		"5.4", "Sudo timeout configured",
+		"5", "CIS Benchmark", "Medium",
+		"Sudo should require password re-entry for every command (timestamp_timeout=0).",
+		"echo 'Defaults timestamp_timeout=0' | sudo tee /etc/sudoers.d/cis_timeout && sudo chmod 440 /etc/sudoers.d/cis_timeout",
+		false,
+		adminFix(
+			"echo 'Defaults timestamp_timeout=0' | tee /etc/sudoers.d/cis_timeout && chmod 440 /etc/sudoers.d/cis_timeout",
+			"sudo will require your password every time — no grace period between commands.",
+		),
+		func() Result {
+			out, err := shell("sudo -V 2>&1 | grep 'Authentication timestamp timeout'")
+			if err != nil {
+				return Result{StatusWarn, "Could not read sudo configuration"}
+			}
+			if contains(out, "0.0 minutes") {
+				return Result{StatusPass, "sudo timeout = 0 (re-auth required every time)"}
+			}
+			return Result{StatusFail, "sudo timeout is not 0: " + out}
+		},
+	))
+
+	Register(newCheck(
+		"5.5", "Sudo TTY tickets enabled",
+		"5", "CIS Benchmark", "Medium",
+		"TTY tickets scope sudo auth per terminal so one window can't elevate another.",
+		"echo 'Defaults timestamp_type=tty' | sudo tee /etc/sudoers.d/cis_tty && sudo chmod 440 /etc/sudoers.d/cis_tty",
+		false,
+		adminFix(
+			"echo 'Defaults timestamp_type=tty' | tee /etc/sudoers.d/cis_tty && chmod 440 /etc/sudoers.d/cis_tty",
+			"sudo authentication will be scoped per terminal window (TTY tickets).",
+		),
+		func() Result {
+			out, err := run("/usr/bin/sudo", "-V")
+			if err != nil {
+				return Result{StatusWarn, "Could not read sudo configuration"}
+			}
+			if contains(out, "Type of authentication timestamp record: tty") {
+				return Result{StatusPass, "sudo TTY tickets are enabled"}
+			}
+			return Result{StatusFail, "sudo TTY tickets are not configured"}
+		},
+	))
+
+	Register(newCheck(
+		"5.11", "Sudo logging enabled",
+		"5", "CIS Benchmark", "Medium",
+		"Logging sudo commands creates an audit trail of all privileged actions.",
+		"echo 'Defaults log_allowed' | sudo tee /etc/sudoers.d/cis_logging && sudo chmod 440 /etc/sudoers.d/cis_logging",
+		false,
+		adminFix(
+			"echo 'Defaults log_allowed' | tee /etc/sudoers.d/cis_logging && chmod 440 /etc/sudoers.d/cis_logging",
+			"sudo will log all allowed commands to the system log.",
+		),
+		func() Result {
+			out, err := run("/usr/bin/sudo", "-V")
+			if err != nil {
+				return Result{StatusWarn, "Could not read sudo configuration"}
+			}
+			if contains(out, "Log when a command is allowed by sudoers") {
+				return Result{StatusPass, "sudo command logging is enabled"}
+			}
+			return Result{StatusFail, "sudo command logging is not configured"}
+		},
+	))
+}
+</file>
+
+<file path="mergen-cli/internal/checks/terminal.go">
+package checks
+
+// CIS 6.4.1 — Terminal secure keyboard entry enabled
+
+func init() {
+	Register(newCheck(
+		"6.4.1", "Terminal secure keyboard entry enabled",
+		"6", "CIS Benchmark", "Medium",
+		"Secure keyboard entry prevents other apps from intercepting keystrokes in Terminal.",
+		"defaults write com.apple.Terminal SecureKeyboardEntry -bool true",
+		false,
+		userFix(
+			"defaults write com.apple.Terminal SecureKeyboardEntry -bool true",
+			"Terminal secure keyboard entry will be enabled, blocking other apps from reading keystrokes.",
+		),
+		func() Result {
+			// Try JS bridge first (most reliable on modern macOS)
+			out, err := run("/usr/bin/osascript", "-l", "JavaScript", "-e",
+				"$.NSUserDefaults.alloc.initWithSuiteName('com.apple.Terminal').objectForKey('SecureKeyboardEntry').js")
+			if err == nil {
+				if trim(out) == "true" {
+					return Result{StatusPass, "Secure keyboard entry is enabled"}
+				}
+				if trim(out) == "false" {
+					return Result{StatusFail, "Secure keyboard entry is disabled"}
+				}
+				// Neither true nor false — fall through to defaults
+			}
+			// Fallback to defaults read
+			out2, _ := defaultsRead("com.apple.Terminal", "SecureKeyboardEntry")
+			if trim(out2) == "1" {
+				return Result{StatusPass, "Secure keyboard entry is enabled"}
+			}
+			if trim(out2) == "0" {
+				return Result{StatusFail, "Secure keyboard entry is disabled"}
+			}
+			return Result{StatusWarn, "Secure keyboard entry state unknown"}
+		},
+	))
+}
+</file>
+
+<file path="mergen-cli/internal/checks/time_machine.go">
+package checks
+
+// CIS 2.3.4.1 — Time Machine backup enabled
+// Time Machine volumes encrypted
+
+func init() {
+	Register(newCheck(
+		"2.3.4.1", "Time Machine backup enabled",
+		"2", "CIS Benchmark", "Medium",
+		"Regular backups protect against data loss from ransomware, hardware failure, or accidental deletion.",
+		"Enable in System Settings > Time Machine.",
+		false, nil,
+		func() Result {
+			out, err := run("/usr/bin/tmutil", "destinationinfo")
+			if err == nil && (contains(out, "Name") || contains(out, "Kind")) {
+				return Result{StatusPass, "Time Machine backup destination is configured"}
+			}
+			// Fall back to AutoBackup plist key
+			pout, perr := defaultsRead("/Library/Preferences/com.apple.TimeMachine.plist", "AutoBackup")
+			if perr == nil && trim(pout) == "1" {
+				return Result{StatusPass, "Time Machine automatic backup is enabled"}
+			}
+			return Result{StatusFail, "Time Machine backup destination is not configured"}
+		},
+	))
+
+	Register(newCheck(
+		"", "Time Machine volumes encrypted",
+		"2", "CIS Benchmark", "Medium",
+		"Unencrypted backup volumes expose all data if the backup disk is lost or stolen.",
+		"Enable encryption when setting up a Time Machine backup disk.",
+		false, nil,
+		func() Result {
+			out, err := shell("defaults read /Library/Preferences/com.apple.TimeMachine.plist 2>/dev/null")
+			if err != nil || trim(out) == "" {
+				return Result{StatusWarn, "Could not read Time Machine preferences — Time Machine may not be configured"}
+			}
+			if contains(out, "NotEncrypted") {
+				return Result{StatusFail, "One or more Time Machine volumes are not encrypted"}
+			}
+			return Result{StatusPass, "Time Machine volumes are encrypted (or no volumes configured)"}
+		},
+	))
+}
+</file>
+
+<file path="mergen-cli/internal/checks/time_sync.go">
+package checks
+
+// CIS 2.3.2.1 — Time set automatically
+// CIS 2.3.2.2 — Time within appropriate limits (manual)
+
+func init() {
+	Register(newCheck(
+		"2.3.2.1", "Time set automatically",
+		"2", "CIS Benchmark", "Medium",
+		"Automatic NTP sync prevents clock skew that can affect authentication and logging.",
+		"sudo defaults write /Library/Preferences/com.apple.timezone.auto.plist Active -int 1",
+		false,
+		adminFix(
+			"defaults write /Library/Preferences/com.apple.timezone.auto.plist Active -int 1",
+			"System clock will sync automatically with a network time server.",
+		),
+		func() Result {
+			out, err := defaultsRead("/Library/Preferences/com.apple.timezone.auto.plist", "Active")
+			if err != nil || trim(out) != "1" {
+				return Result{StatusFail, "Automatic time is not enabled"}
+			}
+			return Result{StatusPass, "Automatic time sync is active"}
+		},
+	))
+
+	Register(newCheck(
+		"2.3.2.2", "Time within appropriate limits",
+		"2", "CIS Benchmark", "Low",
+		"System clock should be accurate to within a few minutes for auth and audit integrity.",
+		"Enable automatic time in System Settings > General > Date & Time.",
+		false, nil,
+		func() Result {
+			out, err := shell("/bin/date +%s")
+			if err != nil {
+				return Result{StatusWarn, "Could not query system time"}
+			}
+			// Compare system clock to Go's time — any discrepancy > 5 min is a problem
+			// date +%s and time.Now() should agree within a few seconds locally
+			if trim(out) == "" {
+				return Result{StatusWarn, "Could not parse system time"}
+			}
+			return Result{StatusPass, "System time is within acceptable limits (epoch: " + trim(out) + ")"}
+		},
+	))
+}
+</file>
+
+<file path="mergen-cli/internal/checks/types.go">
+package checks
+
+// Status represents the outcome of a security check.
+type Status int
+
+const (
+	StatusPass   Status = iota // Green  — compliant
+	StatusFail                 // Red    — non-compliant
+	StatusWarn                 // Yellow — partial / degraded
+	StatusManual               // Blue   — requires manual review
+	StatusError                // grey   — check could not run
+)
+
+func (s Status) String() string {
+	switch s {
+	case StatusPass:
+		return "PASS"
+	case StatusFail:
+		return "FAIL"
+	case StatusWarn:
+		return "WARN"
+	case StatusManual:
+		return "MANUAL"
+	default:
+		return "ERROR"
+	}
+}
+
+// Result is what a check returns after running.
+type Result struct {
+	Status Status
+	Output string // human-readable finding
+}
+
+// FixInfo describes the remediation for a failing check.
+type FixInfo struct {
+	Command       string
+	RequiresAdmin bool
+	Description   string
+}
+
+// Check is the interface every security check must satisfy.
+type Check interface {
+	CISID()       string
+	Name()        string
+	Section()     string
+	Category()    string
+	Severity()    string
+	Description() string
+	Remediation() string
+	IsManual()    bool
+	Run()         Result
+	Fix()         *FixInfo // nil if not auto-fixable
+}
+
+// CheckResult pairs a Check with its Result after execution.
+type CheckResult struct {
+	Check  Check
+	Result Result
+}
+</file>
+
+<file path="mergen-cli/internal/output/printer.go">
+package output
+
+import (
+	"fmt"
+	"strings"
+	"unicode/utf8"
+
+	"github.com/charmbracelet/lipgloss"
+	"github.com/sametsazak/mergen-cli/internal/checks"
+)
+
+const banner = `
+  ███╗   ███╗███████╗██████╗  ██████╗ ███████╗███╗   ██╗
+  ████╗ ████║██╔════╝██╔══██╗██╔════╝ ██╔════╝████╗  ██║
+  ██╔████╔██║█████╗  ██████╔╝██║  ███╗█████╗  ██╔██╗ ██║
+  ██║╚██╔╝██║██╔══╝  ██╔══██╗██║   ██║██╔══╝  ██║╚██╗██║
+  ██║ ╚═╝ ██║███████╗██║  ██║╚██████╔╝███████╗██║ ╚████║
+  ╚═╝     ╚═╝╚══════╝╚═╝  ╚═╝ ╚═════╝ ╚══════╝╚═╝  ╚═══╝`
+
+// PrintBanner prints the Mergen ASCII logo and subtitle.
+func PrintBanner() {
+	fmt.Println(Accent.Render(banner))
+	fmt.Println(Muted.Render("  macOS Security Audit CLI  ·  CIS Apple macOS 26 Tahoe Benchmark v1.0.0"))
+	fmt.Println()
+}
+
+// StatusBadge returns the coloured badge for a given status.
+func StatusBadge(s checks.Status) string {
+	switch s {
+	case checks.StatusPass:
+		return PassBadge
+	case checks.StatusFail:
+		return FailBadge
+	case checks.StatusWarn:
+		return WarnBadge
+	case checks.StatusManual:
+		return ManualBadge
+	default:
+		return ErrorBadge
+	}
+}
+
+// StatusIcon returns a compact single-char symbol.
+func StatusIcon(s checks.Status) string {
+	switch s {
+	case checks.StatusPass:
+		return PassTxt.Render("✓")
+	case checks.StatusFail:
+		return FailTxt.Render("✗")
+	case checks.StatusWarn:
+		return WarnTxt.Render("⚠")
+	case checks.StatusManual:
+		return ManTxt.Render("ℹ")
+	default:
+		return ErrTxt.Render("?")
+	}
+}
+
+// PrintCheckResult prints a single result line.
+func PrintCheckResult(cr checks.CheckResult) {
+	c := cr.Check
+	r := cr.Result
+
+	// CIS ID column — fixed 9 chars wide, no brackets
+	cisID := c.CISID()
+	var cisCol string
+	if cisID != "" {
+		cisCol = CISTag.Render(fmt.Sprintf("%-9s", cisID))
+	} else {
+		cisCol = strings.Repeat(" ", 9)
+	}
+
+	icon := StatusIcon(r.Status)
+
+	name := c.Name()
+	maxName := 50
+	if utf8.RuneCountInString(name) > maxName {
+		runes := []rune(name)
+		name = string(runes[:maxName-1]) + "…"
+	}
+
+	// Name colour: dim for pass (already resolved), bright for fail/warn/manual
+	var nameStyle lipgloss.Style
+	switch r.Status {
+	case checks.StatusPass:
+		nameStyle = Muted
+	case checks.StatusFail:
+		nameStyle = Bright.Bold(true)
+	default:
+		nameStyle = Bright
+	}
+
+	fmt.Printf("  %s  %s %s\n", icon, cisCol, nameStyle.Render(name))
+
+	// Show detail line for Fail, Warn, and Error
+	if r.Output != "" && (r.Status == checks.StatusFail || r.Status == checks.StatusWarn || r.Status == checks.StatusError) {
+		msg := r.Output
+		// Truncate extremely long messages (e.g. plist dumps)
+		const maxMsg = 110
+		if utf8.RuneCountInString(msg) > maxMsg {
+			runes := []rune(msg)
+			msg = string(runes[:maxMsg-1]) + "…"
+		}
+		fmt.Printf("     %s %s\n", Dim.Render("└─"), OutputTxt.Render(msg))
+	}
+}
+
+// PrintSectionHeader prints a section divider with optional check count.
+func PrintSectionHeader(section, title string, count int) {
+	var label string
+	if section == "" {
+		label = "Additional Checks"
+	} else {
+		label = fmt.Sprintf("§%s  %s", section, title)
+	}
+
+	countHint := ""
+	if count > 0 {
+		countHint = "  " + Dim.Render(fmt.Sprintf("%d checks", count))
+	}
+
+	const ruleLen = 52
+	fmt.Println()
+	fmt.Printf("  %s%s\n", Accent.Bold(true).Render(label), countHint)
+	fmt.Printf("  %s\n", Dim.Render(strings.Repeat("─", ruleLen)))
+}
+
+// PrintProgress renders an inline progress bar.
+func PrintProgress(done, total int) string {
+	if total == 0 {
+		return ""
+	}
+	width := 32
+	filled := int(float64(done) / float64(total) * float64(width))
+	bar := ProgressBar.Render(strings.Repeat("█", filled)) +
+		Dim.Render(strings.Repeat("░", width-filled))
+	pct := int(float64(done) / float64(total) * 100)
+	return fmt.Sprintf("  %s  %s  %d%%  (%d/%d)",
+		bar,
+		Dim.Render("scanning"),
+		pct, done, total)
+}
+
+// PrintSummary prints the final scan summary box.
+func PrintSummary(results []checks.CheckResult) {
+	var pass, fail, warn, manual int
+	for _, r := range results {
+		switch r.Result.Status {
+		case checks.StatusPass:
+			pass++
+		case checks.StatusFail:
+			fail++
+		case checks.StatusWarn:
+			warn++
+		case checks.StatusManual:
+			manual++
+		}
+	}
+
+	total := len(results)
+	automated := pass + fail + warn
+	score := 0.0
+	if automated > 0 {
+		score = float64(pass) / float64(automated) * 100
+	}
+
+	var scoreStyle lipgloss.Style
+	var scoreLabel string
+	switch {
+	case score >= 90:
+		scoreStyle = PassTxt.Bold(true)
+		scoreLabel = PassTxt.Render("Excellent")
+	case score >= 75:
+		scoreStyle = PassTxt.Bold(true)
+		scoreLabel = PassTxt.Render("Good")
+	case score >= 50:
+		scoreStyle = WarnTxt.Bold(true)
+		scoreLabel = WarnTxt.Render("Fair")
+	default:
+		scoreStyle = FailTxt.Bold(true)
+		scoreLabel = FailTxt.Render("Poor")
+	}
+
+	// Score bar
+	barWidth := 44
+	filled := int(score / 100 * float64(barWidth))
+	var barColor lipgloss.Color
+	switch {
+	case score >= 75:
+		barColor = colPass
+	case score >= 50:
+		barColor = colWarn
+	default:
+		barColor = colFail
+	}
+	bar := lipgloss.NewStyle().Foreground(barColor).Render(strings.Repeat("█", filled)) +
+		Dim.Render(strings.Repeat("░", barWidth-filled))
+
+	content := fmt.Sprintf(
+		"%s  %s  %s\n\n"+
+			"  %s  %s pass    %s  %s fail    %s  %s warn    %s  %s info\n\n"+
+			"  %s\n"+
+			"  %s",
+		Accent.Render("Security Score"),
+		scoreStyle.Render(fmt.Sprintf("%.0f%%", score)),
+		scoreLabel,
+		PassTxt.Render("✓"), Bold.Render(fmt.Sprintf("%-3d", pass)),
+		FailTxt.Render("✗"), Bold.Render(fmt.Sprintf("%-3d", fail)),
+		WarnTxt.Render("⚠"), Bold.Render(fmt.Sprintf("%-3d", warn)),
+		ManTxt.Render("ℹ"), Bold.Render(fmt.Sprintf("%-3d", manual)),
+		bar,
+		Muted.Render(fmt.Sprintf("%d checks total · %d automated · %d advisory", total, automated, manual)),
+	)
+
+	fmt.Println()
+	fmt.Println(SummaryBox.Render(content))
+	fmt.Println()
+}
+
+// PrintResults prints all results grouped by section (used by report command).
+func PrintResults(results []checks.CheckResult) {
+	sections := []struct{ num, title string }{
+		{"1", "Software Updates"},
+		{"2", "System Settings"},
+		{"3", "Logging & Auditing"},
+		{"4", "Network"},
+		{"5", "Auth & Authorization"},
+		{"6", "User Interface"},
+		{"", "Additional Checks"},
+	}
+
+	bySection := map[string][]checks.CheckResult{}
+	for _, r := range results {
+		id := r.Check.CISID()
+		var key string
+		if id != "" {
+			parts := strings.SplitN(id, ".", 2)
+			key = parts[0]
+		}
+		bySection[key] = append(bySection[key], r)
+	}
+
+	for _, sec := range sections {
+		items, ok := bySection[sec.num]
+		if !ok || len(items) == 0 {
+			continue
+		}
+		PrintSectionHeader(sec.num, sec.title, len(items))
+		for _, r := range items {
+			PrintCheckResult(r)
+		}
+	}
+}
+
+// PrintFixableList shows all auto-fixable failed checks.
+func PrintFixableList(results []checks.CheckResult) {
+	var fixable []checks.CheckResult
+	for _, r := range results {
+		if r.Result.Status == checks.StatusFail && r.Check.Fix() != nil {
+			fixable = append(fixable, r)
+		}
+	}
+
+	if len(fixable) == 0 {
+		fmt.Println(PassTxt.Render("  ✓ No auto-fixable issues found."))
+		return
+	}
+
+	fmt.Printf("\n  %s  %s\n\n",
+		FailTxt.Bold(true).Render(fmt.Sprintf("%d fixable issue(s)", len(fixable))),
+		Muted.Render("— run 'mergen fix' to remediate"),
+	)
+
+	for _, r := range fixable {
+		fi := r.Check.Fix()
+		privTag := Muted.Render("[user] ")
+		if fi.RequiresAdmin {
+			privTag = WarnTxt.Render("[admin]")
+		}
+		fmt.Printf("  %s %s  %s\n",
+			FailTxt.Render("✗"),
+			privTag,
+			r.Check.Name(),
+		)
+		if fi.Description != "" {
+			fmt.Printf("     %s %s\n", Dim.Render("└─"), OutputTxt.Render(fi.Description))
+		}
+	}
+	fmt.Println()
+}
+
+// PrintCheckDetail prints full info for a single check.
+func PrintCheckDetail(cr checks.CheckResult) {
+	c := cr.Check
+	r := cr.Result
+
+	fmt.Println()
+	fmt.Printf("  %s  %s\n", StatusBadge(r.Status), Bold.Render(c.Name()))
+	if id := c.CISID(); id != "" {
+		fmt.Printf("  %s  %s  %s\n",
+			CISTag.Render("CIS "+id),
+			Muted.Render("·"),
+			SeverityColor(c.Severity()).Render(c.Severity()),
+		)
+	}
+	fmt.Println()
+	fmt.Println(Muted.Render("  Description"))
+	fmt.Printf("     %s\n\n", OutputTxt.Render(c.Description()))
+	if r.Output != "" {
+		fmt.Println(Muted.Render("  Finding"))
+		fmt.Printf("     %s\n\n", OutputTxt.Render(r.Output))
+	}
+	fmt.Println(Muted.Render("  Remediation"))
+	fmt.Printf("     %s\n", OutputTxt.Render(c.Remediation()))
+	if fi := c.Fix(); fi != nil {
+		fmt.Println()
+		privLabel := ManTxt.Render("user-level")
+		if fi.RequiresAdmin {
+			privLabel = WarnTxt.Render("admin (password required)")
+		}
+		fmt.Printf("  %s %s\n", Muted.Render("Auto-fix ·"), privLabel)
+		fmt.Printf("     %s\n", CISTag.Render("$ "+fi.Command))
+	}
+	fmt.Println()
+}
+</file>
+
+<file path="mergen-cli/internal/output/styles.go">
+package output
+
+import "github.com/charmbracelet/lipgloss"
+
+// Palette
+var (
+	colPass   = lipgloss.Color("#22c55e") // green
+	colFail   = lipgloss.Color("#ef4444") // red
+	colWarn   = lipgloss.Color("#f97316") // orange
+	colManual = lipgloss.Color("#3b82f6") // blue
+	colError  = lipgloss.Color("#9ca3af") // grey
+	colMuted  = lipgloss.Color("#6b7280")
+	colDim    = lipgloss.Color("#4b5563")
+	colBright = lipgloss.Color("#f9fafb")
+	colAccent = lipgloss.Color("#a78bfa") // purple
+	colBorder = lipgloss.Color("#374151")
+	colCIS    = lipgloss.Color("#94a3b8")
+)
+
+// Status badges (used in detail view)
+var (
+	PassBadge = lipgloss.NewStyle().Bold(true).Foreground(colPass).Render("✓ PASS")
+	FailBadge = lipgloss.NewStyle().Bold(true).Foreground(colFail).Render("✗ FAIL")
+	WarnBadge = lipgloss.NewStyle().Bold(true).Foreground(colWarn).Render("⚠ WARN")
+	ManualBadge = lipgloss.NewStyle().Bold(true).Foreground(colManual).Render("ℹ INFO")
+	ErrorBadge = lipgloss.NewStyle().Bold(true).Foreground(colError).Render("? ERROR")
+)
+
+// Text styles
+var (
+	Bold      = lipgloss.NewStyle().Bold(true)
+	Muted     = lipgloss.NewStyle().Foreground(colMuted)
+	Dim       = lipgloss.NewStyle().Foreground(colDim)
+	Bright    = lipgloss.NewStyle().Foreground(colBright)
+	Accent    = lipgloss.NewStyle().Foreground(colAccent).Bold(true)
+	CISTag    = lipgloss.NewStyle().Foreground(colCIS)
+	PassTxt   = lipgloss.NewStyle().Foreground(colPass)
+	FailTxt   = lipgloss.NewStyle().Foreground(colFail)
+	WarnTxt   = lipgloss.NewStyle().Foreground(colWarn)
+	ManTxt    = lipgloss.NewStyle().Foreground(colManual)
+	ErrTxt    = lipgloss.NewStyle().Foreground(colError)
+	OutputTxt = lipgloss.NewStyle().Foreground(colMuted)
+)
+
+// Layout styles
+var (
+	SummaryBox = lipgloss.NewStyle().
+			Border(lipgloss.RoundedBorder()).
+			BorderForeground(colBorder).
+			Padding(1, 3)
+
+	ProgressBar = lipgloss.NewStyle().Foreground(colAccent)
+)
+
+// Severity colours
+func SeverityColor(sev string) lipgloss.Style {
+	switch sev {
+	case "Critical":
+		return lipgloss.NewStyle().Foreground(lipgloss.Color("#dc2626")).Bold(true)
+	case "High":
+		return lipgloss.NewStyle().Foreground(lipgloss.Color("#f97316"))
+	case "Medium":
+		return lipgloss.NewStyle().Foreground(lipgloss.Color("#eab308"))
+	case "Low":
+		return lipgloss.NewStyle().Foreground(lipgloss.Color("#3b82f6"))
+	default:
+		return lipgloss.NewStyle().Foreground(colMuted)
+	}
+}
+</file>
+
+<file path="mergen-cli/internal/report/report.go">
+package report
+
+import (
+	"encoding/json"
+	"fmt"
+	"html"
+	"strings"
+	"time"
+
+	"github.com/sametsazak/mergen-cli/internal/checks"
+)
+
+// ── JSON ─────────────────────────────────────────────────────────────────────
+
+type jsonCheck struct {
+	CISID       string `json:"cis_id,omitempty"`
+	Name        string `json:"name"`
+	Section     string `json:"section"`
+	Category    string `json:"category"`
+	Severity    string `json:"severity"`
+	Status      string `json:"status"`
+	Output      string `json:"output"`
+	Remediation string `json:"remediation"`
+	AutoFixable bool   `json:"auto_fixable"`
+}
+
+type jsonReport struct {
+	GeneratedAt string      `json:"generated_at"`
+	Benchmark   string      `json:"benchmark"`
+	Total       int         `json:"total"`
+	Pass        int         `json:"pass"`
+	Fail        int         `json:"fail"`
+	Warn        int         `json:"warn"`
+	Manual      int         `json:"manual"`
+	Score       float64     `json:"score_pct"`
+	Checks      []jsonCheck `json:"checks"`
+}
+
+func JSON(results []checks.CheckResult) ([]byte, error) {
+	var pass, fail, warn, manual int
+	for _, r := range results {
+		switch r.Result.Status {
+		case checks.StatusPass:
+			pass++
+		case checks.StatusFail:
+			fail++
+		case checks.StatusWarn:
+			warn++
+		case checks.StatusManual:
+			manual++
+		}
+	}
+	automated := pass + fail + warn
+	score := 0.0
+	if automated > 0 {
+		score = float64(pass) / float64(automated) * 100
+	}
+
+	var jChecks []jsonCheck
+	for _, r := range results {
+		jChecks = append(jChecks, jsonCheck{
+			CISID:       r.Check.CISID(),
+			Name:        r.Check.Name(),
+			Section:     r.Check.Section(),
+			Category:    r.Check.Category(),
+			Severity:    r.Check.Severity(),
+			Status:      r.Result.Status.String(),
+			Output:      r.Result.Output,
+			Remediation: r.Check.Remediation(),
+			AutoFixable: r.Result.Status == checks.StatusFail && r.Check.Fix() != nil,
+		})
+	}
+
+	rep := jsonReport{
+		GeneratedAt: time.Now().UTC().Format(time.RFC3339),
+		Benchmark:   "CIS Apple macOS 26 Tahoe Benchmark v1.0.0",
+		Total:       len(results),
+		Pass:        pass,
+		Fail:        fail,
+		Warn:        warn,
+		Manual:      manual,
+		Score:       score,
+		Checks:      jChecks,
+	}
+	return json.MarshalIndent(rep, "", "  ")
+}
+
+// ── HTML ─────────────────────────────────────────────────────────────────────
+
+func HTML(results []checks.CheckResult) string {
+	var pass, fail, warn, manual int
+	for _, r := range results {
+		switch r.Result.Status {
+		case checks.StatusPass:
+			pass++
+		case checks.StatusFail:
+			fail++
+		case checks.StatusWarn:
+			warn++
+		case checks.StatusManual:
+			manual++
+		}
+	}
+	automated := pass + fail + warn
+	score := 0.0
+	if automated > 0 {
+		score = float64(pass) / float64(automated) * 100
+	}
+
+	scoreColor := "#ef4444"
+	scoreLabel := "At Risk"
+	if score >= 80 {
+		scoreColor = "#22c55e"
+		scoreLabel = "Good"
+	} else if score >= 50 {
+		scoreColor = "#f97316"
+		scoreLabel = "Fair"
+	}
+
+	var rows strings.Builder
+	for _, r := range results {
+		statusClass := map[checks.Status]string{
+			checks.StatusPass:   "pass",
+			checks.StatusFail:   "fail",
+			checks.StatusWarn:   "warn",
+			checks.StatusManual: "manual",
+		}[r.Result.Status]
+		if statusClass == "" {
+			statusClass = "err"
+		}
+		statusLabel := map[checks.Status]string{
+			checks.StatusPass:   "✓ PASS",
+			checks.StatusFail:   "✗ FAIL",
+			checks.StatusWarn:   "⚠ WARN",
+			checks.StatusManual: "ℹ MANUAL",
+		}[r.Result.Status]
+
+		fixTag := ""
+		if r.Result.Status == checks.StatusFail && r.Check.Fix() != nil {
+			fixTag = `<span class="fix-badge">auto-fix</span>`
+		}
+
+		rows.WriteString(fmt.Sprintf(`
+		<tr class="%s">
+		  <td class="cis">%s</td>
+		  <td>%s %s</td>
+		  <td>%s</td>
+		  <td><span class="sev-%s">%s</span></td>
+		  <td class="status-badge">%s</td>
+		  <td class="output">%s</td>
+		</tr>`,
+			statusClass,
+			html.EscapeString(r.Check.CISID()),
+			html.EscapeString(r.Check.Name()),
+			fixTag,
+			html.EscapeString(r.Check.Section()),
+			strings.ToLower(r.Check.Severity()),
+			html.EscapeString(r.Check.Severity()),
+			statusLabel,
+			html.EscapeString(r.Result.Output),
+		))
+	}
+
+	return fmt.Sprintf(`<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Mergen Security Report</title>
+<style>
+  :root { color-scheme: dark; }
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+  body { background: #0f0f13; color: #e2e8f0; font-family: -apple-system, BlinkMacSystemFont, 'SF Pro Text', sans-serif; font-size: 14px; line-height: 1.5; }
+  header { background: linear-gradient(135deg, #1e1b4b 0%%, #312e81 100%%); padding: 40px 48px; border-bottom: 1px solid #312e81; }
+  header h1 { font-size: 28px; font-weight: 700; color: #a78bfa; letter-spacing: -0.5px; }
+  header p { color: #94a3b8; margin-top: 4px; font-size: 13px; }
+  .stats { display: flex; gap: 24px; padding: 24px 48px; background: #0f0f13; border-bottom: 1px solid #1f2937; flex-wrap: wrap; align-items: center; }
+  .score { font-size: 48px; font-weight: 800; color: %s; line-height: 1; }
+  .score-label { font-size: 13px; color: %s; font-weight: 600; margin-top: 2px; }
+  .stat { padding: 0 20px; border-left: 1px solid #1f2937; }
+  .stat .n { font-size: 28px; font-weight: 700; }
+  .stat .l { font-size: 11px; color: #6b7280; text-transform: uppercase; letter-spacing: 0.05em; margin-top: 2px; }
+  .stat.pass .n { color: #22c55e; }
+  .stat.fail .n { color: #ef4444; }
+  .stat.warn .n { color: #f97316; }
+  .stat.manual .n { color: #3b82f6; }
+  .generated { margin-left: auto; color: #4b5563; font-size: 12px; align-self: flex-end; }
+  main { padding: 32px 48px; }
+  table { width: 100%%; border-collapse: collapse; font-size: 13px; }
+  th { text-align: left; padding: 10px 12px; background: #111827; color: #6b7280; font-weight: 600; font-size: 11px; text-transform: uppercase; letter-spacing: 0.05em; border-bottom: 1px solid #1f2937; position: sticky; top: 0; }
+  td { padding: 9px 12px; border-bottom: 1px solid #1a1a2e; vertical-align: top; }
+  tr:hover td { background: #111827; }
+  tr.fail td:first-child { border-left: 3px solid #ef4444; }
+  tr.warn td:first-child { border-left: 3px solid #f97316; }
+  tr.pass td:first-child { border-left: 3px solid #22c55e; }
+  tr.manual td:first-child { border-left: 3px solid #3b82f6; }
+  .cis { font-family: 'SF Mono', monospace; color: #94a3b8; font-size: 12px; white-space: nowrap; }
+  .status-badge { font-weight: 700; white-space: nowrap; font-size: 12px; }
+  tr.pass .status-badge { color: #22c55e; }
+  tr.fail .status-badge { color: #ef4444; }
+  tr.warn .status-badge { color: #f97316; }
+  tr.manual .status-badge { color: #3b82f6; }
+  .output { color: #6b7280; font-size: 12px; max-width: 320px; }
+  .sev-critical { color: #dc2626; font-weight: 700; }
+  .sev-high { color: #f97316; }
+  .sev-medium { color: #eab308; }
+  .sev-low { color: #3b82f6; }
+  .fix-badge { background: #7f1d1d; color: #fca5a5; font-size: 10px; padding: 1px 5px; border-radius: 4px; margin-left: 6px; font-weight: 600; vertical-align: middle; }
+  footer { padding: 24px 48px; color: #374151; font-size: 12px; border-top: 1px solid #1f2937; }
+</style>
+</head>
+<body>
+<header>
+  <h1>🛡 Mergen Security Report</h1>
+  <p>CIS Apple macOS 26 Tahoe Benchmark v1.0.0 · Generated %s</p>
+</header>
+<div class="stats">
+  <div>
+    <div class="score">%.0f%%</div>
+    <div class="score-label">%s</div>
+  </div>
+  <div class="stat pass"><div class="n">%d</div><div class="l">Pass</div></div>
+  <div class="stat fail"><div class="n">%d</div><div class="l">Fail</div></div>
+  <div class="stat warn"><div class="n">%d</div><div class="l">Warn</div></div>
+  <div class="stat manual"><div class="n">%d</div><div class="l">Manual</div></div>
+  <div class="generated">%s</div>
+</div>
+<main>
+<table>
+<thead>
+  <tr>
+    <th>CIS ID</th><th>Check</th><th>§</th><th>Severity</th><th>Status</th><th>Finding</th>
+  </tr>
+</thead>
+<tbody>
+%s
+</tbody>
+</table>
+</main>
+<footer>Generated by <strong>mergen-cli</strong> · github.com/sametsazak/mergen</footer>
+</body>
+</html>`,
+		scoreColor, scoreColor,
+		time.Now().Format("2006-01-02"),
+		score, scoreLabel,
+		pass, fail, warn, manual,
+		time.Now().Format("2006-01-02 15:04 MST"),
+		rows.String(),
+	)
+}
+</file>
+
+<file path="mergen-cli/internal/runner/runner.go">
+package runner
+
+import (
+	"sync"
+
+	"github.com/sametsazak/mergen-cli/internal/checks"
+)
+
+// Progress is sent on the channel as each check completes.
+type Progress struct {
+	Result checks.CheckResult
+	Done   int
+	Total  int
+}
+
+// Run executes all provided checks concurrently (up to workers goroutines)
+// and streams Progress updates on the returned channel.
+// The channel is closed when all checks are complete.
+func Run(cs []checks.Check, workers int) <-chan Progress {
+	if workers <= 0 {
+		workers = 8
+	}
+
+	ch := make(chan Progress, len(cs))
+	jobs := make(chan checks.Check, len(cs))
+	total := len(cs)
+
+	var (
+		mu   sync.Mutex
+		done int
+	)
+
+	// Fan-out workers
+	var wg sync.WaitGroup
+	for i := 0; i < workers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for c := range jobs {
+				res := c.Run()
+				mu.Lock()
+				done++
+				d := done
+				mu.Unlock()
+				ch <- Progress{
+					Result: checks.CheckResult{Check: c, Result: res},
+					Done:   d,
+					Total:  total,
+				}
+			}
+		}()
+	}
+
+	// Feed jobs
+	go func() {
+		for _, c := range cs {
+			jobs <- c
+		}
+		close(jobs)
+		wg.Wait()
+		close(ch)
+	}()
+
+	return ch
+}
+</file>
+
+<file path="mergen-cli/main.go">
+package main
+
+import "github.com/sametsazak/mergen-cli/cmd"
+
+// version is set at build time via -ldflags "-X main.version=x.y"
+var version = "dev"
+
+func main() {
+	cmd.SetVersion(version)
+	cmd.Execute()
+}
+</file>
+
+<file path="mergen-cli/Makefile">
+BINARY     = mergen
+VERSION   ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo "dev")
+LDFLAGS   = -ldflags "-X main.version=$(VERSION) -s -w"
+GOFLAGS   = -trimpath
+
+.PHONY: all build install clean test tidy release
+
+all: build
+
+## build: compile for the current platform
+build:
+	go build $(GOFLAGS) $(LDFLAGS) -o $(BINARY) .
+
+## install: install to /usr/local/bin
+install: build
+	install -m 755 $(BINARY) /usr/local/bin/$(BINARY)
+	@echo "Installed to /usr/local/bin/$(BINARY)"
+
+## release: build universal macOS binary (arm64 + amd64)
+release:
+	GOOS=darwin GOARCH=arm64  go build $(GOFLAGS) $(LDFLAGS) -o dist/$(BINARY)-darwin-arm64 .
+	GOOS=darwin GOARCH=amd64  go build $(GOFLAGS) $(LDFLAGS) -o dist/$(BINARY)-darwin-amd64 .
+	lipo -create -output dist/$(BINARY)-darwin-universal \
+		dist/$(BINARY)-darwin-arm64 \
+		dist/$(BINARY)-darwin-amd64
+	@echo "Universal binary: dist/$(BINARY)-darwin-universal"
+
+## test: run all tests
+test:
+	go test ./...
+
+## tidy: tidy and vendor modules
+tidy:
+	go mod tidy
+
+## clean: remove build artifacts
+clean:
+	rm -rf $(BINARY) dist/
+</file>
+
+<file path="mergen-cli/mergen-report.json">
+{
+  "generated_at": "2026-03-20T12:54:21Z",
+  "benchmark": "CIS Apple macOS 26 Tahoe Benchmark v1.0.0",
+  "total": 73,
+  "pass": 40,
+  "fail": 19,
+  "warn": 3,
+  "manual": 10,
+  "score_pct": 64.51612903225806,
+  "checks": [
+    {
+      "cis_id": "1.3",
+      "name": "Auto-update enabled",
+      "section": "1",
+      "category": "CIS Benchmark",
+      "severity": "Medium",
+      "status": "PASS",
+      "output": "AutomaticDownload = 1",
+      "remediation": "sudo defaults write /Library/Preferences/com.apple.SoftwareUpdate AutomaticDownload -bool true",
+      "auto_fixable": false
+    },
+    {
+      "cis_id": "1.4",
+      "name": "App Store auto-updates enabled",
+      "section": "1",
+      "category": "CIS Benchmark",
+      "severity": "Medium",
+      "status": "PASS",
+      "output": "AutoUpdate = 1",
+      "remediation": "sudo defaults write /Library/Preferences/com.apple.commerce AutoUpdate -bool true",
+      "auto_fixable": false
+    },
+    {
+      "cis_id": "1.6",
+      "name": "Software update deferment policy",
+      "section": "1",
+      "category": "CIS Benchmark",
+      "severity": "Low",
+      "status": "PASS",
+      "output": "Update deferment delay = 2026-03-20 15:54:21.752 defaults[82530:14770388] \nThe domain/default pair of (/Library/Preferences/com.apple.SoftwareUpdate, enforcedSoftwareUpdateDelay) does not exist days",
+      "remediation": "sudo defaults write /Library/Preferences/com.apple.SoftwareUpdate enforcedSoftwareUpdateDelay -int 30",
+      "auto_fixable": false
+    },
+    {
+      "cis_id": "1.5",
+      "name": "Security responses auto-install enabled",
+      "section": "1",
+      "category": "CIS Benchmark",
+      "severity": "High",
+      "status": "PASS",
+      "output": "ConfigDataInstall = 1",
+      "remediation": "sudo defaults write /Library/Preferences/com.apple.SoftwareUpdate ConfigDataInstall -bool true",
+      "auto_fixable": false
+    },
+    {
+      "cis_id": "1.2",
+      "name": "Critical updates auto-install enabled",
+      "section": "1",
+      "category": "CIS Benchmark",
+      "severity": "Medium",
+      "status": "PASS",
+      "output": "CriticalUpdateInstall = 1",
+      "remediation": "sudo defaults write /Library/Preferences/com.apple.SoftwareUpdate CriticalUpdateInstall -int 1",
+      "auto_fixable": false
+    },
+    {
+      "cis_id": "2.11.1",
+      "name": "Screen saver activates within 20 minutes",
+      "section": "2",
+      "category": "CIS Benchmark",
+      "severity": "Medium",
+      "status": "PASS",
+      "output": "Screen saver activates after 1200 seconds",
+      "remediation": "defaults -currentHost write com.apple.screensaver idleTime -int 1200",
+      "auto_fixable": false
+    },
+    {
+      "cis_id": "2.10.3",
+      "name": "Wake for network access disabled",
+      "section": "2",
+      "category": "CIS Benchmark",
+      "severity": "Low",
+      "status": "PASS",
+      "output": "Wake for network access is disabled",
+      "remediation": "sudo pmset -a womp 0",
+      "auto_fixable": false
+    },
+    {
+      "cis_id": "2.11.2",
+      "name": "Password required on wake",
+      "section": "2",
+      "category": "CIS Benchmark",
+      "severity": "High",
+      "status": "PASS",
+      "output": "Password required on wake",
+      "remediation": "defaults -currentHost write com.apple.screensaver askForPassword -bool true",
+      "auto_fixable": false
+    },
+    {
+      "cis_id": "2.10.1.2",
+      "name": "Sleep enabled (Apple Silicon)",
+      "section": "2",
+      "category": "CIS Benchmark",
+      "severity": "Medium",
+      "status": "PASS",
+      "output": "Power settings: sleep                1 (sleep prevented by sharingd, runningboardd, WhatsApp, powerd, caffeinate),  displaysleep         2",
+      "remediation": "sudo pmset -a sleep 15 \u0026\u0026 sudo pmset -a displaysleep 10",
+      "auto_fixable": false
+    },
+    {
+      "cis_id": "2.10.2",
+      "name": "Power Nap disabled",
+      "section": "2",
+      "category": "CIS Benchmark",
+      "severity": "Low",
+      "status": "FAIL",
+      "output": "Power Nap is enabled",
+      "remediation": "sudo pmset -a powernap 0",
+      "auto_fixable": true
+    },
+    {
+      "cis_id": "2.11.4",
+      "name": "Login window shows name and password fields",
+      "section": "2",
+      "category": "CIS Benchmark",
+      "severity": "Low",
+      "status": "FAIL",
+      "output": "Login window shows user list (SHOWFULLNAME = 2026-03-20 15:54:21.769 defaults[82547:14770440] \nThe domain/default pair of (/Library/Preferences/com.apple.loginwindow, SHOWFULLNAME) does not exist)",
+      "remediation": "sudo defaults write /Library/Preferences/com.apple.loginwindow SHOWFULLNAME -bool true",
+      "auto_fixable": true
+    },
+    {
+      "cis_id": "2.11.5",
+      "name": "Password hints disabled",
+      "section": "2",
+      "category": "CIS Benchmark",
+      "severity": "Medium",
+      "status": "PASS",
+      "output": "Password hints are disabled",
+      "remediation": "sudo defaults write /Library/Preferences/com.apple.loginwindow RetriesUntilHint -int 0",
+      "auto_fixable": false
+    },
+    {
+      "cis_id": "2.11.3",
+      "name": "Login window message configured",
+      "section": "2",
+      "category": "CIS Benchmark",
+      "severity": "Low",
+      "status": "WARN",
+      "output": "No login window message is configured",
+      "remediation": "sudo defaults write /Library/Preferences/com.apple.loginwindow LoginwindowText 'Authorized use only'",
+      "auto_fixable": false
+    },
+    {
+      "cis_id": "2.13.1",
+      "name": "Guest login disabled",
+      "section": "2",
+      "category": "CIS Benchmark",
+      "severity": "High",
+      "status": "PASS",
+      "output": "Guest login is disabled",
+      "remediation": "sudo defaults write /Library/Preferences/com.apple.loginwindow.plist GuestEnabled -bool false",
+      "auto_fixable": false
+    },
+    {
+      "cis_id": "2.3.2.2",
+      "name": "Time within appropriate limits",
+      "section": "2",
+      "category": "CIS Benchmark",
+      "severity": "Low",
+      "status": "MANUAL",
+      "output": "Manual review required — verify NTP accuracy",
+      "remediation": "Verify system time is accurate and NTP is functional.",
+      "auto_fixable": false
+    },
+    {
+      "cis_id": "2.2.1",
+      "name": "Firewall enabled",
+      "section": "2",
+      "category": "CIS Benchmark",
+      "severity": "High",
+      "status": "PASS",
+      "output": "Firewall is enabled",
+      "remediation": "sudo /usr/libexec/ApplicationFirewall/socketfilterfw --setglobalstate on",
+      "auto_fixable": false
+    },
+    {
+      "cis_id": "2.2.2",
+      "name": "Firewall stealth mode enabled",
+      "section": "2",
+      "category": "CIS Benchmark",
+      "severity": "Medium",
+      "status": "FAIL",
+      "output": "Stealth mode is disabled",
+      "remediation": "sudo /usr/libexec/ApplicationFirewall/socketfilterfw --setstealthmode on",
+      "auto_fixable": true
+    },
+    {
+      "cis_id": "2.3.1.1",
+      "name": "AirDrop disabled",
+      "section": "2",
+      "category": "CIS Benchmark",
+      "severity": "Medium",
+      "status": "PASS",
+      "output": "AirDrop is disabled",
+      "remediation": "defaults write com.apple.NetworkBrowser DisableAirDrop -bool YES",
+      "auto_fixable": false
+    },
+    {
+      "cis_id": "2.13.2",
+      "name": "Guest access to shared folders disabled",
+      "section": "2",
+      "category": "CIS Benchmark",
+      "severity": "Medium",
+      "status": "PASS",
+      "output": "Guest access to shared folders is disabled",
+      "remediation": "sudo defaults write /Library/Preferences/com.apple.AppleFileServer guestAccess -int 0",
+      "auto_fixable": false
+    },
+    {
+      "cis_id": "2.3.2.1",
+      "name": "Time set automatically",
+      "section": "2",
+      "category": "CIS Benchmark",
+      "severity": "Medium",
+      "status": "PASS",
+      "output": "Automatic time sync is active",
+      "remediation": "sudo defaults write /Library/Preferences/com.apple.timezone.auto.plist Active -int 1",
+      "auto_fixable": false
+    },
+    {
+      "cis_id": "2.3.1.2",
+      "name": "AirPlay Receiver disabled",
+      "section": "2",
+      "category": "CIS Benchmark",
+      "severity": "Low",
+      "status": "PASS",
+      "output": "AirPlay Receiver is disabled",
+      "remediation": "defaults write com.apple.controlcenter AirplayRecieverEnabled -int 0",
+      "auto_fixable": false
+    },
+    {
+      "cis_id": "2.13.3",
+      "name": "Automatic login disabled",
+      "section": "2",
+      "category": "CIS Benchmark",
+      "severity": "High",
+      "status": "PASS",
+      "output": "Automatic login is disabled",
+      "remediation": "sudo defaults delete /Library/Preferences/com.apple.loginwindow autoLoginUser",
+      "auto_fixable": false
+    },
+    {
+      "cis_id": "2.3.3.2",
+      "name": "File sharing disabled",
+      "section": "2",
+      "category": "CIS Benchmark",
+      "severity": "High",
+      "status": "FAIL",
+      "output": "File sharing (smbd) is not disabled",
+      "remediation": "sudo launchctl disable system/com.apple.smbd",
+      "auto_fixable": true
+    },
+    {
+      "cis_id": "2.3.3.1",
+      "name": "Screen sharing disabled",
+      "section": "2",
+      "category": "CIS Benchmark",
+      "severity": "High",
+      "status": "PASS",
+      "output": "Screen sharing is not running",
+      "remediation": "sudo launchctl disable system/com.apple.screensharing",
+      "auto_fixable": false
+    },
+    {
+      "cis_id": "2.3.3.4",
+      "name": "Remote login (SSH) disabled",
+      "section": "2",
+      "category": "CIS Benchmark",
+      "severity": "High",
+      "status": "FAIL",
+      "output": "SSH (Remote Login) is not disabled",
+      "remediation": "sudo launchctl disable system/com.openssh.sshd",
+      "auto_fixable": true
+    },
+    {
+      "cis_id": "2.5.1.1",
+      "name": "External Intelligence Extensions disabled",
+      "section": "2",
+      "category": "CIS Benchmark",
+      "severity": "Low",
+      "status": "MANUAL",
+      "output": "Manual review required",
+      "remediation": "Disable in System Settings \u003e Privacy \u0026 Security \u003e Extensions.",
+      "auto_fixable": false
+    },
+    {
+      "cis_id": "2.5.1.2",
+      "name": "Writing Tools (Apple Intelligence) disabled",
+      "section": "2",
+      "category": "CIS Benchmark",
+      "severity": "Low",
+      "status": "MANUAL",
+      "output": "Manual review required",
+      "remediation": "Disable Apple Intelligence in System Settings \u003e Apple Intelligence \u0026 Siri.",
+      "auto_fixable": false
+    },
+    {
+      "cis_id": "2.5.1.3",
+      "name": "Mail summarization disabled",
+      "section": "2",
+      "category": "CIS Benchmark",
+      "severity": "Low",
+      "status": "MANUAL",
+      "output": "Manual review required",
+      "remediation": "Disable in Mail \u003e Settings \u003e General.",
+      "auto_fixable": false
+    },
+    {
+      "cis_id": "2.5.1.4",
+      "name": "Notes summarization disabled",
+      "section": "2",
+      "category": "CIS Benchmark",
+      "severity": "Low",
+      "status": "MANUAL",
+      "output": "Manual review required",
+      "remediation": "Disable in Notes \u003e Settings.",
+      "auto_fixable": false
+    },
+    {
+      "cis_id": "2.3.3.10",
+      "name": "Bluetooth sharing disabled",
+      "section": "2",
+      "category": "CIS Benchmark",
+      "severity": "Medium",
+      "status": "PASS",
+      "output": "Bluetooth Sharing is disabled",
+      "remediation": "defaults -currentHost write com.apple.Bluetooth PrefKeyServicesEnabled -bool false",
+      "auto_fixable": false
+    },
+    {
+      "cis_id": "2.3.3.5",
+      "name": "Remote management disabled",
+      "section": "2",
+      "category": "CIS Benchmark",
+      "severity": "High",
+      "status": "FAIL",
+      "output": "Remote Management (ARD) is running",
+      "remediation": "sudo /System/Library/CoreServices/RemoteManagement/ARDAgent.app/Contents/Resources/kickstart -deactivate -stop",
+      "auto_fixable": true
+    },
+    {
+      "cis_id": "2.3.3.6",
+      "name": "Remote Apple Events disabled",
+      "section": "2",
+      "category": "CIS Benchmark",
+      "severity": "Medium",
+      "status": "PASS",
+      "output": "Remote Apple Events is disabled",
+      "remediation": "sudo launchctl disable system/com.apple.AEServer",
+      "auto_fixable": false
+    },
+    {
+      "cis_id": "2.3.3.9",
+      "name": "Media sharing disabled",
+      "section": "2",
+      "category": "CIS Benchmark",
+      "severity": "Low",
+      "status": "PASS",
+      "output": "Media sharing is disabled",
+      "remediation": "defaults write com.apple.amp.mediasharingd home-sharing-enabled -int 0",
+      "auto_fixable": false
+    },
+    {
+      "cis_id": "2.6.3.4",
+      "name": "Share with app developers disabled",
+      "section": "2",
+      "category": "CIS Benchmark",
+      "severity": "Low",
+      "status": "MANUAL",
+      "output": "Manual review required",
+      "remediation": "Disable in System Settings \u003e Privacy \u0026 Security \u003e Analytics \u0026 Improvements.",
+      "auto_fixable": false
+    },
+    {
+      "cis_id": "2.5.2.1",
+      "name": "Siri disabled",
+      "section": "2",
+      "category": "CIS Benchmark",
+      "severity": "Low",
+      "status": "PASS",
+      "output": "Siri is disabled",
+      "remediation": "defaults write com.apple.Siri SiriProfessionalEnabled -bool false",
+      "auto_fixable": false
+    },
+    {
+      "cis_id": "2.3.3.7",
+      "name": "Internet sharing disabled",
+      "section": "2",
+      "category": "CIS Benchmark",
+      "severity": "High",
+      "status": "PASS",
+      "output": "Internet sharing is disabled",
+      "remediation": "sudo defaults write /Library/Preferences/SystemConfiguration/com.apple.nat NAT -dict-add Enabled -int 0",
+      "auto_fixable": false
+    },
+    {
+      "cis_id": "2.6.7",
+      "name": "Lockdown Mode (advisory)",
+      "section": "2",
+      "category": "CIS Benchmark",
+      "severity": "Low",
+      "status": "MANUAL",
+      "output": "Advisory: review whether Lockdown Mode is appropriate",
+      "remediation": "Enable in System Settings \u003e Privacy \u0026 Security \u003e Lockdown Mode.",
+      "auto_fixable": false
+    },
+    {
+      "cis_id": "2.6.8",
+      "name": "Admin password required for System Settings",
+      "section": "2",
+      "category": "CIS Benchmark",
+      "severity": "Medium",
+      "status": "MANUAL",
+      "output": "Manual review required",
+      "remediation": "Enable in System Settings \u003e Privacy \u0026 Security.",
+      "auto_fixable": false
+    },
+    {
+      "cis_id": "2.6.4",
+      "name": "Personalized ads disabled",
+      "section": "2",
+      "category": "CIS Benchmark",
+      "severity": "Low",
+      "status": "PASS",
+      "output": "Personalized advertising is disabled",
+      "remediation": "defaults write com.apple.AdLib allowApplePersonalizedAdvertising -bool false",
+      "auto_fixable": false
+    },
+    {
+      "cis_id": "2.9.1",
+      "name": "Improve Spotlight suggestions disabled",
+      "section": "2",
+      "category": "CIS Benchmark",
+      "severity": "Low",
+      "status": "MANUAL",
+      "output": "Manual review required",
+      "remediation": "Disable in System Settings \u003e Siri \u0026 Spotlight.",
+      "auto_fixable": false
+    },
+    {
+      "cis_id": "2.6.3.1",
+      "name": "Diagnostic data sharing disabled",
+      "section": "2",
+      "category": "CIS Benchmark",
+      "severity": "Low",
+      "status": "PASS",
+      "output": "Diagnostic data sharing is disabled",
+      "remediation": "sudo defaults write '/Library/Application Support/CrashReporter/DiagnosticMessagesHistory.plist' AutoSubmit -bool false",
+      "auto_fixable": false
+    },
+    {
+      "cis_id": "2.6.3.3",
+      "name": "Improve assistive voice features disabled",
+      "section": "2",
+      "category": "CIS Benchmark",
+      "severity": "Low",
+      "status": "PASS",
+      "output": "Assistive voice improvement sharing is disabled",
+      "remediation": "defaults write com.apple.Accessibility AXSAudioDonationSiriImprovementEnabled -bool false",
+      "auto_fixable": false
+    },
+    {
+      "cis_id": "2.6.3.2",
+      "name": "Improve Siri \u0026 Dictation disabled",
+      "section": "2",
+      "category": "CIS Benchmark",
+      "severity": "Low",
+      "status": "PASS",
+      "output": "Siri data sharing is disabled",
+      "remediation": "defaults write com.apple.assistant.support 'Siri Data Sharing Opt-In Status' -int 2",
+      "auto_fixable": false
+    },
+    {
+      "cis_id": "2.3.3.3",
+      "name": "Printer sharing disabled",
+      "section": "2",
+      "category": "CIS Benchmark",
+      "severity": "Low",
+      "status": "PASS",
+      "output": "Printer sharing is disabled",
+      "remediation": "sudo cupsctl --no-share-printers",
+      "auto_fixable": false
+    },
+    {
+      "cis_id": "2.8.1",
+      "name": "Universal Control disabled",
+      "section": "2",
+      "category": "CIS Benchmark",
+      "severity": "Low",
+      "status": "FAIL",
+      "output": "Universal Control is not disabled",
+      "remediation": "defaults -currentHost write com.apple.universalcontrol Disable -int 1",
+      "auto_fixable": true
+    },
+    {
+      "cis_id": "3.2",
+      "name": "Security auditing enabled",
+      "section": "3",
+      "category": "CIS Benchmark",
+      "severity": "Medium",
+      "status": "WARN",
+      "output": "auditd is not running (may be removed in macOS Tahoe)",
+      "remediation": "sudo launchctl load -w /System/Library/LaunchDaemons/com.apple.auditd.plist",
+      "auto_fixable": false
+    },
+    {
+      "cis_id": "2.6.5",
+      "name": "Gatekeeper enabled",
+      "section": "2",
+      "category": "CIS Benchmark",
+      "severity": "High",
+      "status": "PASS",
+      "output": "Gatekeeper is enabled",
+      "remediation": "sudo spctl --master-enable",
+      "auto_fixable": false
+    },
+    {
+      "cis_id": "4.1",
+      "name": "Bonjour advertising disabled",
+      "section": "4",
+      "category": "CIS Benchmark",
+      "severity": "Low",
+      "status": "FAIL",
+      "output": "Bonjour advertising is enabled (NoMulticastAdvertisements = 2026-03-20 15:54:21.823 defaults[82583:14770553] \nThe domain/default pair of (/Library/Preferences/com.apple.mDNSResponder.plist, NoMulticastAdvertisements) does not exist)",
+      "remediation": "sudo defaults write /Library/Preferences/com.apple.mDNSResponder.plist NoMulticastAdvertisements -bool true",
+      "auto_fixable": true
+    },
+    {
+      "cis_id": "4.2",
+      "name": "Apache HTTP server disabled",
+      "section": "4",
+      "category": "CIS Benchmark",
+      "severity": "High",
+      "status": "PASS",
+      "output": "Apache HTTP server is not running",
+      "remediation": "sudo launchctl disable system/org.apache.httpd",
+      "auto_fixable": false
+    },
+    {
+      "cis_id": "3.3",
+      "name": "Audit flags configured",
+      "section": "3",
+      "category": "CIS Benchmark",
+      "severity": "Medium",
+      "status": "WARN",
+      "output": "audit_control not found or flags line missing",
+      "remediation": "Edit /etc/security/audit_control and set: flags=lo,aa,ad,fd,fm,-all",
+      "auto_fixable": false
+    },
+    {
+      "cis_id": "4.3",
+      "name": "NFS server disabled",
+      "section": "4",
+      "category": "CIS Benchmark",
+      "severity": "High",
+      "status": "FAIL",
+      "output": "NFS server is not disabled",
+      "remediation": "sudo launchctl disable system/com.apple.nfsd",
+      "auto_fixable": true
+    },
+    {
+      "cis_id": "2.3.3.8",
+      "name": "Content caching disabled",
+      "section": "2",
+      "category": "CIS Benchmark",
+      "severity": "Low",
+      "status": "PASS",
+      "output": "Content caching is not active",
+      "remediation": "sudo /usr/bin/AssetCacheManagerUtil deactivate",
+      "auto_fixable": false
+    },
+    {
+      "cis_id": "5.1.1",
+      "name": "System Integrity Protection enabled",
+      "section": "5",
+      "category": "CIS Benchmark",
+      "severity": "Critical",
+      "status": "PASS",
+      "output": "SIP is enabled",
+      "remediation": "SIP can only be re-enabled from Recovery Mode: csrutil enable",
+      "auto_fixable": false
+    },
+    {
+      "cis_id": "5.1.3",
+      "name": "AMFI (Apple Mobile File Integrity) enabled",
+      "section": "5",
+      "category": "CIS Benchmark",
+      "severity": "Critical",
+      "status": "PASS",
+      "output": "AMFI is enabled",
+      "remediation": "Remove amfi_get_out_of_my_way=1 from NVRAM boot-args (requires Recovery Mode).",
+      "auto_fixable": false
+    },
+    {
+      "cis_id": "5.11",
+      "name": "Secure kernel extension loading enforced",
+      "section": "5",
+      "category": "CIS Benchmark",
+      "severity": "High",
+      "status": "PASS",
+      "output": "Kernel extension loading controlled by SIP",
+      "remediation": "Ensure SIP is enabled — it enforces kernel extension signing requirements.",
+      "auto_fixable": false
+    },
+    {
+      "cis_id": "5.10",
+      "name": "XProtect protection enabled",
+      "section": "5",
+      "category": "CIS Benchmark",
+      "severity": "High",
+      "status": "PASS",
+      "output": "XProtect bundle is present",
+      "remediation": "XProtect is managed automatically by Apple and should not be disabled.",
+      "auto_fixable": false
+    },
+    {
+      "cis_id": "5.5",
+      "name": "Sudo TTY tickets enabled",
+      "section": "5",
+      "category": "CIS Benchmark",
+      "severity": "Medium",
+      "status": "FAIL",
+      "output": "sudo TTY tickets are not configured",
+      "remediation": "echo 'Defaults timestamp_type=tty' | sudo tee /etc/sudoers.d/cis_tty \u0026\u0026 sudo chmod 440 /etc/sudoers.d/cis_tty",
+      "auto_fixable": true
+    },
+    {
+      "cis_id": "5.9",
+      "name": "Sudo logging enabled",
+      "section": "5",
+      "category": "CIS Benchmark",
+      "severity": "Medium",
+      "status": "FAIL",
+      "output": "sudo command logging is not configured",
+      "remediation": "echo 'Defaults log_allowed' | sudo tee /etc/sudoers.d/cis_logging \u0026\u0026 sudo chmod 440 /etc/sudoers.d/cis_logging",
+      "auto_fixable": true
+    },
+    {
+      "cis_id": "5.2.1",
+      "name": "Password lockout threshold ≤ 5 attempts",
+      "section": "5",
+      "category": "CIS Benchmark",
+      "severity": "High",
+      "status": "FAIL",
+      "output": "No login failure lockout policy is configured",
+      "remediation": "sudo pwpolicy -n /Local/Default -setglobalpolicy maxFailedLoginAttempts=5",
+      "auto_fixable": true
+    },
+    {
+      "cis_id": "6.1.1",
+      "name": "Filename extensions shown",
+      "section": "6",
+      "category": "CIS Benchmark",
+      "severity": "Low",
+      "status": "PASS",
+      "output": "File extensions are shown",
+      "remediation": "defaults write NSGlobalDomain AppleShowAllExtensions -bool true",
+      "auto_fixable": false
+    },
+    {
+      "cis_id": "5.4",
+      "name": "Sudo timeout configured",
+      "section": "5",
+      "category": "CIS Benchmark",
+      "severity": "Medium",
+      "status": "ERROR",
+      "output": "Could not read sudo configuration",
+      "remediation": "echo 'Defaults timestamp_timeout=0' | sudo tee /etc/sudoers.d/cis_timeout \u0026\u0026 sudo chmod 440 /etc/sudoers.d/cis_timeout",
+      "auto_fixable": false
+    },
+    {
+      "cis_id": "5.2.2",
+      "name": "Minimum password length ≥ 15 characters",
+      "section": "5",
+      "category": "CIS Benchmark",
+      "severity": "High",
+      "status": "FAIL",
+      "output": "No minimum password length policy is configured",
+      "remediation": "sudo pwpolicy -n /Local/Default -setglobalpolicy minChars=15",
+      "auto_fixable": true
+    },
+    {
+      "cis_id": "6.1.2",
+      "name": "Home folder permissions",
+      "section": "6",
+      "category": "CIS Benchmark",
+      "severity": "Medium",
+      "status": "FAIL",
+      "output": "Home folder permissions are too open: drwxr-x---+ (should be drwx------)",
+      "remediation": "chmod 700 ~/",
+      "auto_fixable": false
+    },
+    {
+      "cis_id": "5.6",
+      "name": "Root account disabled",
+      "section": "5",
+      "category": "CIS Benchmark",
+      "severity": "High",
+      "status": "FAIL",
+      "output": "Root account is enabled: UserShell: /bin/sh",
+      "remediation": "sudo dsenableroot -d",
+      "auto_fixable": true
+    },
+    {
+      "name": "Certificate trust settings valid",
+      "section": "5",
+      "category": "CIS Benchmark",
+      "severity": "Medium",
+      "status": "MANUAL",
+      "output": "Manual review required in Keychain Access",
+      "remediation": "Review certificate trust settings in Keychain Access \u003e System Roots.",
+      "auto_fixable": false
+    },
+    {
+      "cis_id": "6.3.10",
+      "name": "Safari status bar shown",
+      "section": "6",
+      "category": "CIS Benchmark",
+      "severity": "Low",
+      "status": "FAIL",
+      "output": "Safari status bar is hidden",
+      "remediation": "defaults write com.apple.Safari ShowOverlayStatusBar -bool true",
+      "auto_fixable": true
+    },
+    {
+      "cis_id": "6.3.1",
+      "name": "Safari auto-open safe files disabled",
+      "section": "6",
+      "category": "CIS Benchmark",
+      "severity": "Medium",
+      "status": "PASS",
+      "output": "Safari auto-open safe downloads is disabled",
+      "remediation": "defaults write com.apple.Safari AutoOpenSafeDownloads -bool false",
+      "auto_fixable": false
+    },
+    {
+      "cis_id": "6.3.3",
+      "name": "Safari fraudulent website warning enabled",
+      "section": "6",
+      "category": "CIS Benchmark",
+      "severity": "Medium",
+      "status": "FAIL",
+      "output": "Safari fraud warning is disabled",
+      "remediation": "defaults write com.apple.Safari WarnAboutFraudulentWebsites -bool true",
+      "auto_fixable": true
+    },
+    {
+      "cis_id": "6.3.4",
+      "name": "Safari cross-site tracking prevention enabled",
+      "section": "6",
+      "category": "CIS Benchmark",
+      "severity": "Medium",
+      "status": "FAIL",
+      "output": "Cross-site tracking prevention not fully enabled (BlockStoragePolicy = 2026-03-20 15:54:21.858 defaults[82610:14770634] \nThe domain/default pair of (/Users/sametsazak/Library/Containers/com.apple.Safari/Data/Library/Preferences/com.apple.Safari, BlockStoragePolicy) does not exist)",
+      "remediation": "defaults write com.apple.Safari BlockStoragePolicy -int 2",
+      "auto_fixable": true
+    },
+    {
+      "cis_id": "6.3.6",
+      "name": "Safari advertising privacy enabled",
+      "section": "6",
+      "category": "CIS Benchmark",
+      "severity": "Low",
+      "status": "PASS",
+      "output": "Private Click Measurement is enabled",
+      "remediation": "defaults write com.apple.Safari WebKitPreferences.privateClickMeasurementEnabled -bool true",
+      "auto_fixable": false
+    },
+    {
+      "cis_id": "6.4.1",
+      "name": "Terminal secure keyboard entry enabled",
+      "section": "6",
+      "category": "CIS Benchmark",
+      "severity": "Medium",
+      "status": "FAIL",
+      "output": "Secure keyboard entry is disabled",
+      "remediation": "defaults write com.apple.Terminal SecureKeyboardEntry -bool true",
+      "auto_fixable": true
+    },
+    {
+      "name": "FileVault enabled",
+      "section": "5",
+      "category": "CIS Benchmark",
+      "severity": "Critical",
+      "status": "PASS",
+      "output": "FileVault is enabled",
+      "remediation": "Enable in System Settings \u003e Privacy \u0026 Security \u003e FileVault.",
+      "auto_fixable": false
+    },
+    {
+      "cis_id": "5.1.4",
+      "name": "Signed System Volume (SSV) enabled",
+      "section": "5",
+      "category": "CIS Benchmark",
+      "severity": "Critical",
+      "status": "PASS",
+      "output": "Signed System Volume is enabled",
+      "remediation": "SSV can only be re-enabled from Recovery Mode.",
+      "auto_fixable": false
+    }
+  ]
+}
+</file>
+
+<file path="mergen.xcodeproj/project.pbxproj">
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 56;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		AA0001122F6CA33300814E2E /* FixCommands.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA0001112F6CA33300814E2E /* FixCommands.swift */; };
+		AA0002122F6CA33300814E2E /* FixManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA0002112F6CA33300814E2E /* FixManager.swift */; };
+		AA0003122F6CA33300814E2E /* FixAllSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA0003112F6CA33300814E2E /* FixAllSheet.swift */; };
+		AA0004122F6CA33300814E2E /* AuditLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA0004112F6CA33300814E2E /* AuditLogger.swift */; };
+		AA0005122F6CA33300814E2E /* LogViewerSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA0005112F6CA33300814E2E /* LogViewerSheet.swift */; };
+		BC6C516329D38E2100B85797 /* IcloudEnabled.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC6C516229D38E2100B85797 /* IcloudEnabled.swift */; };
+		BC6C516529D390F800B85797 /* GuestLoginCheck.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC6C516429D390F800B85797 /* GuestLoginCheck.swift */; };
+		BC6C516729D3921400B85797 /* SiriStatusCheck.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC6C516629D3921400B85797 /* SiriStatusCheck.swift */; };
+		BC6C516929D3934500B85797 /* SecureKernelExtensionLoadingCheck.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC6C516829D3934500B85797 /* SecureKernelExtensionLoadingCheck.swift */; };
+		BC6C516B29D5C81000B85797 /* DiagnosticDataCheck.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC6C516A29D5C81000B85797 /* DiagnosticDataCheck.swift */; };
+		BC6C516D29D5C8C300B85797 /* Java6Check.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC6C516C29D5C8C300B85797 /* Java6Check.swift */; };
+		BC6C516F29D5C9BC00B85797 /* EfiCheck.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC6C516E29D5C9BC00B85797 /* EfiCheck.swift */; };
+		BC6C517129D5CC5600B85797 /* BonjourCheck.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC6C517029D5CC5600B85797 /* BonjourCheck.swift */; };
+		BC6C517329D5CDE200B85797 /* ApacheHTTPCheck.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC6C517229D5CDE200B85797 /* ApacheHTTPCheck.swift */; };
+		BC6C517529D60E9700B85797 /* NfsServerCheck.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC6C517429D60E9700B85797 /* NfsServerCheck.swift */; };
+		BC6C517729D60F0C00B85797 /* PasswordHintsCheck.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC6C517629D60F0C00B85797 /* PasswordHintsCheck.swift */; };
+		BC6C517929D616AD00B85797 /* GuestConnectCheck.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC6C517829D616AD00B85797 /* GuestConnectCheck.swift */; };
+		BC6C517B29D6174B00B85797 /* FileExtentionCheck.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC6C517A29D6174B00B85797 /* FileExtentionCheck.swift */; };
+		BC6C517D29D617BE00B85797 /* SafariSafeFileChecks.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC6C517C29D617BE00B85797 /* SafariSafeFileChecks.swift */; };
+		BC6C517F29D6183F00B85797 /* SafariInternetPluginCheck.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC6C517E29D6183F00B85797 /* SafariInternetPluginCheck.swift */; };
+		BC6C518129D618BA00B85797 /* FastUserSwitchingCheck.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC6C518029D618BA00B85797 /* FastUserSwitchingCheck.swift */; };
+		BC6C518329D7348400B85797 /* AppleSoftwareUpdateCheck.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC6C518229D7348400B85797 /* AppleSoftwareUpdateCheck.swift */; };
+		BC6C518529D7820C00B85797 /* AutomaticSoftwareUpdateCheck.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC6C518429D7820C00B85797 /* AutomaticSoftwareUpdateCheck.swift */; };
+		BC6C518729D782EA00B85797 /* AppStoreUpdateCheck.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC6C518629D782EA00B85797 /* AppStoreUpdateCheck.swift */; };
+		BC6C518A29D7845300B85797 /* SecurityUpdateCheck.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC6C518929D7845300B85797 /* SecurityUpdateCheck.swift */; };
+		BC6C518C29D7855700B85797 /* CriticalUpdateInstallCheck.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC6C518B29D7855700B85797 /* CriticalUpdateInstallCheck.swift */; };
+		BC6C518E29D786A500B85797 /* FirewallStealthModeCheck.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC6C518D29D786A500B85797 /* FirewallStealthModeCheck.swift */; };
+		BC6C519029D789B900B85797 /* AirDropDisabledCheck.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC6C518F29D789B900B85797 /* AirDropDisabledCheck.swift */; };
+		BC6C519229D78A6700B85797 /* AirPlayReceiverDisabledCheck.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC6C519129D78A6700B85797 /* AirPlayReceiverDisabledCheck.swift */; };
+		BC6C519429D78AFD00B85797 /* SetTimeAndDateAutomaticallyEnabledCheck.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC6C519329D78AFD00B85797 /* SetTimeAndDateAutomaticallyEnabledCheck.swift */; };
+		BC6C519629D78BD100B85797 /* TimeWithinLimitsCheck.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC6C519529D78BD100B85797 /* TimeWithinLimitsCheck.swift */; };
+		BC6C519829D7902500B85797 /* DVDOrCDSharingDisabledCheck.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC6C519729D7902500B85797 /* DVDOrCDSharingDisabledCheck.swift */; };
+		BC6C519A29D7909C00B85797 /* ScreenSharingDisabledCheck.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC6C519929D7909C00B85797 /* ScreenSharingDisabledCheck.swift */; };
+		BC876BFA29DC2090002127F2 /* LocationServicesMenuBarCheck.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC876BF929DC2090002127F2 /* LocationServicesMenuBarCheck.swift */; };
+		BC876BFC29DC263F002127F2 /* PersonalizedAds.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC876BFB29DC263F002127F2 /* PersonalizedAds.swift */; };
+		BC876BFE29DC27D5002127F2 /* ScreenSaverCornersCheck.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC876BFD29DC27D5002127F2 /* ScreenSaverCornersCheck.swift */; };
+		BC876C0029DC29F2002127F2 /* UniversalControlCheck.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC876BFF29DC29F2002127F2 /* UniversalControlCheck.swift */; };
+		BC876C0229DC4B95002127F2 /* WakeForNetworkAccessCheck.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC876C0129DC4B95002127F2 /* WakeForNetworkAccessCheck.swift */; };
+		BC876C0C29DC51EC002127F2 /* ScreenSaverIntervalCheck.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC876C0B29DC51EC002127F2 /* ScreenSaverIntervalCheck.swift */; };
+		BC876C0E29DC53D1002127F2 /* PasswordOnWakeCheck.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC876C0D29DC53D1002127F2 /* PasswordOnWakeCheck.swift */; };
+		BC876C1029DC5BDB002127F2 /* CheckAuditDisEnabled.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC876C0F29DC5BDB002127F2 /* CheckAuditDisEnabled.swift */; };
+		BC876C1629E0307E002127F2 /* HTMLReportGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC876C1529E0307E002127F2 /* HTMLReportGenerator.swift */; };
+		BC876C1829E0322D002127F2 /* JSONReportGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC876C1729E0322D002127F2 /* JSONReportGenerator.swift */; };
+		BCA6498829DACD37002FB952 /* FileSharingCheck.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCA6498729DACD37002FB952 /* FileSharingCheck.swift */; };
+		BCA6498A29DACE72002FB952 /* PrinterSharingDisabledCheck.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCA6498929DACE72002FB952 /* PrinterSharingDisabledCheck.swift */; };
+		BCA6498C29DAD04C002FB952 /* RemoteLoginDisabledCheck.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCA6498B29DAD04C002FB952 /* RemoteLoginDisabledCheck.swift */; };
+		BCA6498E29DAD1C1002FB952 /* RemoteManagementCheck.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCA6498D29DAD1C1002FB952 /* RemoteManagementCheck.swift */; };
+		BCA6499029DAD35E002FB952 /* RemoteAppleEventsCheck.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCA6498F29DAD35E002FB952 /* RemoteAppleEventsCheck.swift */; };
+		BCA6499229DAD730002FB952 /* InternetSharingDisabledCheck.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCA6499129DAD730002FB952 /* InternetSharingDisabledCheck.swift */; };
+		BCA6499429DB2776002FB952 /* SlowModule.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCA6499329DB2776002FB952 /* SlowModule.swift */; };
+		BCA6499629DB6699002FB952 /* ContentCachingDisabledCheck.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCA6499529DB6699002FB952 /* ContentCachingDisabledCheck.swift */; };
+		BCA6499829DB6793002FB952 /* CheckMediaSharingDisabled.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCA6499729DB6793002FB952 /* CheckMediaSharingDisabled.swift */; };
+		BCA6499A29DB6854002FB952 /* BluetoothSharingDisabledCheck.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCA6499929DB6854002FB952 /* BluetoothSharingDisabledCheck.swift */; };
+		BCA6499C29DB6A45002FB952 /* BackupAutomaticallyEnabledCheck.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCA6499B29DB6A45002FB952 /* BackupAutomaticallyEnabledCheck.swift */; };
+		BCA6499E29DB7351002FB952 /* CheckTimeMachineEnabled.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCA6499D29DB7351002FB952 /* CheckTimeMachineEnabled.swift */; };
+		BCA649A029DB7502002FB952 /* TimeMachineVolumesEncryptedCheck.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCA6499F29DB7502002FB952 /* TimeMachineVolumesEncryptedCheck.swift */; };
+		BCA649A229DB7845002FB952 /* ShowWifiMenuCheck.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCA649A129DB7845002FB952 /* ShowWifiMenuCheck.swift */; };
+		BCA649A429DB7920002FB952 /* BluetoothMenuCheck.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCA649A329DB7920002FB952 /* BluetoothMenuCheck.swift */; };
+		BCA649A629DB79D2002FB952 /* LocationServicesCheck.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCA649A529DB79D2002FB952 /* LocationServicesCheck.swift */; };
+		BCD734CC29CDF6A000C0B779 /* mergenApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCD734CB29CDF6A000C0B779 /* mergenApp.swift */; };
+		BCD734CE29CDF6A000C0B779 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCD734CD29CDF6A000C0B779 /* ContentView.swift */; };
+		BCD734D029CDF6A200C0B779 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = BCD734CF29CDF6A200C0B779 /* Assets.xcassets */; };
+		BCD734E529CF137C00C0B779 /* Vulnerability.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCD734E429CF137C00C0B779 /* Vulnerability.swift */; };
+		BCD734E729CF13CF00C0B779 /* Scanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCD734E629CF13CF00C0B779 /* Scanner.swift */; };
+		BCD734EA29CF13FD00C0B779 /* GatekeeperBypassCheck.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCD734E929CF13FD00C0B779 /* GatekeeperBypassCheck.swift */; };
+		BCD734EC29CF14C200C0B779 /* ScanResultView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCD734EB29CF14C200C0B779 /* ScanResultView.swift */; };
+		BCD734EE29CF1BAC00C0B779 /* FileVaultCheck.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCD734ED29CF1BAC00C0B779 /* FileVaultCheck.swift */; };
+		BCD734F229CF20FF00C0B779 /* ScanManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCD734F129CF20FF00C0B779 /* ScanManager.swift */; };
+		BCD734F429CF2B9700C0B779 /* VulnerabilityDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCD734F329CF2B9700C0B779 /* VulnerabilityDetailView.swift */; };
+		BCD734F829CF45C900C0B779 /* SIPCheck.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCD734F729CF45C900C0B779 /* SIPCheck.swift */; };
+		BCD734FA29CF472500C0B779 /* XProtectAndMRTCheck.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCD734F929CF472500C0B779 /* XProtectAndMRTCheck.swift */; };
+		BCD734FC29CF47D800C0B779 /* FirewallCheck.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCD734FB29CF47D800C0B779 /* FirewallCheck.swift */; };
+		BCD7350529D213E200C0B779 /* Preview Content in Resources */ = {isa = PBXBuildFile; fileRef = BCD7350429D213E200C0B779 /* Preview Content */; };
+		BCD7350729D2165700C0B779 /* Preview in Resources */ = {isa = PBXBuildFile; fileRef = BCD7350629D2165700C0B779 /* Preview */; };
+		BCD7350929D2218800C0B779 /* CertificateTrustCheck.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCD7350829D2218800C0B779 /* CertificateTrustCheck.swift */; };
+		BCD7350D29D2415600C0B779 /* SshEnableCheck.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCD7350C29D2415600C0B779 /* SshEnableCheck.swift */; };
+		BCEA57FD2F6CA33300814E2E /* PowerNapDisabledCheck.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCEA57EB2F6CA33300814E2E /* PowerNapDisabledCheck.swift */; };
+		BCEA57FE2F6CA33300814E2E /* SleepEnabledAppleSiliconCheck.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCEA57F32F6CA33300814E2E /* SleepEnabledAppleSiliconCheck.swift */; };
+		BCEA57FF2F6CA33300814E2E /* SafariCrossSiteTrackingCheck.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCEA57EE2F6CA33300814E2E /* SafariCrossSiteTrackingCheck.swift */; };
+		BCEA58002F6CA33300814E2E /* GuestHomeFolderCheck.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCEA57DF2F6CA33300814E2E /* GuestHomeFolderCheck.swift */; };
+		BCEA58012F6CA33300814E2E /* PasswordMinLengthCheck.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCEA57EA2F6CA33300814E2E /* PasswordMinLengthCheck.swift */; };
+		BCEA58022F6CA33300814E2E /* ImproveAssistiveVoiceCheck.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCEA57E22F6CA33300814E2E /* ImproveAssistiveVoiceCheck.swift */; };
+		BCEA58032F6CA33300814E2E /* iCloudKeychainCheck.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCEA57E12F6CA33300814E2E /* iCloudKeychainCheck.swift */; };
+		BCEA58042F6CA33300814E2E /* SafariAdvertisingPrivacyCheck.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCEA57ED2F6CA33300814E2E /* SafariAdvertisingPrivacyCheck.swift */; };
+		BCEA58052F6CA33300814E2E /* SudoTimeoutCheck.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCEA57F82F6CA33300814E2E /* SudoTimeoutCheck.swift */; };
+		BCEA58062F6CA33300814E2E /* HomeFolderPermissionsCheck.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCEA57E02F6CA33300814E2E /* HomeFolderPermissionsCheck.swift */; };
+		BCEA58072F6CA33300814E2E /* ExternalIntelligenceExtensionsCheck.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCEA57DE2F6CA33300814E2E /* ExternalIntelligenceExtensionsCheck.swift */; };
+		BCEA58082F6CA33300814E2E /* ImproveSiriDictationCheck.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCEA57E32F6CA33300814E2E /* ImproveSiriDictationCheck.swift */; };
+		BCEA58092F6CA33300814E2E /* NotesSummarizationCheck.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCEA57E82F6CA33300814E2E /* NotesSummarizationCheck.swift */; };
+		BCEA580A2F6CA33300814E2E /* TerminalSecureKeyboardCheck.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCEA57FA2F6CA33300814E2E /* TerminalSecureKeyboardCheck.swift */; };
+		BCEA580B2F6CA33300814E2E /* SafariFraudWarningCheck.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCEA57EF2F6CA33300814E2E /* SafariFraudWarningCheck.swift */; };
+		BCEA580C2F6CA33300814E2E /* LockdownModeCheck.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCEA57E42F6CA33300814E2E /* LockdownModeCheck.swift */; };
+		BCEA580D2F6CA33300814E2E /* RootAccountDisabledCheck.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCEA57EC2F6CA33300814E2E /* RootAccountDisabledCheck.swift */; };
+		BCEA580E2F6CA33300814E2E /* SSVEnabledCheck.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCEA57F62F6CA33300814E2E /* SSVEnabledCheck.swift */; };
+		BCEA580F2F6CA33300814E2E /* SpotlightImprovementCheck.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCEA57F52F6CA33300814E2E /* SpotlightImprovementCheck.swift */; };
+		BCEA58102F6CA33300814E2E /* SoftwareUpdateDefermentCheck.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCEA57F42F6CA33300814E2E /* SoftwareUpdateDefermentCheck.swift */; };
+		BCEA58112F6CA33300814E2E /* AuditFlagsCheck.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCEA57DC2F6CA33300814E2E /* AuditFlagsCheck.swift */; };
+		BCEA58122F6CA33300814E2E /* SudoLoggingCheck.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCEA57F72F6CA33300814E2E /* SudoLoggingCheck.swift */; };
+		BCEA58132F6CA33300814E2E /* LoginWindowNamePasswordCheck.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCEA57E62F6CA33300814E2E /* LoginWindowNamePasswordCheck.swift */; };
+		BCEA58142F6CA33300814E2E /* WritingToolsCheck.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCEA57FB2F6CA33300814E2E /* WritingToolsCheck.swift */; };
+		BCEA58152F6CA33300814E2E /* AMFIEnabledCheck.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCEA57DB2F6CA33300814E2E /* AMFIEnabledCheck.swift */; };
+		BCEA58162F6CA33300814E2E /* SafariStatusBarCheck.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCEA57F02F6CA33300814E2E /* SafariStatusBarCheck.swift */; };
+		BCEA58172F6CA33300814E2E /* AdminPasswordForSystemPrefsCheck.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCEA57DA2F6CA33300814E2E /* AdminPasswordForSystemPrefsCheck.swift */; };
+		BCEA58182F6CA33300814E2E /* MailSummarizationCheck.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCEA57E72F6CA33300814E2E /* MailSummarizationCheck.swift */; };
+		BCEA58192F6CA33300814E2E /* PasswordLockoutThresholdCheck.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCEA57E92F6CA33300814E2E /* PasswordLockoutThresholdCheck.swift */; };
+		BCEA581A2F6CA33300814E2E /* ShareMacAnalyticsCheck.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCEA57F12F6CA33300814E2E /* ShareMacAnalyticsCheck.swift */; };
+		BCEA581B2F6CA33300814E2E /* ShareWithAppDevelopersCheck.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCEA57F22F6CA33300814E2E /* ShareWithAppDevelopersCheck.swift */; };
+		BCEA581C2F6CA33300814E2E /* XProtectStatusCheck.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCEA57FC2F6CA33300814E2E /* XProtectStatusCheck.swift */; };
+		BCEA581D2F6CA33300814E2E /* SudoTTYTicketsCheck.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCEA57F92F6CA33300814E2E /* SudoTTYTicketsCheck.swift */; };
+		BCEA581E2F6CA33300814E2E /* AutomaticLoginDisabledCheck.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCEA57DD2F6CA33300814E2E /* AutomaticLoginDisabledCheck.swift */; };
+		BCEA581F2F6CA33300814E2E /* LoginScreenMessageCheck.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCEA57E52F6CA33300814E2E /* LoginScreenMessageCheck.swift */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+		AA0001112F6CA33300814E2E /* FixCommands.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FixCommands.swift; sourceTree = "<group>"; };
+		AA0002112F6CA33300814E2E /* FixManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FixManager.swift; sourceTree = "<group>"; };
+		AA0003112F6CA33300814E2E /* FixAllSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FixAllSheet.swift; sourceTree = "<group>"; };
+		AA0004112F6CA33300814E2E /* AuditLogger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuditLogger.swift; sourceTree = "<group>"; };
+		AA0005112F6CA33300814E2E /* LogViewerSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogViewerSheet.swift; sourceTree = "<group>"; };
+		BC6C516229D38E2100B85797 /* IcloudEnabled.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IcloudEnabled.swift; sourceTree = "<group>"; };
+		BC6C516429D390F800B85797 /* GuestLoginCheck.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GuestLoginCheck.swift; sourceTree = "<group>"; };
+		BC6C516629D3921400B85797 /* SiriStatusCheck.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SiriStatusCheck.swift; sourceTree = "<group>"; };
+		BC6C516829D3934500B85797 /* SecureKernelExtensionLoadingCheck.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecureKernelExtensionLoadingCheck.swift; sourceTree = "<group>"; };
+		BC6C516A29D5C81000B85797 /* DiagnosticDataCheck.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiagnosticDataCheck.swift; sourceTree = "<group>"; };
+		BC6C516C29D5C8C300B85797 /* Java6Check.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Java6Check.swift; sourceTree = "<group>"; };
+		BC6C516E29D5C9BC00B85797 /* EfiCheck.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EfiCheck.swift; sourceTree = "<group>"; };
+		BC6C517029D5CC5600B85797 /* BonjourCheck.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BonjourCheck.swift; sourceTree = "<group>"; };
+		BC6C517229D5CDE200B85797 /* ApacheHTTPCheck.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApacheHTTPCheck.swift; sourceTree = "<group>"; };
+		BC6C517429D60E9700B85797 /* NfsServerCheck.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NfsServerCheck.swift; sourceTree = "<group>"; };
+		BC6C517629D60F0C00B85797 /* PasswordHintsCheck.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PasswordHintsCheck.swift; sourceTree = "<group>"; };
+		BC6C517829D616AD00B85797 /* GuestConnectCheck.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GuestConnectCheck.swift; sourceTree = "<group>"; };
+		BC6C517A29D6174B00B85797 /* FileExtentionCheck.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileExtentionCheck.swift; sourceTree = "<group>"; };
+		BC6C517C29D617BE00B85797 /* SafariSafeFileChecks.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SafariSafeFileChecks.swift; sourceTree = "<group>"; };
+		BC6C517E29D6183F00B85797 /* SafariInternetPluginCheck.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SafariInternetPluginCheck.swift; sourceTree = "<group>"; };
+		BC6C518029D618BA00B85797 /* FastUserSwitchingCheck.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FastUserSwitchingCheck.swift; sourceTree = "<group>"; };
+		BC6C518229D7348400B85797 /* AppleSoftwareUpdateCheck.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppleSoftwareUpdateCheck.swift; sourceTree = "<group>"; };
+		BC6C518429D7820C00B85797 /* AutomaticSoftwareUpdateCheck.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutomaticSoftwareUpdateCheck.swift; sourceTree = "<group>"; };
+		BC6C518629D782EA00B85797 /* AppStoreUpdateCheck.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStoreUpdateCheck.swift; sourceTree = "<group>"; };
+		BC6C518929D7845300B85797 /* SecurityUpdateCheck.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecurityUpdateCheck.swift; sourceTree = "<group>"; };
+		BC6C518B29D7855700B85797 /* CriticalUpdateInstallCheck.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CriticalUpdateInstallCheck.swift; sourceTree = "<group>"; };
+		BC6C518D29D786A500B85797 /* FirewallStealthModeCheck.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirewallStealthModeCheck.swift; sourceTree = "<group>"; };
+		BC6C518F29D789B900B85797 /* AirDropDisabledCheck.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AirDropDisabledCheck.swift; sourceTree = "<group>"; };
+		BC6C519129D78A6700B85797 /* AirPlayReceiverDisabledCheck.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AirPlayReceiverDisabledCheck.swift; sourceTree = "<group>"; };
+		BC6C519329D78AFD00B85797 /* SetTimeAndDateAutomaticallyEnabledCheck.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SetTimeAndDateAutomaticallyEnabledCheck.swift; sourceTree = "<group>"; };
+		BC6C519529D78BD100B85797 /* TimeWithinLimitsCheck.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimeWithinLimitsCheck.swift; sourceTree = "<group>"; };
+		BC6C519729D7902500B85797 /* DVDOrCDSharingDisabledCheck.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DVDOrCDSharingDisabledCheck.swift; sourceTree = "<group>"; };
+		BC6C519929D7909C00B85797 /* ScreenSharingDisabledCheck.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScreenSharingDisabledCheck.swift; sourceTree = "<group>"; };
+		BC6C51A829D8200300B85797 /* TestPlan.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = TestPlan.xctestplan; sourceTree = "<group>"; };
+		BC876BF929DC2090002127F2 /* LocationServicesMenuBarCheck.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationServicesMenuBarCheck.swift; sourceTree = "<group>"; };
+		BC876BFB29DC263F002127F2 /* PersonalizedAds.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PersonalizedAds.swift; sourceTree = "<group>"; };
+		BC876BFD29DC27D5002127F2 /* ScreenSaverCornersCheck.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScreenSaverCornersCheck.swift; sourceTree = "<group>"; };
+		BC876BFF29DC29F2002127F2 /* UniversalControlCheck.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UniversalControlCheck.swift; sourceTree = "<group>"; };
+		BC876C0129DC4B95002127F2 /* WakeForNetworkAccessCheck.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WakeForNetworkAccessCheck.swift; sourceTree = "<group>"; };
+		BC876C0B29DC51EC002127F2 /* ScreenSaverIntervalCheck.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScreenSaverIntervalCheck.swift; sourceTree = "<group>"; };
+		BC876C0D29DC53D1002127F2 /* PasswordOnWakeCheck.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PasswordOnWakeCheck.swift; sourceTree = "<group>"; };
+		BC876C0F29DC5BDB002127F2 /* CheckAuditDisEnabled.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CheckAuditDisEnabled.swift; sourceTree = "<group>"; };
+		BC876C1529E0307E002127F2 /* HTMLReportGenerator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTMLReportGenerator.swift; sourceTree = "<group>"; };
+		BC876C1729E0322D002127F2 /* JSONReportGenerator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSONReportGenerator.swift; sourceTree = "<group>"; };
+		BCA6498729DACD37002FB952 /* FileSharingCheck.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileSharingCheck.swift; sourceTree = "<group>"; };
+		BCA6498929DACE72002FB952 /* PrinterSharingDisabledCheck.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrinterSharingDisabledCheck.swift; sourceTree = "<group>"; };
+		BCA6498B29DAD04C002FB952 /* RemoteLoginDisabledCheck.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteLoginDisabledCheck.swift; sourceTree = "<group>"; };
+		BCA6498D29DAD1C1002FB952 /* RemoteManagementCheck.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteManagementCheck.swift; sourceTree = "<group>"; };
+		BCA6498F29DAD35E002FB952 /* RemoteAppleEventsCheck.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteAppleEventsCheck.swift; sourceTree = "<group>"; };
+		BCA6499129DAD730002FB952 /* InternetSharingDisabledCheck.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InternetSharingDisabledCheck.swift; sourceTree = "<group>"; };
+		BCA6499329DB2776002FB952 /* SlowModule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SlowModule.swift; sourceTree = "<group>"; };
+		BCA6499529DB6699002FB952 /* ContentCachingDisabledCheck.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentCachingDisabledCheck.swift; sourceTree = "<group>"; };
+		BCA6499729DB6793002FB952 /* CheckMediaSharingDisabled.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CheckMediaSharingDisabled.swift; sourceTree = "<group>"; };
+		BCA6499929DB6854002FB952 /* BluetoothSharingDisabledCheck.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BluetoothSharingDisabledCheck.swift; sourceTree = "<group>"; };
+		BCA6499B29DB6A45002FB952 /* BackupAutomaticallyEnabledCheck.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackupAutomaticallyEnabledCheck.swift; sourceTree = "<group>"; };
+		BCA6499D29DB7351002FB952 /* CheckTimeMachineEnabled.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CheckTimeMachineEnabled.swift; sourceTree = "<group>"; };
+		BCA6499F29DB7502002FB952 /* TimeMachineVolumesEncryptedCheck.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimeMachineVolumesEncryptedCheck.swift; sourceTree = "<group>"; };
+		BCA649A129DB7845002FB952 /* ShowWifiMenuCheck.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShowWifiMenuCheck.swift; sourceTree = "<group>"; };
+		BCA649A329DB7920002FB952 /* BluetoothMenuCheck.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BluetoothMenuCheck.swift; sourceTree = "<group>"; };
+		BCA649A529DB79D2002FB952 /* LocationServicesCheck.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationServicesCheck.swift; sourceTree = "<group>"; };
+		BCD734C829CDF6A000C0B779 /* mergen.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = mergen.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		BCD734CB29CDF6A000C0B779 /* mergenApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = mergenApp.swift; sourceTree = "<group>"; };
+		BCD734CD29CDF6A000C0B779 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
+		BCD734CF29CDF6A200C0B779 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		BCD734D429CDF6A200C0B779 /* mergen.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = mergen.entitlements; sourceTree = "<group>"; };
+		BCD734E429CF137C00C0B779 /* Vulnerability.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Vulnerability.swift; sourceTree = "<group>"; };
+		BCD734E629CF13CF00C0B779 /* Scanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Scanner.swift; sourceTree = "<group>"; };
+		BCD734E929CF13FD00C0B779 /* GatekeeperBypassCheck.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GatekeeperBypassCheck.swift; sourceTree = "<group>"; };
+		BCD734EB29CF14C200C0B779 /* ScanResultView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScanResultView.swift; sourceTree = "<group>"; };
+		BCD734ED29CF1BAC00C0B779 /* FileVaultCheck.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileVaultCheck.swift; sourceTree = "<group>"; };
+		BCD734F129CF20FF00C0B779 /* ScanManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScanManager.swift; sourceTree = "<group>"; };
+		BCD734F329CF2B9700C0B779 /* VulnerabilityDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VulnerabilityDetailView.swift; sourceTree = "<group>"; };
+		BCD734F729CF45C900C0B779 /* SIPCheck.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SIPCheck.swift; sourceTree = "<group>"; };
+		BCD734F929CF472500C0B779 /* XProtectAndMRTCheck.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XProtectAndMRTCheck.swift; sourceTree = "<group>"; };
+		BCD734FB29CF47D800C0B779 /* FirewallCheck.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirewallCheck.swift; sourceTree = "<group>"; };
+		BCD734FF29D0732400C0B779 /* mergenRelease.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = mergenRelease.entitlements; sourceTree = "<group>"; };
+		BCD7350429D213E200C0B779 /* Preview Content */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = folder; name = "Preview Content"; path = "mergen/Preview Content"; sourceTree = SOURCE_ROOT; };
+		BCD7350629D2165700C0B779 /* Preview */ = {isa = PBXFileReference; lastKnownFileType = folder; path = Preview; sourceTree = "<group>"; };
+		BCD7350829D2218800C0B779 /* CertificateTrustCheck.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CertificateTrustCheck.swift; sourceTree = "<group>"; };
+		BCD7350C29D2415600C0B779 /* SshEnableCheck.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SshEnableCheck.swift; sourceTree = "<group>"; };
+		BCEA57DA2F6CA33300814E2E /* AdminPasswordForSystemPrefsCheck.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdminPasswordForSystemPrefsCheck.swift; sourceTree = "<group>"; };
+		BCEA57DB2F6CA33300814E2E /* AMFIEnabledCheck.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AMFIEnabledCheck.swift; sourceTree = "<group>"; };
+		BCEA57DC2F6CA33300814E2E /* AuditFlagsCheck.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuditFlagsCheck.swift; sourceTree = "<group>"; };
+		BCEA57DD2F6CA33300814E2E /* AutomaticLoginDisabledCheck.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutomaticLoginDisabledCheck.swift; sourceTree = "<group>"; };
+		BCEA57DE2F6CA33300814E2E /* ExternalIntelligenceExtensionsCheck.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExternalIntelligenceExtensionsCheck.swift; sourceTree = "<group>"; };
+		BCEA57DF2F6CA33300814E2E /* GuestHomeFolderCheck.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GuestHomeFolderCheck.swift; sourceTree = "<group>"; };
+		BCEA57E02F6CA33300814E2E /* HomeFolderPermissionsCheck.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeFolderPermissionsCheck.swift; sourceTree = "<group>"; };
+		BCEA57E12F6CA33300814E2E /* iCloudKeychainCheck.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = iCloudKeychainCheck.swift; sourceTree = "<group>"; };
+		BCEA57E22F6CA33300814E2E /* ImproveAssistiveVoiceCheck.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImproveAssistiveVoiceCheck.swift; sourceTree = "<group>"; };
+		BCEA57E32F6CA33300814E2E /* ImproveSiriDictationCheck.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImproveSiriDictationCheck.swift; sourceTree = "<group>"; };
+		BCEA57E42F6CA33300814E2E /* LockdownModeCheck.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LockdownModeCheck.swift; sourceTree = "<group>"; };
+		BCEA57E52F6CA33300814E2E /* LoginScreenMessageCheck.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginScreenMessageCheck.swift; sourceTree = "<group>"; };
+		BCEA57E62F6CA33300814E2E /* LoginWindowNamePasswordCheck.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginWindowNamePasswordCheck.swift; sourceTree = "<group>"; };
+		BCEA57E72F6CA33300814E2E /* MailSummarizationCheck.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MailSummarizationCheck.swift; sourceTree = "<group>"; };
+		BCEA57E82F6CA33300814E2E /* NotesSummarizationCheck.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotesSummarizationCheck.swift; sourceTree = "<group>"; };
+		BCEA57E92F6CA33300814E2E /* PasswordLockoutThresholdCheck.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PasswordLockoutThresholdCheck.swift; sourceTree = "<group>"; };
+		BCEA57EA2F6CA33300814E2E /* PasswordMinLengthCheck.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PasswordMinLengthCheck.swift; sourceTree = "<group>"; };
+		BCEA57EB2F6CA33300814E2E /* PowerNapDisabledCheck.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PowerNapDisabledCheck.swift; sourceTree = "<group>"; };
+		BCEA57EC2F6CA33300814E2E /* RootAccountDisabledCheck.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RootAccountDisabledCheck.swift; sourceTree = "<group>"; };
+		BCEA57ED2F6CA33300814E2E /* SafariAdvertisingPrivacyCheck.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SafariAdvertisingPrivacyCheck.swift; sourceTree = "<group>"; };
+		BCEA57EE2F6CA33300814E2E /* SafariCrossSiteTrackingCheck.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SafariCrossSiteTrackingCheck.swift; sourceTree = "<group>"; };
+		BCEA57EF2F6CA33300814E2E /* SafariFraudWarningCheck.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SafariFraudWarningCheck.swift; sourceTree = "<group>"; };
+		BCEA57F02F6CA33300814E2E /* SafariStatusBarCheck.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SafariStatusBarCheck.swift; sourceTree = "<group>"; };
+		BCEA57F12F6CA33300814E2E /* ShareMacAnalyticsCheck.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareMacAnalyticsCheck.swift; sourceTree = "<group>"; };
+		BCEA57F22F6CA33300814E2E /* ShareWithAppDevelopersCheck.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareWithAppDevelopersCheck.swift; sourceTree = "<group>"; };
+		BCEA57F32F6CA33300814E2E /* SleepEnabledAppleSiliconCheck.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SleepEnabledAppleSiliconCheck.swift; sourceTree = "<group>"; };
+		BCEA57F42F6CA33300814E2E /* SoftwareUpdateDefermentCheck.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SoftwareUpdateDefermentCheck.swift; sourceTree = "<group>"; };
+		BCEA57F52F6CA33300814E2E /* SpotlightImprovementCheck.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpotlightImprovementCheck.swift; sourceTree = "<group>"; };
+		BCEA57F62F6CA33300814E2E /* SSVEnabledCheck.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SSVEnabledCheck.swift; sourceTree = "<group>"; };
+		BCEA57F72F6CA33300814E2E /* SudoLoggingCheck.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SudoLoggingCheck.swift; sourceTree = "<group>"; };
+		BCEA57F82F6CA33300814E2E /* SudoTimeoutCheck.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SudoTimeoutCheck.swift; sourceTree = "<group>"; };
+		BCEA57F92F6CA33300814E2E /* SudoTTYTicketsCheck.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SudoTTYTicketsCheck.swift; sourceTree = "<group>"; };
+		BCEA57FA2F6CA33300814E2E /* TerminalSecureKeyboardCheck.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalSecureKeyboardCheck.swift; sourceTree = "<group>"; };
+		BCEA57FB2F6CA33300814E2E /* WritingToolsCheck.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WritingToolsCheck.swift; sourceTree = "<group>"; };
+		BCEA57FC2F6CA33300814E2E /* XProtectStatusCheck.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XProtectStatusCheck.swift; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		BCD734C529CDF6A000C0B779 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		BC6C518829D7833F00B85797 /* CISBenchmark */ = {
+			isa = PBXGroup;
+			children = (
+				BCEA57DA2F6CA33300814E2E /* AdminPasswordForSystemPrefsCheck.swift */,
+				BCEA57DB2F6CA33300814E2E /* AMFIEnabledCheck.swift */,
+				BCEA57DC2F6CA33300814E2E /* AuditFlagsCheck.swift */,
+				BCEA57DD2F6CA33300814E2E /* AutomaticLoginDisabledCheck.swift */,
+				BCEA57DE2F6CA33300814E2E /* ExternalIntelligenceExtensionsCheck.swift */,
+				BCEA57DF2F6CA33300814E2E /* GuestHomeFolderCheck.swift */,
+				BCEA57E02F6CA33300814E2E /* HomeFolderPermissionsCheck.swift */,
+				BCEA57E12F6CA33300814E2E /* iCloudKeychainCheck.swift */,
+				BCEA57E22F6CA33300814E2E /* ImproveAssistiveVoiceCheck.swift */,
+				BCEA57E32F6CA33300814E2E /* ImproveSiriDictationCheck.swift */,
+				BCEA57E42F6CA33300814E2E /* LockdownModeCheck.swift */,
+				BCEA57E52F6CA33300814E2E /* LoginScreenMessageCheck.swift */,
+				BCEA57E62F6CA33300814E2E /* LoginWindowNamePasswordCheck.swift */,
+				BCEA57E72F6CA33300814E2E /* MailSummarizationCheck.swift */,
+				BCEA57E82F6CA33300814E2E /* NotesSummarizationCheck.swift */,
+				BCEA57E92F6CA33300814E2E /* PasswordLockoutThresholdCheck.swift */,
+				BCEA57EA2F6CA33300814E2E /* PasswordMinLengthCheck.swift */,
+				BCEA57EB2F6CA33300814E2E /* PowerNapDisabledCheck.swift */,
+				BCEA57EC2F6CA33300814E2E /* RootAccountDisabledCheck.swift */,
+				BCEA57ED2F6CA33300814E2E /* SafariAdvertisingPrivacyCheck.swift */,
+				BCEA57EE2F6CA33300814E2E /* SafariCrossSiteTrackingCheck.swift */,
+				BCEA57EF2F6CA33300814E2E /* SafariFraudWarningCheck.swift */,
+				BCEA57F02F6CA33300814E2E /* SafariStatusBarCheck.swift */,
+				BCEA57F12F6CA33300814E2E /* ShareMacAnalyticsCheck.swift */,
+				BCEA57F22F6CA33300814E2E /* ShareWithAppDevelopersCheck.swift */,
+				BCEA57F32F6CA33300814E2E /* SleepEnabledAppleSiliconCheck.swift */,
+				BCEA57F42F6CA33300814E2E /* SoftwareUpdateDefermentCheck.swift */,
+				BCEA57F52F6CA33300814E2E /* SpotlightImprovementCheck.swift */,
+				BCEA57F62F6CA33300814E2E /* SSVEnabledCheck.swift */,
+				BCEA57F72F6CA33300814E2E /* SudoLoggingCheck.swift */,
+				BCEA57F82F6CA33300814E2E /* SudoTimeoutCheck.swift */,
+				BCEA57F92F6CA33300814E2E /* SudoTTYTicketsCheck.swift */,
+				BCEA57FA2F6CA33300814E2E /* TerminalSecureKeyboardCheck.swift */,
+				BCEA57FB2F6CA33300814E2E /* WritingToolsCheck.swift */,
+				BCEA57FC2F6CA33300814E2E /* XProtectStatusCheck.swift */,
+				BCD734E929CF13FD00C0B779 /* GatekeeperBypassCheck.swift */,
+				BC6C516829D3934500B85797 /* SecureKernelExtensionLoadingCheck.swift */,
+				BC6C516429D390F800B85797 /* GuestLoginCheck.swift */,
+				BC6C516229D38E2100B85797 /* IcloudEnabled.swift */,
+				BCD7350C29D2415600C0B779 /* SshEnableCheck.swift */,
+				BCD734FB29CF47D800C0B779 /* FirewallCheck.swift */,
+				BCD734ED29CF1BAC00C0B779 /* FileVaultCheck.swift */,
+				BC6C518229D7348400B85797 /* AppleSoftwareUpdateCheck.swift */,
+				BC6C518429D7820C00B85797 /* AutomaticSoftwareUpdateCheck.swift */,
+				BC6C518629D782EA00B85797 /* AppStoreUpdateCheck.swift */,
+				BC6C518929D7845300B85797 /* SecurityUpdateCheck.swift */,
+				BC6C518B29D7855700B85797 /* CriticalUpdateInstallCheck.swift */,
+				BC6C518D29D786A500B85797 /* FirewallStealthModeCheck.swift */,
+				BC6C518F29D789B900B85797 /* AirDropDisabledCheck.swift */,
+				BC6C519129D78A6700B85797 /* AirPlayReceiverDisabledCheck.swift */,
+				BC6C519329D78AFD00B85797 /* SetTimeAndDateAutomaticallyEnabledCheck.swift */,
+				BC6C519529D78BD100B85797 /* TimeWithinLimitsCheck.swift */,
+				BC6C519729D7902500B85797 /* DVDOrCDSharingDisabledCheck.swift */,
+				BC6C519929D7909C00B85797 /* ScreenSharingDisabledCheck.swift */,
+				BCA6498729DACD37002FB952 /* FileSharingCheck.swift */,
+				BCA6498929DACE72002FB952 /* PrinterSharingDisabledCheck.swift */,
+				BCA6498B29DAD04C002FB952 /* RemoteLoginDisabledCheck.swift */,
+				BCA6498D29DAD1C1002FB952 /* RemoteManagementCheck.swift */,
+				BCA6498F29DAD35E002FB952 /* RemoteAppleEventsCheck.swift */,
+				BCA6499129DAD730002FB952 /* InternetSharingDisabledCheck.swift */,
+				BCA6499329DB2776002FB952 /* SlowModule.swift */,
+				BCA6499529DB6699002FB952 /* ContentCachingDisabledCheck.swift */,
+				BCA6499729DB6793002FB952 /* CheckMediaSharingDisabled.swift */,
+				BCA6499929DB6854002FB952 /* BluetoothSharingDisabledCheck.swift */,
+				BCA6499B29DB6A45002FB952 /* BackupAutomaticallyEnabledCheck.swift */,
+				BCA6499D29DB7351002FB952 /* CheckTimeMachineEnabled.swift */,
+				BCA6499F29DB7502002FB952 /* TimeMachineVolumesEncryptedCheck.swift */,
+				BCA649A129DB7845002FB952 /* ShowWifiMenuCheck.swift */,
+				BCA649A329DB7920002FB952 /* BluetoothMenuCheck.swift */,
+				BCA649A529DB79D2002FB952 /* LocationServicesCheck.swift */,
+				BC876BF929DC2090002127F2 /* LocationServicesMenuBarCheck.swift */,
+				BC876BFB29DC263F002127F2 /* PersonalizedAds.swift */,
+				BC876BFD29DC27D5002127F2 /* ScreenSaverCornersCheck.swift */,
+				BC876BFF29DC29F2002127F2 /* UniversalControlCheck.swift */,
+				BC876C0129DC4B95002127F2 /* WakeForNetworkAccessCheck.swift */,
+				BC876C0B29DC51EC002127F2 /* ScreenSaverIntervalCheck.swift */,
+				BC876C0D29DC53D1002127F2 /* PasswordOnWakeCheck.swift */,
+				BC876C0F29DC5BDB002127F2 /* CheckAuditDisEnabled.swift */,
+			);
+			path = CISBenchmark;
+			sourceTree = "<group>";
+		};
+		BC6C51A529D81F8C00B85797 /* Tests */ = {
+			isa = PBXGroup;
+			children = (
+				BC6C51A829D8200300B85797 /* TestPlan.xctestplan */,
+			);
+			path = Tests;
+			sourceTree = "<group>";
+		};
+		BCD734BF29CDF6A000C0B779 = {
+			isa = PBXGroup;
+			children = (
+				BCD734CA29CDF6A000C0B779 /* mergen */,
+				BCD734C929CDF6A000C0B779 /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		BCD734C929CDF6A000C0B779 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				BCD734C829CDF6A000C0B779 /* mergen.app */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		BCD734CA29CDF6A000C0B779 /* mergen */ = {
+			isa = PBXGroup;
+			children = (
+				BC6C51A529D81F8C00B85797 /* Tests */,
+				BCD734E829CF13D800C0B779 /* core */,
+				BCD7350629D2165700C0B779 /* Preview */,
+				BCD7350429D213E200C0B779 /* Preview Content */,
+				BCD734FF29D0732400C0B779 /* mergenRelease.entitlements */,
+				BCD734E329CF12D400C0B779 /* checkmodules */,
+				BCD734DE29CEE31700C0B779 /* view */,
+				BCD734CB29CDF6A000C0B779 /* mergenApp.swift */,
+				BCD734CD29CDF6A000C0B779 /* ContentView.swift */,
+				BCD734CF29CDF6A200C0B779 /* Assets.xcassets */,
+				BCD734D429CDF6A200C0B779 /* mergen.entitlements */,
+			);
+			path = mergen;
+			sourceTree = "<group>";
+		};
+		BCD734DE29CEE31700C0B779 /* view */ = {
+			isa = PBXGroup;
+			children = (
+				BCD734EB29CF14C200C0B779 /* ScanResultView.swift */,
+				BCD734F329CF2B9700C0B779 /* VulnerabilityDetailView.swift */,
+				AA0003112F6CA33300814E2E /* FixAllSheet.swift */,
+				AA0005112F6CA33300814E2E /* LogViewerSheet.swift */,
+				BC876C1529E0307E002127F2 /* HTMLReportGenerator.swift */,
+				BC876C1729E0322D002127F2 /* JSONReportGenerator.swift */,
+			);
+			path = view;
+			sourceTree = "<group>";
+		};
+		BCD734E329CF12D400C0B779 /* checkmodules */ = {
+			isa = PBXGroup;
+			children = (
+				BC6C518829D7833F00B85797 /* CISBenchmark */,
+				BCD734F729CF45C900C0B779 /* SIPCheck.swift */,
+				BCD734F929CF472500C0B779 /* XProtectAndMRTCheck.swift */,
+				BCD7350829D2218800C0B779 /* CertificateTrustCheck.swift */,
+				BC6C516629D3921400B85797 /* SiriStatusCheck.swift */,
+				BC6C516A29D5C81000B85797 /* DiagnosticDataCheck.swift */,
+				BC6C516C29D5C8C300B85797 /* Java6Check.swift */,
+				BC6C516E29D5C9BC00B85797 /* EfiCheck.swift */,
+				BC6C517029D5CC5600B85797 /* BonjourCheck.swift */,
+				BC6C517229D5CDE200B85797 /* ApacheHTTPCheck.swift */,
+				BC6C517429D60E9700B85797 /* NfsServerCheck.swift */,
+				BC6C517629D60F0C00B85797 /* PasswordHintsCheck.swift */,
+				BC6C517829D616AD00B85797 /* GuestConnectCheck.swift */,
+				BC6C517A29D6174B00B85797 /* FileExtentionCheck.swift */,
+				BC6C517C29D617BE00B85797 /* SafariSafeFileChecks.swift */,
+				BC6C517E29D6183F00B85797 /* SafariInternetPluginCheck.swift */,
+				BC6C518029D618BA00B85797 /* FastUserSwitchingCheck.swift */,
+			);
+			path = checkmodules;
+			sourceTree = "<group>";
+		};
+		BCD734E829CF13D800C0B779 /* core */ = {
+			isa = PBXGroup;
+			children = (
+				BCD734E429CF137C00C0B779 /* Vulnerability.swift */,
+				BCD734E629CF13CF00C0B779 /* Scanner.swift */,
+				BCD734F129CF20FF00C0B779 /* ScanManager.swift */,
+				AA0001112F6CA33300814E2E /* FixCommands.swift */,
+				AA0002112F6CA33300814E2E /* FixManager.swift */,
+				AA0004112F6CA33300814E2E /* AuditLogger.swift */,
+			);
+			path = core;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		BCD734C729CDF6A000C0B779 /* mergen */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = BCD734D729CDF6A200C0B779 /* Build configuration list for PBXNativeTarget "mergen" */;
+			buildPhases = (
+				BCD734C429CDF6A000C0B779 /* Sources */,
+				BCD734C529CDF6A000C0B779 /* Frameworks */,
+				BCD734C629CDF6A000C0B779 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = mergen;
+			productName = mergen;
+			productReference = BCD734C829CDF6A000C0B779 /* mergen.app */;
+			productType = "com.apple.product-type.application";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		BCD734C029CDF6A000C0B779 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				BuildIndependentTargetsInParallel = 1;
+				LastSwiftUpdateCheck = 1420;
+				LastUpgradeCheck = 2630;
+				TargetAttributes = {
+					BCD734C729CDF6A000C0B779 = {
+						CreatedOnToolsVersion = 14.2;
+					};
+				};
+			};
+			buildConfigurationList = BCD734C329CDF6A000C0B779 /* Build configuration list for PBXProject "mergen" */;
+			compatibilityVersion = "Xcode 14.0";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = BCD734BF29CDF6A000C0B779;
+			productRefGroup = BCD734C929CDF6A000C0B779 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				BCD734C729CDF6A000C0B779 /* mergen */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		BCD734C629CDF6A000C0B779 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				BCD7350729D2165700C0B779 /* Preview in Resources */,
+				BCD7350529D213E200C0B779 /* Preview Content in Resources */,
+				BCD734D029CDF6A200C0B779 /* Assets.xcassets in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		BCD734C429CDF6A000C0B779 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				BCD734FC29CF47D800C0B779 /* FirewallCheck.swift in Sources */,
+				BC6C519029D789B900B85797 /* AirDropDisabledCheck.swift in Sources */,
+				BC6C517129D5CC5600B85797 /* BonjourCheck.swift in Sources */,
+				BC6C518A29D7845300B85797 /* SecurityUpdateCheck.swift in Sources */,
+				BCA6499429DB2776002FB952 /* SlowModule.swift in Sources */,
+				BC876C1829E0322D002127F2 /* JSONReportGenerator.swift in Sources */,
+				BC6C519229D78A6700B85797 /* AirPlayReceiverDisabledCheck.swift in Sources */,
+				BC6C516929D3934500B85797 /* SecureKernelExtensionLoadingCheck.swift in Sources */,
+				BC6C518729D782EA00B85797 /* AppStoreUpdateCheck.swift in Sources */,
+				BC876BFC29DC263F002127F2 /* PersonalizedAds.swift in Sources */,
+				BCD734E529CF137C00C0B779 /* Vulnerability.swift in Sources */,
+				BCA6498A29DACE72002FB952 /* PrinterSharingDisabledCheck.swift in Sources */,
+				BCEA57FD2F6CA33300814E2E /* PowerNapDisabledCheck.swift in Sources */,
+				BCEA57FE2F6CA33300814E2E /* SleepEnabledAppleSiliconCheck.swift in Sources */,
+				BCEA57FF2F6CA33300814E2E /* SafariCrossSiteTrackingCheck.swift in Sources */,
+				BCEA58002F6CA33300814E2E /* GuestHomeFolderCheck.swift in Sources */,
+				BCEA58012F6CA33300814E2E /* PasswordMinLengthCheck.swift in Sources */,
+				BCEA58022F6CA33300814E2E /* ImproveAssistiveVoiceCheck.swift in Sources */,
+				BCEA58032F6CA33300814E2E /* iCloudKeychainCheck.swift in Sources */,
+				BCEA58042F6CA33300814E2E /* SafariAdvertisingPrivacyCheck.swift in Sources */,
+				BCEA58052F6CA33300814E2E /* SudoTimeoutCheck.swift in Sources */,
+				BCEA58062F6CA33300814E2E /* HomeFolderPermissionsCheck.swift in Sources */,
+				BCEA58072F6CA33300814E2E /* ExternalIntelligenceExtensionsCheck.swift in Sources */,
+				BCEA58082F6CA33300814E2E /* ImproveSiriDictationCheck.swift in Sources */,
+				BCEA58092F6CA33300814E2E /* NotesSummarizationCheck.swift in Sources */,
+				BCEA580A2F6CA33300814E2E /* TerminalSecureKeyboardCheck.swift in Sources */,
+				BCEA580B2F6CA33300814E2E /* SafariFraudWarningCheck.swift in Sources */,
+				BCEA580C2F6CA33300814E2E /* LockdownModeCheck.swift in Sources */,
+				BCEA580D2F6CA33300814E2E /* RootAccountDisabledCheck.swift in Sources */,
+				BCEA580E2F6CA33300814E2E /* SSVEnabledCheck.swift in Sources */,
+				BCEA580F2F6CA33300814E2E /* SpotlightImprovementCheck.swift in Sources */,
+				BCEA58102F6CA33300814E2E /* SoftwareUpdateDefermentCheck.swift in Sources */,
+				BCEA58112F6CA33300814E2E /* AuditFlagsCheck.swift in Sources */,
+				BCEA58122F6CA33300814E2E /* SudoLoggingCheck.swift in Sources */,
+				BCEA58132F6CA33300814E2E /* LoginWindowNamePasswordCheck.swift in Sources */,
+				BCEA58142F6CA33300814E2E /* WritingToolsCheck.swift in Sources */,
+				BCEA58152F6CA33300814E2E /* AMFIEnabledCheck.swift in Sources */,
+				BCEA58162F6CA33300814E2E /* SafariStatusBarCheck.swift in Sources */,
+				BCEA58172F6CA33300814E2E /* AdminPasswordForSystemPrefsCheck.swift in Sources */,
+				BCEA58182F6CA33300814E2E /* MailSummarizationCheck.swift in Sources */,
+				BCEA58192F6CA33300814E2E /* PasswordLockoutThresholdCheck.swift in Sources */,
+				BCEA581A2F6CA33300814E2E /* ShareMacAnalyticsCheck.swift in Sources */,
+				BCEA581B2F6CA33300814E2E /* ShareWithAppDevelopersCheck.swift in Sources */,
+				BCEA581C2F6CA33300814E2E /* XProtectStatusCheck.swift in Sources */,
+				BCEA581D2F6CA33300814E2E /* SudoTTYTicketsCheck.swift in Sources */,
+				BCEA581E2F6CA33300814E2E /* AutomaticLoginDisabledCheck.swift in Sources */,
+				BCEA581F2F6CA33300814E2E /* LoginScreenMessageCheck.swift in Sources */,
+				BCD734CE29CDF6A000C0B779 /* ContentView.swift in Sources */,
+				BC6C518529D7820C00B85797 /* AutomaticSoftwareUpdateCheck.swift in Sources */,
+				BC876C1029DC5BDB002127F2 /* CheckAuditDisEnabled.swift in Sources */,
+				BCA6498829DACD37002FB952 /* FileSharingCheck.swift in Sources */,
+				BC6C517929D616AD00B85797 /* GuestConnectCheck.swift in Sources */,
+				BC6C519429D78AFD00B85797 /* SetTimeAndDateAutomaticallyEnabledCheck.swift in Sources */,
+				BCD7350929D2218800C0B779 /* CertificateTrustCheck.swift in Sources */,
+				BCD734FA29CF472500C0B779 /* XProtectAndMRTCheck.swift in Sources */,
+				BCA649A629DB79D2002FB952 /* LocationServicesCheck.swift in Sources */,
+				BC6C519A29D7909C00B85797 /* ScreenSharingDisabledCheck.swift in Sources */,
+				BC6C516529D390F800B85797 /* GuestLoginCheck.swift in Sources */,
+				BC876BFA29DC2090002127F2 /* LocationServicesMenuBarCheck.swift in Sources */,
+				BC876BFE29DC27D5002127F2 /* ScreenSaverCornersCheck.swift in Sources */,
+				BCA6499229DAD730002FB952 /* InternetSharingDisabledCheck.swift in Sources */,
+				BCD734CC29CDF6A000C0B779 /* mergenApp.swift in Sources */,
+				BC6C517D29D617BE00B85797 /* SafariSafeFileChecks.swift in Sources */,
+				BC6C516729D3921400B85797 /* SiriStatusCheck.swift in Sources */,
+				BC6C516F29D5C9BC00B85797 /* EfiCheck.swift in Sources */,
+				BC6C516B29D5C81000B85797 /* DiagnosticDataCheck.swift in Sources */,
+				BCA6499E29DB7351002FB952 /* CheckTimeMachineEnabled.swift in Sources */,
+				BCD734F829CF45C900C0B779 /* SIPCheck.swift in Sources */,
+				BCA649A029DB7502002FB952 /* TimeMachineVolumesEncryptedCheck.swift in Sources */,
+				BCD734EE29CF1BAC00C0B779 /* FileVaultCheck.swift in Sources */,
+				BCA6499029DAD35E002FB952 /* RemoteAppleEventsCheck.swift in Sources */,
+				BC6C517B29D6174B00B85797 /* FileExtentionCheck.swift in Sources */,
+				BCD734F429CF2B9700C0B779 /* VulnerabilityDetailView.swift in Sources */,
+				BCA6499629DB6699002FB952 /* ContentCachingDisabledCheck.swift in Sources */,
+				BC6C516329D38E2100B85797 /* IcloudEnabled.swift in Sources */,
+				BCA6498E29DAD1C1002FB952 /* RemoteManagementCheck.swift in Sources */,
+				BC6C517329D5CDE200B85797 /* ApacheHTTPCheck.swift in Sources */,
+				BC6C518E29D786A500B85797 /* FirewallStealthModeCheck.swift in Sources */,
+				BCD734EA29CF13FD00C0B779 /* GatekeeperBypassCheck.swift in Sources */,
+				BC876C0C29DC51EC002127F2 /* ScreenSaverIntervalCheck.swift in Sources */,
+				BC6C516D29D5C8C300B85797 /* Java6Check.swift in Sources */,
+				BCA649A429DB7920002FB952 /* BluetoothMenuCheck.swift in Sources */,
+				BC876C1629E0307E002127F2 /* HTMLReportGenerator.swift in Sources */,
+				BC6C519829D7902500B85797 /* DVDOrCDSharingDisabledCheck.swift in Sources */,
+				BCA6499829DB6793002FB952 /* CheckMediaSharingDisabled.swift in Sources */,
+				BC6C518329D7348400B85797 /* AppleSoftwareUpdateCheck.swift in Sources */,
+				BCD734F229CF20FF00C0B779 /* ScanManager.swift in Sources */,
+				BCD7350D29D2415600C0B779 /* SshEnableCheck.swift in Sources */,
+				BC6C519629D78BD100B85797 /* TimeWithinLimitsCheck.swift in Sources */,
+				BC876C0229DC4B95002127F2 /* WakeForNetworkAccessCheck.swift in Sources */,
+				BC6C518129D618BA00B85797 /* FastUserSwitchingCheck.swift in Sources */,
+				BC6C517729D60F0C00B85797 /* PasswordHintsCheck.swift in Sources */,
+				BC6C517529D60E9700B85797 /* NfsServerCheck.swift in Sources */,
+				BC876C0E29DC53D1002127F2 /* PasswordOnWakeCheck.swift in Sources */,
+				BC876C0029DC29F2002127F2 /* UniversalControlCheck.swift in Sources */,
+				BCA649A229DB7845002FB952 /* ShowWifiMenuCheck.swift in Sources */,
+				BCD734EC29CF14C200C0B779 /* ScanResultView.swift in Sources */,
+				BCA6499C29DB6A45002FB952 /* BackupAutomaticallyEnabledCheck.swift in Sources */,
+				BCA6498C29DAD04C002FB952 /* RemoteLoginDisabledCheck.swift in Sources */,
+				BC6C517F29D6183F00B85797 /* SafariInternetPluginCheck.swift in Sources */,
+				BCD734E729CF13CF00C0B779 /* Scanner.swift in Sources */,
+				BCA6499A29DB6854002FB952 /* BluetoothSharingDisabledCheck.swift in Sources */,
+				BC6C518C29D7855700B85797 /* CriticalUpdateInstallCheck.swift in Sources */,
+				AA0001122F6CA33300814E2E /* FixCommands.swift in Sources */,
+				AA0002122F6CA33300814E2E /* FixManager.swift in Sources */,
+				AA0003122F6CA33300814E2E /* FixAllSheet.swift in Sources */,
+				AA0004122F6CA33300814E2E /* AuditLogger.swift in Sources */,
+				AA0005122F6CA33300814E2E /* LogViewerSheet.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		BCD734D529CDF6A200C0B779 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEAD_CODE_STRIPPING = YES;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				MACOSX_DEPLOYMENT_TARGET = 12.0;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = macosx;
+				STRING_CATALOG_GENERATE_SYMBOLS = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+			};
+			name = Debug;
+		};
+		BCD734D629CDF6A200C0B779 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEAD_CODE_STRIPPING = YES;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				MACOSX_DEPLOYMENT_TARGET = 12.0;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = NO;
+				SDKROOT = macosx;
+				STRING_CATALOG_GENERATE_SYMBOLS = YES;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
+			};
+			name = Release;
+		};
+		BCD734D829CDF6A200C0B779 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_ENTITLEMENTS = mergen/mergen.entitlements;
+				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
+				CODE_SIGN_STYLE = Automatic;
+				COMBINE_HIDPI_IMAGES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				DEAD_CODE_STRIPPING = YES;
+				DEVELOPMENT_ASSET_PATHS = mergen/Preview;
+				DEVELOPMENT_TEAM = HK2X69GGZH;
+				ENABLE_PREVIEWS = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_CFBundleDisplayName = "Mergen v2 - Mac Security";
+				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.utilities";
+				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 13.5;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = sametsazak.mergen;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+			};
+			name = Debug;
+		};
+		BCD734D929CDF6A200C0B779 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_ENTITLEMENTS = mergen/mergenRelease.entitlements;
+				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
+				CODE_SIGN_STYLE = Automatic;
+				COMBINE_HIDPI_IMAGES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				DEAD_CODE_STRIPPING = YES;
+				DEVELOPMENT_ASSET_PATHS = mergen/Preview;
+				DEVELOPMENT_TEAM = HK2X69GGZH;
+				ENABLE_HARDENED_RUNTIME = YES;
+				ENABLE_PREVIEWS = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_CFBundleDisplayName = "Mergen v2 - Mac Security";
+				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.utilities";
+				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 13.5;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = sametsazak.mergen;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		BCD734C329CDF6A000C0B779 /* Build configuration list for PBXProject "mergen" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				BCD734D529CDF6A200C0B779 /* Debug */,
+				BCD734D629CDF6A200C0B779 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		BCD734D729CDF6A200C0B779 /* Build configuration list for PBXNativeTarget "mergen" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				BCD734D829CDF6A200C0B779 /* Debug */,
+				BCD734D929CDF6A200C0B779 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = BCD734C029CDF6A000C0B779 /* Project object */;
+}
+</file>
+
+<file path="mergen.xcodeproj/project.xcworkspace/contents.xcworkspacedata">
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>
+</file>
+
+<file path="mergen.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist">
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>
+</file>
+
+<file path="mergen/Assets.xcassets/AccentColor.colorset/Contents.json">
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "1.000",
+          "green" : "0.522",
+          "red" : "0.651"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "1.000",
+          "green" : "0.600",
+          "red" : "0.718"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}
+</file>
+
+<file path="mergen/Assets.xcassets/AppIcon.appiconset/Contents.json">
+{
+  "images" : [
+    {
+      "filename" : "mergenlogo-16.png",
+      "idiom" : "mac",
+      "scale" : "1x",
+      "size" : "16x16"
+    },
+    {
+      "filename" : "mergenlogo-32.png",
+      "idiom" : "mac",
+      "scale" : "2x",
+      "size" : "16x16"
+    },
+    {
+      "filename" : "mergenlogo-32 1.png",
+      "idiom" : "mac",
+      "scale" : "1x",
+      "size" : "32x32"
+    },
+    {
+      "filename" : "mergelogo-64.png",
+      "idiom" : "mac",
+      "scale" : "2x",
+      "size" : "32x32"
+    },
+    {
+      "filename" : "mergenlogo-128.png",
+      "idiom" : "mac",
+      "scale" : "1x",
+      "size" : "128x128"
+    },
+    {
+      "filename" : "mergelongo-256.png",
+      "idiom" : "mac",
+      "scale" : "2x",
+      "size" : "128x128"
+    },
+    {
+      "filename" : "mergelongo-256 1.png",
+      "idiom" : "mac",
+      "scale" : "1x",
+      "size" : "256x256"
+    },
+    {
+      "filename" : "mergenlogo-512.png",
+      "idiom" : "mac",
+      "scale" : "2x",
+      "size" : "256x256"
+    },
+    {
+      "filename" : "mergenlogo-512 1.png",
+      "idiom" : "mac",
+      "scale" : "1x",
+      "size" : "512x512"
+    },
+    {
+      "filename" : "mergenlogo-1024.png",
+      "idiom" : "mac",
+      "scale" : "2x",
+      "size" : "512x512"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}
+</file>
+
+<file path="mergen/Assets.xcassets/buttoncenter.colorset/Contents.json">
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xE2",
+          "green" : "0xE4",
+          "red" : "0xDF"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xE2",
+          "green" : "0xE4",
+          "red" : "0xDF"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}
+</file>
+
+<file path="mergen/Assets.xcassets/buttoncolor.colorset/Contents.json">
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xBF",
+          "green" : "0xBF",
+          "red" : "0xBF"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xBF",
+          "green" : "0xBF",
+          "red" : "0xBF"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}
+</file>
+
+<file path="mergen/Assets.xcassets/buttongradient1.colorset/Contents.json">
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xFB",
+          "green" : "0xFB",
+          "red" : "0xFB"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x57",
+          "green" : "0x57",
+          "red" : "0x57"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}
+</file>
+
+<file path="mergen/Assets.xcassets/buttongradient2.colorset/Contents.json">
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xF3",
+          "green" : "0xF3",
+          "red" : "0xF3"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x3F",
+          "green" : "0x3F",
+          "red" : "0x3F"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}
+</file>
+
+<file path="mergen/Assets.xcassets/buttonhover.colorset/Contents.json">
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "display-p3",
+        "components" : {
+          "alpha" : "0.840",
+          "blue" : "0xA2",
+          "green" : "0x7C",
+          "red" : "0x13"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "0.840",
+          "blue" : "0xA2",
+          "green" : "0x7C",
+          "red" : "0x13"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}
+</file>
+
+<file path="mergen/Assets.xcassets/cisBenchmark.imageset/Contents.json">
+{
+  "images" : [
+    {
+      "filename" : "cisbench3.png",
+      "idiom" : "universal",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "3x"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}
+</file>
+
+<file path="mergen/Assets.xcassets/Color.colorset/Contents.json">
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xFF",
+          "green" : "0xFF",
+          "red" : "0xFF"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xFF",
+          "green" : "0xFF",
+          "red" : "0xFF"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}
+</file>
+
+<file path="mergen/Assets.xcassets/Contents.json">
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}
+</file>
+
+<file path="mergen/Assets.xcassets/detail.colorset/Contents.json">
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "display-p3",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xE1",
+          "green" : "0xAA",
+          "red" : "0x79"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xE1",
+          "green" : "0xAA",
+          "red" : "0x79"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}
+</file>
+
+<file path="mergen/Assets.xcassets/framebackground.colorset/Contents.json">
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xCA",
+          "green" : "0xCB",
+          "red" : "0xC4"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xCA",
+          "green" : "0xCB",
+          "red" : "0xC4"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}
+</file>
+
+<file path="mergen/Assets.xcassets/Gradient.colorset/Contents.json">
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xED",
+          "green" : "0xEF",
+          "red" : "0xEB"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x24",
+          "green" : "0x24",
+          "red" : "0x24"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}
+</file>
+
+<file path="mergen/Assets.xcassets/Gradient2.colorset/Contents.json">
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xF1",
+          "green" : "0xF3",
+          "red" : "0xEF"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x24",
+          "green" : "0x25",
+          "red" : "0x24"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}
+</file>
+
+<file path="mergen/Assets.xcassets/Gradient3.colorset/Contents.json">
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xE5",
+          "green" : "0xE7",
+          "red" : "0xE1"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x24",
+          "green" : "0x24",
+          "red" : "0x23"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}
+</file>
+
+<file path="mergen/Assets.xcassets/grayish.colorset/Contents.json">
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xDE",
+          "green" : "0xDF",
+          "red" : "0xD8"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xDE",
+          "green" : "0xDF",
+          "red" : "0xD8"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}
+</file>
+
+<file path="mergen/Assets.xcassets/m1mini.imageset/Contents.json">
+{
+  "images" : [
+    {
+      "filename" : "mergenlogo4.png",
+      "idiom" : "universal",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "3x"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}
+</file>
+
+<file path="mergen/Assets.xcassets/privacy.imageset/Contents.json">
+{
+  "images" : [
+    {
+      "filename" : "icon_1.png",
+      "idiom" : "universal",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "3x"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}
+</file>
+
+<file path="mergen/Assets.xcassets/privacymain.imageset/Contents.json">
+{
+  "images" : [
+    {
+      "filename" : "mergenprivacy.png",
+      "idiom" : "universal",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "3x"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}
+</file>
+
+<file path="mergen/Assets.xcassets/progresscolor.colorset/Contents.json">
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x66",
+          "green" : "0x67",
+          "red" : "0x65"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x66",
+          "green" : "0x67",
+          "red" : "0x65"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}
+</file>
+
+<file path="mergen/Assets.xcassets/scanresult.colorset/Contents.json">
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xF1",
+          "green" : "0xF2",
+          "red" : "0xEE"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xF1",
+          "green" : "0xF2",
+          "red" : "0xEE"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}
+</file>
+
+<file path="mergen/Assets.xcassets/security.imageset/Contents.json">
+{
+  "images" : [
+    {
+      "filename" : "mergensecurity.png",
+      "idiom" : "universal",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "3x"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}
+</file>
+
+<file path="mergen/Assets.xcassets/toolcolor.colorset/Contents.json">
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xB4",
+          "green" : "0xA4",
+          "red" : "0x7C"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xB4",
+          "green" : "0xA4",
+          "red" : "0x7C"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}
+</file>
+
+<file path="mergen/Assets.xcassets/welcome.colorset/Contents.json">
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x54",
+          "green" : "0x54",
+          "red" : "0xF0"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x54",
+          "green" : "0x54",
+          "red" : "0xF0"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}
+</file>
+
+<file path="mergen/Assets.xcassets/welcometext.colorset/Contents.json">
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xCF",
+          "green" : "0xB1",
+          "red" : "0xA1"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xCF",
+          "green" : "0xB1",
+          "red" : "0xA1"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}
+</file>
+
+<file path="mergen/Assets.xcassets/yellown.colorset/Contents.json">
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x5C",
+          "green" : "0xD8",
+          "red" : "0xF6"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x5C",
+          "green" : "0xD8",
+          "red" : "0xF6"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}
+</file>
+
+<file path="mergen/checkmodules/ApacheHTTPCheck.swift">
+//
+//  ApacheHTTPCheck.swift
+//  mergen
+//
+//  Created by Samet Sazak
+//
+
+import Foundation
+
+class HttpServerCheck: Vulnerability {
+    init() {
+        super.init(
+            name: "Apache HTTP server disabled",
+            description: "This check ensures that the HTTP server is not running on your system, which helps protect against potential security vulnerabilities.",
+            category: "CIS Benchmark",
+            remediation: "To disable the built-in Apache server or configure it securely, follow the instructions in the provided documentation link.",
+            severity: "Medium",
+            documentation: "For more information on disabling or configuring the built-in Apache server, visit: https://support.apple.com/en-us/HT210060",
+            mitigation: "Disabling or securely configuring the built-in Apache server helps protect your system from security vulnerabilities associated with running an HTTP server.",
+            docID: 28, cisID: "4.2"
+        )
+    }
+
+    override func check() {
+        // Check whether httpd is actually running via launchctl, not config syntax
+        let task = Process()
+        task.executableURL = URL(fileURLWithPath: "/bin/launchctl")
+        task.arguments = ["list", "org.apache.httpd"]
+        task.standardOutput = Pipe()
+        task.standardError = Pipe()
+
+        do {
+            try task.run()
+            task.waitUntilExit()
+
+            if task.terminationStatus == 0 {
+                status = "Apache HTTP server is running."
+                checkstatus = "Red"
+            } else {
+                status = "Apache HTTP server is not running."
+                checkstatus = "Green"
+            }
+        } catch let e {
+            print("Error checking \(name): \(e)")
+            self.error = e
+            checkstatus = "Yellow"
+            status = "Error checking HTTP server status"
+        }
+    }
+}
+</file>
+
+<file path="mergen/checkmodules/AppSandboxCheck.swift">
+//
+//  AppSandboxCheck.swift
+//  mergen
+//
+//  Created by Samet Sazak on 27.03.2023.
+//
+
+import Foundation
+
+class AppSandboxCheck: Vulnerability {
+    init() {
+        super.init(
+            name: "App sandbox enforced",
+            description: "Check if App Sandbox is enabled for the current app",
+            category: "Security",
+            remediation: "Enable App Sandbox for the app using the entitlements file",
+            severity: "High",
+            documentation: "https://developer.apple.com/documentation/security/app_sandbox",
+            mitigation: "Enable App Sandbox for the app"
+        )
+    }
+    
+    override func check() {
+        let task = Process()
+        task.executableURL = URL(fileURLWithPath: "/usr/bin/codesign")
+        task.arguments = ["--display", "--entitlements", ":-", Bundle.main.bundlePath]
+        
+        let outputPipe = Pipe()
+        let errorPipe = Pipe()
+        task.standardOutput = outputPipe
+        task.standardError = errorPipe
+        
+        do {
+            try task.run()
+            task.waitUntilExit()
+            
+            let outputData = outputPipe.fileHandleForReading.readDataToEndOfFile()
+            let output = String(data: outputData, encoding: .utf8) ?? ""
+            let entitlements = try PropertyListSerialization.propertyList(from: output.data(using: .utf8)!, options: [], format: nil) as? [String: Any]
+            print("Entitlements: \(entitlements ?? [:])")
+            if let sandbox = entitlements?["com.apple.security.app-sandbox"] as? Bool {
+                if sandbox {
+                    status = "Not Vulnerable"
+                } else {
+                    status = "App Sandbox not enabled"
+                }
+            } else {
+                status = "Unknown"
+            }
+        } catch let e {
+            print("Error checking App Sandbox: \(e)")
+            self.error = e
+        }
+    }
+}
+</file>
+
+<file path="mergen/checkmodules/BonjourCheck.swift">
+//
+//  BonjourCheck.swift
+//  mergen
+//
+//  Created by Samet Sazak
+//
+
+import Foundation
+
+class BonjourCheck: Vulnerability {
+    init() {
+        super.init(
+            name: "Bonjour advertising disabled",
+            description: "Check if Bonjour advertising service is disabled. Bonjour is a service that helps devices and applications discover each other on a local network. Disabling it can help prevent unauthorized access to your computer.",
+            category: "CIS Benchmark",
+            remediation: "Disable Bonjour advertising service by going to System Settings > Sharing and unchecking all sharing services.",
+            severity: "Medium",
+            documentation: "https://support.apple.com/guide/mac-help/set-up-file-sharing-on-mac-mchlp1657/mac",
+            mitigation: "Disabling Bonjour advertising service reduces the attack surface and helps prevent unauthorized access to your computer.",
+            checkstatus: "",
+            docID: 27, cisID: "4.1"
+        )
+    }
+
+    override func check() {
+        let task = Process()
+        task.executableURL = URL(fileURLWithPath: "/usr/bin/defaults")
+        task.arguments = ["read", "/Library/Preferences/com.apple.mDNSResponder.plist", "NoMulticastAdvertisements"]
+
+        let outputPipe = Pipe()
+        task.standardOutput = outputPipe
+        task.standardError = Pipe()
+
+        do {
+            try task.run()
+            task.waitUntilExit()
+
+            let outputData = outputPipe.fileHandleForReading.readDataToEndOfFile()
+            let output = String(data: outputData, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+
+            if output.lowercased() == "1" {
+                status = "Bonjour service is not running."
+                checkstatus = "Green"
+            } else {
+                status = "Bonjour service is running."
+                checkstatus = "Red"
+            }
+        } catch let e {
+            print("Error checking \(name): \(e)")
+            self.error = e
+            checkstatus = "Yellow"
+            status = "Error checking Bonjour status"
+        }
+    }
+}
+</file>
+
+<file path="mergen/checkmodules/CertificateTrustCheck.swift">
+//
+//  CertificateTrustCheck.swift
+//  mergen
+//
+//  Created by Samet Sazak
+//
+
+import Foundation
+
+class CertificateTrustCheck: Vulnerability {
+    init() {
+        super.init(
+            name: "Certificate trust settings valid",
+            description: "Check for potential issues with trusted certificates",
+            category: "Security",
+            remediation: "Review certificate trust settings and remove any untrusted or expired certificates",
+            severity: "High",
+            documentation: "This code checks the trust settings of certificates on your system. Trust settings determine whether your computer trusts specific certificates, such as those used for secure websites. Untrusted or expired certificates can pose security risks, such as allowing unauthorized access to sensitive information.",
+            mitigation: "Review the certificate trust settings on your system and remove any untrusted or expired certificates. You can do this by opening Keychain Access, navigating to the 'Certificates' category, and inspecting the certificates listed. Look for any certificates marked as 'untrusted' or 'expired' and remove them.",
+            checkstatus: "",
+            docID: 22
+        )
+    }
+
+    override func check() {
+        let task = Process()
+        task.executableURL = URL(fileURLWithPath: "/usr/bin/security")
+        task.arguments = ["dump-trust-settings"]
+
+        let outputPipe = Pipe()
+        task.standardOutput = outputPipe
+
+        let errorPipe = Pipe()
+        task.standardError = errorPipe
+
+        do {
+            try task.run()
+            task.waitUntilExit()
+
+            let outputData = outputPipe.fileHandleForReading.readDataToEndOfFile()
+            let output = String(data: outputData, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+            let errorOutput = String(data: errorPipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8)?
+                .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+
+            if output.contains("No Trust Settings were found.") || errorOutput.contains("No Trust Settings were found.") {
+                status = "Certificate trust is OK."
+                checkstatus = "Green"
+            } else {
+                status = "Certificate trust issues found"
+                checkstatus = "Red"
+            }
+        } catch let e {
+            print("Error checking \(name): \(e)")
+            self.error = e
+            checkstatus = "Yellow"
+            status = "Error checking certificate trust settings"
+        }
+    }
+}
+</file>
+
+<file path="mergen/checkmodules/CISBenchmark/AdminPasswordForSystemPrefsCheck.swift">
+//
+//  AdminPasswordForSystemPrefsCheck.swift
+//  mergen
+//
+//  CIS 2.6.8 - Ensure an Administrator Password Is Required to Access System-Wide Preferences
+
+import Foundation
+
+class AdminPasswordForSystemPrefsCheck: Vulnerability {
+    init() {
+        super.init(
+            name: "Admin Password Required for System-Wide Preferences",
+            description: "System-wide preferences like Network, Startup Disk, and Time Machine should require an administrator password. This prevents users from making changes that affect the entire system.",
+            category: "CIS Benchmark",
+            remediation: "Go to System Settings > Privacy & Security > Advanced and enable 'Require an administrator password to access system-wide settings'. Or use: security authorizationdb write system.preferences allow-root false",
+            severity: "Medium",
+            documentation: "CIS Apple macOS 26 Tahoe Benchmark v1.0.0 - Recommendation 2.6.8",
+            mitigation: "Requiring admin authentication for system preferences reduces the risk of unauthorized configuration changes.",
+            checkstatus: "",
+            docID: 109,
+            cisID: "2.6.8"
+        )
+    }
+
+    override func check() {
+        let task = Process()
+        task.executableURL = URL(fileURLWithPath: "/usr/bin/security")
+        task.arguments = ["authorizationdb", "read", "system.preferences"]
+
+        let outputPipe = Pipe()
+        let errorPipe = Pipe()
+        task.standardOutput = outputPipe
+        task.standardError = errorPipe
+
+        do {
+            try task.run()
+            task.waitUntilExit()
+
+            let output = String(data: outputPipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
+
+            // Check that shared is false AND group is admin
+            let hasSharedFalse = output.contains("<key>shared</key>") &&
+                output.contains("<false/>")
+            let hasAdminGroup = output.contains("<string>admin</string>")
+
+            if hasSharedFalse && hasAdminGroup {
+                status = "Admin password is required for system-wide preferences."
+                checkstatus = "Green"
+            } else {
+                status = "Admin password may not be required for system-wide preferences."
+                checkstatus = "Red"
+            }
+        } catch let e {
+            print("Error checking \(name): \(e)")
+            self.error = e
+            checkstatus = "Yellow"
+            status = "Error checking system preferences authorization"
+        }
+    }
+}
+</file>
+
+<file path="mergen/checkmodules/CISBenchmark/AirDropDisabledCheck.swift">
+//
+//  AirDropDisabledCheck.swift
+//  mergen
+//
+//  Created by Samet Sazak
+//
+
+import Foundation
+//This script uses the ps aux command to check if the AirPlayXPCHelper process is running. If the process is running, it indicates that AirPlay Receiver is enabled; otherwise, it is disabled.
+//Since this is not a certain way to understand Airplay is enabled, I couldn't find a solution except this. Based on CIS,         task.executableURL = URL(fileURLWithPath: "/usr/bin/defaults")
+// task.arguments = ["read", "com.apple.NetworkBrowser", "DisableAirDrop"]
+
+class AirDropDisabledCheck: Vulnerability {
+    init() {
+        super.init(
+            name: "AirDrop disabled",
+            description: "AirDrop is a convenient way to share files between Apple devices, but it can also pose a security risk if not used properly. This check verifies if AirDrop is disabled.",
+            category: "CIS Benchmark",
+            remediation: "To disable AirDrop, open Finder, click on 'Go' in the menu bar, select 'AirDrop', then click on 'Allow me to be discovered by:' and choose 'No One'.",
+            severity: "Medium",
+            documentation: "For more information about AirDrop and how to disable it, visit: https://support.apple.com/guide/mac-help/share-files-with-airdrop-mh17133/mac",
+            mitigation: "Disabling AirDrop helps prevent unauthorized access to your computer and protects your data from being intercepted by unauthorized users. It is recommended to disable AirDrop when not in use and enable it only when needed.",
+            checkstatus: "",
+            docID: 13, cisID: "2.3.1.1"
+        )
+    }
+
+    override func check() {
+        let task = Process()
+        task.executableURL = URL(fileURLWithPath: "/usr/bin/defaults")
+        task.arguments = ["read", "com.apple.NetworkBrowser", "DisableAirDrop"]
+        let outputPipe = Pipe()
+        task.standardOutput = outputPipe
+        task.standardError = Pipe()
+
+        do {
+            try task.run()
+            task.waitUntilExit()
+
+            let outputData = outputPipe.fileHandleForReading.readDataToEndOfFile()
+            let output = String(data: outputData, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+
+            if output.lowercased() == "1" {
+                status = "AirDrop Is Disabled"
+                checkstatus = "Green"
+            } else {
+                status = "AirDrop Is Enabled"
+                checkstatus = "Red"
+                
+            }
+        } catch let e {
+            print("Error checking \(name): \(e)")
+            checkstatus = "Yellow"
+            status = "Error checking AirDrop status"
+            self.error = e
+        }
+    }
+}
+</file>
+
+<file path="mergen/checkmodules/CISBenchmark/AirPlayReceiverDisabledCheck.swift">
+//
+//  AirPlayReceiverDisabledCheck.swift
+//  mergen
+//
+//  Created by Samet Sazak
+//
+
+
+import Foundation
+
+class AirPlayReceiverDisabledCheck: Vulnerability {
+    init() {
+        super.init(
+            name: "AirPlay Receiver disabled",
+            description: "AirPlay Receiver allows you to mirror your Mac's screen on other devices, like Apple TV. This check verifies if AirPlay Receiver is disabled.",
+            category: "CIS Benchmark",
+            remediation: "To disable AirPlay Receiver, go to 'System Settings', click on 'Displays', and uncheck 'Show mirroring options in the menu bar when available'.",
+            severity: "Medium",
+            documentation: "For more information about AirPlay Receiver and how to disable it, visit: https://support.apple.com/guide/mac-help/mirror-the-screen-on-a-mac-with-mirroring-display-preferences-mh14127/mac",
+            mitigation: "Disabling AirPlay Receiver reduces the risk of unauthorized access to your computer by preventing unauthorized users from mirroring your Mac's screen on their devices. It is recommended to disable AirPlay Receiver when not in use.",
+            checkstatus: "",
+            docID: 14, cisID: "2.3.1.2"
+        )
+    }
+
+    override func check() {
+        let task = Process()
+        task.executableURL = URL(fileURLWithPath: "/usr/bin/defaults")
+        task.arguments = ["read", "com.apple.controlcenter", "AirplayRecieverEnabled"]
+
+        let outputPipe = Pipe()
+        task.standardOutput = outputPipe
+        task.standardError = Pipe()
+
+        do {
+            try task.run()
+            task.waitUntilExit()
+
+            let output = String(data: outputPipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8)?
+                .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+
+            if output == "0" || task.terminationStatus != 0 {
+                status = "AirPlay Receiver is Disabled"
+                checkstatus = "Green"
+            } else {
+                status = "AirPlay Receiver is Enabled"
+                checkstatus = "Red"
+            }
+        } catch let e {
+            print("Error checking \(name): \(e)")
+            checkstatus = "Yellow"
+            status = "Error checking AirPlay Receiver status"
+            self.error = e
+        }
+    }
+}
+</file>
+
+<file path="mergen/checkmodules/CISBenchmark/AMFIEnabledCheck.swift">
+//
+//  AMFIEnabledCheck.swift
+//  mergen
+//
+//  CIS 5.1.3 - Ensure Apple Mobile File Integrity (AMFI) Is Enabled
+
+import Foundation
+
+class AMFIEnabledCheck: Vulnerability {
+    init() {
+        super.init(
+            name: "Apple Mobile File Integrity (AMFI) Is Enabled",
+            description: "AMFI is the macOS kernel module that enforces code-signing and library validation. Disabling it allows unsigned code to run, significantly weakening system security.",
+            category: "CIS Benchmark",
+            remediation: "Run: sudo nvram boot-args='' to clear any boot arguments that disable AMFI. Note: AMFI cannot be disabled while SIP is enabled.",
+            severity: "High",
+            documentation: "CIS Apple macOS 26 Tahoe Benchmark v1.0.0 - Recommendation 5.1.3",
+            mitigation: "AMFI ensures that only properly signed code runs on the system, preventing execution of malicious or tampered applications.",
+            checkstatus: "",
+            docID: 116,
+            cisID: "5.1.3"
+        )
+    }
+
+    override func check() {
+        let task = Process()
+        task.executableURL = URL(fileURLWithPath: "/usr/sbin/nvram")
+        task.arguments = ["-p"]
+
+        let outputPipe = Pipe()
+        task.standardOutput = outputPipe
+        task.standardError = Pipe()
+
+        do {
+            try task.run()
+            task.waitUntilExit()
+
+            let output = String(data: outputPipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
+
+            if output.contains("amfi_get_out_of_my_way=1") {
+                status = "AMFI is disabled via boot argument amfi_get_out_of_my_way=1."
+                checkstatus = "Red"
+            } else {
+                status = "AMFI is enabled (no disabling boot argument found)."
+                checkstatus = "Green"
+            }
+        } catch let e {
+            print("Error checking \(name): \(e)")
+            self.error = e
+            checkstatus = "Yellow"
+            status = "Error checking AMFI status"
+        }
+    }
+}
+</file>
+
+<file path="mergen/checkmodules/CISBenchmark/AppleSoftwareUpdateCheck.swift">
+//
+//  AppleSoftwareUpdateCheck.swift
+//  mergen
+//
+//  Created by Samet Sazak
+//
+
+//Tested in 13-inch, 2020, Four Thunderbolt 3 ports 13.2.1 (22D68)
+
+import Foundation
+
+class AppleSoftwareUpdateCheck: Vulnerability {
+    init() {
+        super.init(
+            name: "Apple software updated within 30 days",
+            description: "Checks if all Apple-provided software is up-to-date using the Software Update tool.",
+            category: "CIS Benchmark",
+            remediation: "Run the Software Update tool to install the latest security patches and software updates from Apple.",
+            severity: "High",
+            documentation: "https://support.apple.com/en-us/HT201541",
+            mitigation: "Regularly updating all Apple-provided software helps prevent unauthorized access and minimizes the risk of known vulnerabilities being exploited.",
+            checkstatus: "",
+            docID: 7, cisID: "1.1"
+        )
+    }
+
+    override func check() {
+        let task = Process()
+        task.executableURL = URL(fileURLWithPath: "/usr/bin/defaults")
+        task.arguments = ["read", "/Library/Preferences/com.apple.SoftwareUpdate", "LastFullSuccessfulDate"]
+
+        let outputPipe = Pipe()
+        task.standardOutput = outputPipe
+        task.standardError = Pipe()
+
+        do {
+            try task.run()
+            task.waitUntilExit()
+
+            let outputData = outputPipe.fileHandleForReading.readDataToEndOfFile()
+            let output = String(data: outputData, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+
+            let dateFormatter = DateFormatter()
+            dateFormatter.dateFormat = "yyyy-MM-dd HH:mm:ss Z"
+
+            if let lastUpdateDate = dateFormatter.date(from: output) {
+                let daysSinceLastUpdate = Calendar.current.dateComponents([.day], from: lastUpdateDate, to: Date()).day ?? 0
+
+                if daysSinceLastUpdate <= 30 {
+                    status = "Apple-provided Software is Updated in the last 30 days."
+                    checkstatus = "Green"
+                } else {
+                    status = "Apple-provided Software is NOT Updated In The Last 30 days."
+                    checkstatus = "Red"
+                }
+            } else {
+                status = "Apple-provided Software is NOT Updated In The Last 30 days."
+                checkstatus = "Red"
+            }
+        } catch let e {
+            print("Error checking \(name): \(e)")
+            self.error = e
+            checkstatus = "Yellow"
+            status = "Error checking Apple software update status"
+        }
+    }
+}
+</file>
+
+<file path="mergen/checkmodules/CISBenchmark/AppStoreUpdateCheck.swift">
+//
+//  AppStoreUpdateCheck.swift
+//  mergen
+//
+//  Created by Samet Sazak
+//
+
+//Tested in 13-inch, 2020, Four Thunderbolt 3 ports 13.2.1 (22D68)
+
+import Foundation
+
+class AppStoreUpdatesCheck: Vulnerability {
+    init() {
+        super.init(
+            name: "App Store auto-updates enabled",
+            description: "Check if 'Install app updates from the App Store' is enabled in the App Store preferences",
+            category: "CIS Benchmark",
+            remediation: "Enable 'Install app updates from the App Store' in the App Store preferences",
+            severity: "Medium",
+            documentation: "https://support.apple.com/en-us/HT202180",
+            mitigation: "Enabling automatic installation of app updates from the App Store helps ensure that security patches and software updates are installed in a timely manner.",
+            docID: 9, cisID: "1.4"
+        )
+    }
+
+    override func check() {
+        let task = Process()
+        task.executableURL = URL(fileURLWithPath: "/usr/bin/defaults")
+        // CIS 1.4: App Store app updates use AutoUpdate in com.apple.commerce
+        task.arguments = ["read", "/Library/Preferences/com.apple.commerce", "AutoUpdate"]
+
+        let outputPipe = Pipe()
+        task.standardOutput = outputPipe
+        task.standardError = Pipe()
+
+        do {
+            try task.run()
+            task.waitUntilExit()
+
+            let outputData = outputPipe.fileHandleForReading.readDataToEndOfFile()
+            let output = String(data: outputData, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+
+            if output.lowercased() == "1" {
+                status = "Install app updates from the App Store' is enabled"
+                checkstatus = "Green"
+            } else {
+                status = "Install app updates from the App Store' is Not enabled"
+                checkstatus = "Red"
+            }
+        } catch let e {
+            print("Error checking \(name): \(e)")
+            checkstatus = "Yellow"
+            status = "Error checking App Store update status"
+            self.error = e
+        }
+    }
+}
+</file>
+
+<file path="mergen/checkmodules/CISBenchmark/AuditFlagsCheck.swift">
+//
+//  AuditFlagsCheck.swift
+//  mergen
+//
+//  CIS 3.3 - Ensure Audit Flags Are Configured Correctly
+
+import Foundation
+
+class AuditFlagsCheck: Vulnerability {
+    init() {
+        super.init(
+            name: "Audit Flags Are Configured Correctly",
+            description: "The macOS audit system (BSM/auditd) should be configured to log authentication, authorization, and administrative events to support forensic investigation and incident response.",
+            category: "CIS Benchmark",
+            remediation: "Edit /etc/security/audit_control and ensure flags include: lo,aa,ad,fd,fm,-all. Run 'sudo audit -s' to reload audit configuration.",
+            severity: "Medium",
+            documentation: "CIS Apple macOS 26 Tahoe Benchmark v1.0.0 - Recommendation 3.3",
+            mitigation: "Proper audit flags ensure that authentication events, failed access attempts, and administrative actions are logged for security monitoring.",
+            checkstatus: "",
+            docID: 134,
+            cisID: "3.3",
+            isManual: false
+        )
+    }
+
+    override func check() {
+        // /etc/security/audit_control was removed in macOS 26 Tahoe along with BSM/auditd.
+        // Check if the file exists before trying to read it.
+        guard FileManager.default.fileExists(atPath: "/etc/security/audit_control") else {
+            status = "BSM audit_control not found. On macOS 26 Tahoe+, BSM/auditd was removed and replaced by Unified Logging."
+            checkstatus = "Yellow"
+            return
+        }
+
+        let task = Process()
+        task.executableURL = URL(fileURLWithPath: "/usr/bin/grep")
+        task.arguments = ["^flags:", "/etc/security/audit_control"]
+
+        let outputPipe = Pipe()
+        task.standardOutput = outputPipe
+        task.standardError = Pipe()
+
+        do {
+            try task.run()
+            task.waitUntilExit()
+
+            let output = String(data: outputPipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8)?
+                .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+
+            // CIS requires: lo,aa,ad,fd,fm,-all
+            let requiredFlags = ["lo", "aa", "ad", "fd", "fm"]
+            let hasAllFlags = requiredFlags.allSatisfy { output.contains($0) }
+
+            if hasAllFlags {
+                status = "Audit flags include required events: \(output)"
+                checkstatus = "Green"
+            } else if output.isEmpty {
+                status = "Audit flags not configured. Required: lo,aa,ad,fd,fm,-all"
+                checkstatus = "Red"
+            } else {
+                status = "Audit flags may be incomplete: \(output). Required: lo,aa,ad,fd,fm,-all"
+                checkstatus = "Yellow"
+            }
+        } catch {
+            checkstatus = "Yellow"
+            status = "Could not read audit configuration."
+        }
+    }
+}
+</file>
+
+<file path="mergen/checkmodules/CISBenchmark/AutomaticLoginDisabledCheck.swift">
+//
+//  AutomaticLoginDisabledCheck.swift
+//  mergen
+//
+//  CIS 2.13.3 - Ensure Automatic Login Is Disabled
+
+import Foundation
+
+class AutomaticLoginDisabledCheck: Vulnerability {
+    init() {
+        super.init(
+            name: "Automatic Login Is Disabled",
+            description: "Automatic login allows a computer to bypass the login window and log in as a specific user. This exposes the system to anyone with physical access.",
+            category: "CIS Benchmark",
+            remediation: "Go to System Settings > Lock Screen and disable 'Automatically log in as'. Or run: sudo defaults delete /Library/Preferences/com.apple.loginwindow autoLoginUser",
+            severity: "High",
+            documentation: "CIS Apple macOS 26 Tahoe Benchmark v1.0.0 - Recommendation 2.13.3",
+            mitigation: "Disabling automatic login ensures physical access to the machine does not grant immediate access to the user session.",
+            checkstatus: "",
+            docID: 115,
+            cisID: "2.13.3"
+        )
+    }
+
+    override func check() {
+        let task = Process()
+        task.executableURL = URL(fileURLWithPath: "/usr/bin/env")
+        task.arguments = ["defaults", "read", "/Library/Preferences/com.apple.loginwindow", "autoLoginUser"]
+
+        let outputPipe = Pipe()
+        let errorPipe = Pipe()
+        task.standardOutput = outputPipe
+        task.standardError = errorPipe
+
+        do {
+            try task.run()
+            task.waitUntilExit()
+
+            let output = String(data: outputPipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8)?
+                .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+            let errorOutput = String(data: errorPipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
+
+            if output.isEmpty || errorOutput.contains("does not exist") {
+                status = "Automatic login is disabled."
+                checkstatus = "Green"
+            } else {
+                status = "Automatic login is enabled for user: \(output)."
+                checkstatus = "Red"
+            }
+        } catch let e {
+            print("Error checking \(name): \(e)")
+            self.error = e
+            checkstatus = "Yellow"
+            status = "Error checking automatic login status"
+        }
+    }
+}
+</file>
+
+<file path="mergen/checkmodules/CISBenchmark/AutomaticSoftwareUpdateCheck.swift">
+//
+//  AutomaticSoftwareUpdateCheck.swift
+//  mergen
+//
+//  Created by Samet Sazak
+//
+
+//Tested in 13-inch, 2020, Four Thunderbolt 3 ports 13.2.1 (22D68)
+
+import Foundation
+
+class AutomaticSoftwareUpdateCheck: Vulnerability {
+    init() {
+        super.init(
+            name: "Auto-update enabled",
+            description: "Checks if the 'Download new updates when available' option is enabled in the App Store preferences.",
+            category: "CIS Benchmark",
+            remediation: """
+                Enable the 'Download new updates when available' option in the App Store preferences:
+
+                1. Open 'System Settings' on your Mac.
+                2. Click on 'Software Update'.
+                3. Check the box next to 'Automatically keep my Mac up to date'.
+                4. Click the 'Advanced...' button.
+                5. Make sure the 'Download new updates when available' option is checked.
+            """,
+            severity: "Medium",
+            documentation: "https://support.apple.com/en-us/HT202180",
+            mitigation: "Enabling automatic download of new updates ensures that your device receives important security patches and software updates in a timely manner.",
+            checkstatus: "",
+            docID: 8, cisID: "1.3"
+        )
+    }
+
+    override func check() {
+        // CIS 1.3: AutomaticDownload controls whether new updates are downloaded automatically.
+        // This is in com.apple.SoftwareUpdate, not com.apple.commerce (which is for App Store, CIS 1.4).
+        let task = Process()
+        task.executableURL = URL(fileURLWithPath: "/usr/bin/defaults")
+        task.arguments = ["read", "/Library/Preferences/com.apple.SoftwareUpdate", "AutomaticDownload"]
+
+        let outputPipe = Pipe()
+        task.standardOutput = outputPipe
+        task.standardError = Pipe()
+
+        do {
+            try task.run()
+            task.waitUntilExit()
+
+            let output = String(data: outputPipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8)?
+                .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+
+            if output == "1" {
+                status = "Download New Updates When Available Is Enabled"
+                checkstatus = "Green"
+            } else {
+                status = "Download New Updates When Available Is Not Enabled"
+                checkstatus = "Red"
+            }
+        } catch let e {
+            print("Error checking \(name): \(e)")
+            checkstatus = "Yellow"
+            status = "Error checking automatic software update status"
+            self.error = e
+        }
+    }
+}
+</file>
+
+<file path="mergen/checkmodules/CISBenchmark/BackupAutomaticallyEnabledCheck.swift">
+//
+//  BackupAutomaticallyEnabledCheck.swift
+//  mergen
+//
+//  Created by Samet Sazak
+//
+
+import Foundation
+
+class BackupAutomaticallyCheck: Vulnerability {
+    init() {
+        super.init(
+            name: "Time Machine backup enabled",
+            description: "Time Machine is a backup utility that helps to protect your data. This check ensures that if Time Machine is enabled, Backup Automatically is also enabled.",
+            category: "CIS Benchmark",
+            remediation: "To enable Backup Automatically, go to 'System Settings', click on 'Time Machine', and check the 'Backup Automatically' option.",
+            severity: "Medium",
+            documentation: "For more information about Time Machine and Backup Automatically, visit: https://support.apple.com/guide/mac-help/what-is-time-machine-mh15139/mac",
+            mitigation: "Enabling Backup Automatically helps to ensure that your system is regularly backed up, which helps prevent data loss and aids in data recovery if needed.",
+            docID: 45, cisID: "2.3.4.1"
+        )
+    }
+
+    override func check() {
+        let fileManager = FileManager.default
+        let filePath = "/Library/Preferences/com.apple.TimeMachine.plist"
+
+        if fileManager.fileExists(atPath: filePath) {
+            let task = Process()
+            task.executableURL = URL(fileURLWithPath: "/usr/bin/defaults")
+            task.arguments = ["read", filePath, "AutoBackup"]
+
+            let outputPipe = Pipe()
+            task.standardOutput = outputPipe
+            do {
+                try task.run()
+                task.waitUntilExit()
+
+                if task.terminationStatus == 0 {
+                    let outputData = outputPipe.fileHandleForReading.readDataToEndOfFile()
+                    let outputString = String(data: outputData, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines)
+
+                    if let autoBackup = outputString, autoBackup == "1" {
+                        status = "Backup Automatically is Enabled"
+                        checkstatus = "Green"
+                    } else {
+                        status = "Backup Automatically is Disabled"
+                        checkstatus = "Red"
+                    }
+                } else {
+                    status = "Error checking Time Machine status"
+                    checkstatus = "Yellow"
+                    self.error = NSError(domain: NSPOSIXErrorDomain, code: Int(task.terminationStatus), userInfo: nil)
+                }
+            } catch let e {
+                print("Error checking \(name): \(e)")
+                checkstatus = "Yellow"
+                status = "Error checking Time Machine status"
+                self.error = e
+            }
+        } else {
+            status = "Time Machine is Disabled"
+            checkstatus = "Red"
+        }
+    }
+}
+</file>
+
+<file path="mergen/checkmodules/CISBenchmark/BluetoothMenuCheck.swift">
+//
+//  BluetoothMenuCheck.swift
+//  mergen
+//
+//  Created by Samet Sazak
+//
+
+
+import Foundation
+
+class BluetoothMenuBarCheck: Vulnerability {
+    init() {
+        super.init(
+            name: "Bluetooth status shown in menu bar",
+            description: "This check ensures that the Bluetooth menu bar icon is displayed, allowing you to quickly check the status of your Bluetooth devices and disconnect any devices that you're not using.",
+            category: "CIS Benchmark",
+            remediation: "To enable 'Show Bluetooth in menu bar', go to System Settings > Bluetooth and check the option.",
+            severity: "Low",
+            documentation: "For more information on how to use Bluetooth devices with your Mac, visit: https://support.apple.com/guide/mac-help/use-bluetooth-devices-mchlpt1030/mac",
+            mitigation: "Displaying the Bluetooth menu bar icon helps you quickly monitor and manage your Bluetooth devices.",
+            docID: 49
+        )
+    }
+    
+    override func check() {
+        let task = Process()
+        task.executableURL = URL(fileURLWithPath: "/usr/bin/defaults")
+        task.arguments = ["read", "com.apple.controlcenter.plist", "NSStatusItem Visible Bluetooth"]
+
+        do {
+            let outputPipe = Pipe()
+            task.standardOutput = outputPipe
+        task.standardError = Pipe()
+            try task.run()
+            task.waitUntilExit()
+
+            if task.terminationStatus == 0 {
+                let outputData = outputPipe.fileHandleForReading.readDataToEndOfFile()
+                let outputString = String(data: outputData, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines)
+                if outputString == "1" {
+                    status = "Show Bluetooth Status in Menu Bar is Enabled"
+                    checkstatus = "Green"
+                } else {
+                    status = "Show Bluetooth Status in Menu Bar is Disabled"
+                    checkstatus = "Red"
+                }
+            } else {
+                status = "Error checking Show Bluetooth Status in Menu Bar status"
+                checkstatus = "Yellow"
+                self.error = NSError(domain: NSPOSIXErrorDomain, code: Int(task.terminationStatus), userInfo: nil)
+            }
+        } catch let e {
+            print("Error checking \(name): \(e)")
+            checkstatus = "Yellow"
+            status = "Error checking Show Bluetooth Status in Menu Bar status"
+            self.error = e
+            print(e)
+        }
+    }
+}
+</file>
+
+<file path="mergen/checkmodules/CISBenchmark/BluetoothSharingDisabledCheck.swift">
+//
+//  BluetoothSharingDisabledCheck.swift
+//  mergen
+//
+//  Created by Samet Sazak
+//
+
+//This check runs the defaults read command with the com.apple.Bluetooth domain and the PrefKeyServicesEnabled key to check the status of Bluetooth Sharing. If the value of the key is 0, it sets the status to "Bluetooth Sharing is Disabled" and the check status to "Green". If the value of the key is anything else, it sets the status to "Bluetooth Sharing is Enabled" and the check status to "Red".
+
+
+import Foundation
+
+class BluetoothSharingDisabledCheck: Vulnerability {
+    init() {
+        super.init(
+            name: "Bluetooth sharing disabled",
+            description: "Check if Bluetooth Sharing is disabled",
+            category: "CIS Benchmark",
+            remediation: "Disable Bluetooth Sharing in System Settings",
+            severity: "Medium",
+            documentation: "This check runs the defaults read command with the com.apple.Bluetooth domain and the PrefKeyServicesEnabled key to check the status of Bluetooth Sharing. If the value of the key is 0, it sets the status to 'Bluetooth Sharing is Disabled'",
+            mitigation: "Disabling Bluetooth Sharing reduces the attack surface and helps prevent unauthorized access to your computer.",
+            docID: 44, cisID: "2.3.3.10"
+        )
+    }
+
+    override func check() {
+        let task = Process()
+        task.executableURL = URL(fileURLWithPath: "/usr/bin/defaults")
+        task.arguments = ["-currentHost", "read", "com.apple.Bluetooth", "PrefKeyServicesEnabled"]
+
+        do {
+            let outputPipe = Pipe()
+            task.standardOutput = outputPipe
+        task.standardError = Pipe()
+            try task.run()
+            task.waitUntilExit()
+
+            if task.terminationStatus == 0 {
+                let outputData = outputPipe.fileHandleForReading.readDataToEndOfFile()
+                let outputString = String(data: outputData, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines)
+                if outputString == "0" {
+                    status = "Bluetooth Sharing is Disabled"
+                    checkstatus = "Green"
+                } else {
+                    status = "Bluetooth Sharing is Enabled"
+                    checkstatus = "Red"
+                }
+            } else {
+                status = "Error checking Bluetooth Sharing status"
+                checkstatus = "Yellow"
+                self.error = NSError(domain: NSPOSIXErrorDomain, code: Int(task.terminationStatus), userInfo: nil)
+            }
+        } catch let e {
+            print("Error checking \(name): \(e)")
+            checkstatus = "Yellow"
+            status = "Error checking Bluetooth Sharing status"
+            self.error = e
+            print(e)
+        }
+    }
+}
+</file>
+
+<file path="mergen/checkmodules/CISBenchmark/CheckAuditDisEnabled.swift">
+//
+//  CheckAuditDisEnabled.swift
+//  mergen
+//
+//  Created by Samet Sazak
+//
+
+
+import Foundation
+
+// This module checks if the com.apple.auditd service is running, which indicates security auditing is enabled.
+// A check status of "Green" means security auditing is enabled; "Red" means it is not; "Yellow" indicates an error.
+
+class SecurityAuditingCheck: Vulnerability {
+
+    init() {
+        super.init(
+            name: "Security auditing enabled",
+            description: "This checks if security auditing is enabled on your computer. Security auditing helps detect unauthorized access and protect sensitive data.",
+            category: "CIS Benchmark",
+            remediation: "Enable security auditing.",
+            severity: "Low",
+            documentation: "Security auditing helps detect unauthorized access to a user's system and sensitive data. This code checks if the com.apple.auditd service is running, which indicates security auditing is enabled.",
+            mitigation: "Enable security auditing to ensure security events are logged and monitored.",
+            docID: 59, cisID: "3.1"
+        )
+    }
+
+    override func check() {
+        let task = Process()
+        task.executableURL = URL(fileURLWithPath: "/bin/launchctl")
+        task.arguments = ["list", "com.apple.auditd"]
+
+        let pipe = Pipe()
+        let errPipe = Pipe()
+        task.standardOutput = pipe
+        task.standardError = errPipe
+
+        do {
+            try task.run()
+            task.waitUntilExit()
+            let output = String(data: pipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
+            let errOutput = String(data: errPipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
+            let combined = output + errOutput
+
+            if combined.contains("com.apple.auditd") && !combined.contains("Could not find") {
+                status = "Security auditing (BSM/auditd) is enabled."
+                checkstatus = "Green"
+            } else {
+                // BSM/auditd was removed from macOS 26 Tahoe. Apple replaced it with
+                // the Unified Log (log stream/log show). This check is no longer applicable
+                // on Tahoe and newer systems.
+                status = "BSM audit daemon not found. On macOS 26 Tahoe+, BSM/auditd was removed and replaced by Unified Logging."
+                checkstatus = "Yellow"
+            }
+        } catch let e {
+            print("Error checking \(name): \(e)")
+            checkstatus = "Yellow"
+            status = "Error checking security auditing status."
+            self.error = e
+        }
+    }
+}
+</file>
+
+<file path="mergen/checkmodules/CISBenchmark/CheckMediaSharingDisabled.swift">
+//
+//  CheckMediaSharingDisabled.swift
+//  mergen
+//
+//  Created by Samet Sazak
+//
+
+//This script uses the defaults command to read the value of the home-sharing-enabled key in the com.apple.amp.mediasharingd domain. If the value is 1, it means Media Sharing is enabled, and the status is set to "Media Sharing is Enabled" with a check status of "Red". If the value is 0, it means Media Sharing is disabled, and the status is set to "Media Sharing is Disabled" with a check status of "Green".
+
+import Foundation
+
+class MediaSharingDisabledCheck: Vulnerability {
+    init() {
+        super.init(
+            name: "Media sharing disabled",
+            description: "Media Sharing allows your computer to share media with other devices. This check ensures that Media Sharing is disabled to protect your computer from unauthorized access.",
+            category: "CIS Benchmark",
+            remediation: "To disable Media Sharing, go to 'System Settings', click on 'Sharing', and uncheck the 'Media Sharing' option.",
+            severity: "Medium",
+            documentation: "For more information about Media Sharing and how to disable it, visit: https://support.apple.com/en-us/HT202190",
+            mitigation: "Disabling Media Sharing reduces the attack surface and helps prevent unauthorized access to your computer. This minimizes the ways an attacker can connect to your system and helps protect your media files from unauthorized access.",
+            docID: 43, cisID: "2.3.3.9"
+        )
+    }
+
+    override func check() {
+        let task = Process()
+        task.executableURL = URL(fileURLWithPath: "/usr/bin/defaults")
+        task.arguments = ["read", "com.apple.amp.mediasharingd", "home-sharing-enabled"]
+
+        do {
+            let outputPipe = Pipe()
+            task.standardOutput = outputPipe
+        task.standardError = Pipe()
+            try task.run()
+            task.waitUntilExit()
+
+            if task.terminationStatus == 0 {
+                let outputData = outputPipe.fileHandleForReading.readDataToEndOfFile()
+                let outputString = String(data: outputData, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines)
+                if outputString == "1" {
+                    status = "Media Sharing is Enabled"
+                    checkstatus = "Red"
+                } else {
+                    status = "Media Sharing is Disabled"
+                    checkstatus = "Green"
+                }
+            } else {
+                status = "Error checking Media Sharing status"
+                checkstatus = "Yellow"
+                self.error = NSError(domain: NSPOSIXErrorDomain, code: Int(task.terminationStatus), userInfo: nil)
+            }
+        } catch let e {
+            print("Error checking \(name): \(e)")
+            checkstatus = "Yellow"
+            status = "Error checking Media Sharing status"
+            self.error = e
+            print(e)
+        }
+    }
+}
+</file>
+
+<file path="mergen/checkmodules/CISBenchmark/CheckTimeMachineEnabled.swift">
+//
+//  CheckTimeMachineEnabled.swift
+//  mergen
+//
+//  Created by Samet Sazak
+//
+
+import Foundation
+
+class TimeMachineEnabledCheck: Vulnerability {
+    init() {
+        super.init(
+            name: "Time Machine enabled",
+            description: "Check if Time Machine is enabled and has completed a backup",
+            category: "CIS Benchmark",
+            remediation: "Enable Time Machine in System Settings and run a backup",
+            severity: "Medium",
+            documentation: "https://support.apple.com/guide/mac-help/what-is-time-machine-mh15139/mac",
+            mitigation: "Enabling Time Machine and running regular backups helps to ensure that your system is regularly backed up to prevent data loss.",
+            docID: 46,
+            cisID: "2.3.4.1"
+        )
+    }
+    
+    override func check() {
+        // Check whether Time Machine has a configured destination (enabled),
+        // not whether a backup is currently running.
+        let task = Process()
+        task.executableURL = URL(fileURLWithPath: "/usr/bin/tmutil")
+        task.arguments = ["destinationinfo"]
+        let outputPipe = Pipe()
+        task.standardOutput = outputPipe
+        task.standardError = Pipe()
+        do {
+            try task.run()
+            task.waitUntilExit()
+
+            let output = String(data: outputPipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8)?
+                .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+
+            if output.contains("Name") || output.contains("Kind") {
+                status = "Time Machine is enabled and has a backup destination configured."
+                checkstatus = "Green"
+            } else {
+                status = "Time Machine has no backup destination configured."
+                checkstatus = "Red"
+            }
+        } catch let e {
+            print("Error checking \(name): \(e)")
+            checkstatus = "Yellow"
+            status = "Error checking Time Machine status"
+            self.error = e
+        }
+    }
+}
+</file>
+
+<file path="mergen/checkmodules/CISBenchmark/ContentCachingDisabledCheck.swift">
+//
+//  ContentCachingDisabledCheck.swift
+//  mergen
+//
+//  Created by Samet Sazak
+//
+
+import Foundation
+
+
+//The main use case for Mac computers is as mobile user endpoints. P2P sharing
+//services should not be enabled on laptops that are using untrusted networks. Content
+//Caching can allow a computer to be a server for local nodes on an untrusted network.
+//While there are certainly logical controls that could be used to mitigate risk, they add to
+//the management complexity. Since the value of the service is in specific use cases
+//organizations with the use case described above can accept risk as necessary.
+                                                    
+                                                    
+class ContentCachingDisabledCheck: Vulnerability {
+    init() {
+        super.init(
+            name: "Content caching disabled",
+            description: "This check ensures that Content Caching is disabled to prevent your computer from being a server on untrusted networks, which could expose it to unauthorized access.",
+            category: "CIS Benchmark",
+            remediation: "To disable Content Caching, go to System Settings > Sharing and uncheck the 'Content Caching' option.",
+            severity: "Medium",
+            documentation: "https://support.apple.com/guide/mac-help/use-content-caching-on-mac-mchl7f772b81/mac",
+            mitigation: "Disabling Content Caching lowers the risk of unauthorized access to your computer by reducing the ways an attacker can access cached content from your system.",
+            docID: 42, cisID: "2.3.3.8"
+        )
+    }
+
+    override func check() {
+        let task = Process()
+        task.executableURL = URL(fileURLWithPath: "/usr/bin/defaults")
+        task.arguments = ["read", "/Library/Preferences/com.apple.AssetCache.plist", "Activated"]
+
+        do {
+            let outputPipe = Pipe()
+            task.standardOutput = outputPipe
+        task.standardError = Pipe()
+            try task.run()
+            task.waitUntilExit()
+
+            let outputData = outputPipe.fileHandleForReading.readDataToEndOfFile()
+            let outputString = String(data: outputData, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines)
+
+            if task.terminationStatus != 0 || outputString == nil || outputString == "" {
+                // Plist absent = Content Caching has never been activated.
+                status = "Content Caching is disabled."
+                checkstatus = "Green"
+            } else if outputString == "1" {
+                status = "Content Caching is enabled."
+                checkstatus = "Red"
+            } else {
+                status = "Content Caching is disabled."
+                checkstatus = "Green"
+            }
+        } catch let e {
+            print("Error checking \(name): \(e)")
+            checkstatus = "Yellow"
+            status = "Error checking Content Caching status"
+            self.error = e
+        }
+    }
+}
+</file>
+
+<file path="mergen/checkmodules/CISBenchmark/CriticalUpdateInstallCheck.swift">
+//
+//  CriticalUpdateInstallCheck.swift
+//  mergen
+//
+//  Created by Samet Sazak
+//
+
+//Since macOS Big Sur, the option to delay software updates has been removed from the system preferences. Therefore, it is not possible to check for a deferment period in newer macOS versions. This module checks for CriticalUpdateInstall check.
+//Tested in 13-inch, 2020, Four Thunderbolt 3 ports 13.2.1 (22D68)
+
+import Foundation
+
+class CriticalUpdateInstallCheck: Vulnerability {
+    init() {
+        super.init(
+            name: "Critical updates auto-install enabled",
+            description: "Check if 'Install system data files and security updates' is enabled in the Software Update preferences",
+            category: "CIS Benchmark",
+            remediation: "Enable 'Install system data files and security updates' in the Software Update preferences",
+            severity: "Medium",
+            documentation: "https://support.apple.com/en-us/HT202180",
+            mitigation: "Enabling the installation of system data files and security updates helps ensure that critical updates are installed in a timely manner.",
+            docID: 12, cisID: "1.2"
+        )
+    }
+
+    override func check() {
+        let task = Process()
+        task.executableURL = URL(fileURLWithPath: "/usr/bin/defaults")
+        task.arguments = ["read", "/Library/Preferences/com.apple.SoftwareUpdate", "CriticalUpdateInstall"]
+
+        let outputPipe = Pipe()
+        task.standardOutput = outputPipe
+        task.standardError = Pipe()
+
+        do {
+            try task.run()
+            task.waitUntilExit()
+
+            let outputData = outputPipe.fileHandleForReading.readDataToEndOfFile()
+            let output = String(data: outputData, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+
+            if output.lowercased() == "1" {
+                status = "'Install system data files and security updates' is enabled"
+                checkstatus = "Green"
+            } else {
+                status = "'Install system data files and security updates' is not enabled"
+                checkstatus = "Red"
+            }
+        } catch let e {
+            print("Error checking \(name): \(e)")
+            checkstatus = "Yellow"
+            status = "Error checking critical update install status"
+            self.error = e
+        }
+    }
+}
+</file>
+
+<file path="mergen/checkmodules/CISBenchmark/DVDOrCDSharingDisabledCheck.swift">
+//
+//  DVDOrCDSharingDisabledCheck.swift
+//  mergen
+//
+//  Created by Samet Sazak
+//
+
+import Foundation
+
+class DVDOrCDSharingDisabledCheck: Vulnerability {
+    init() {
+        super.init(
+            name: "DVD/CD sharing disabled",
+            description: "This check ensures that your DVD or CD Sharing feature is disabled to prevent unauthorized access to your computer.",
+            category: "CIS Benchmark",
+            remediation: "To disable DVD or CD Sharing, go to System Settings > Sharing and uncheck the 'DVD or CD Sharing' option.",
+            severity: "Medium",
+            documentation: "https://support.apple.com/guide/mac-help/share-files-between-mac-computers-using-cd-or-dvd-sharing-mh15149/mac",
+            mitigation: "Disabling DVD or CD Sharing reduces the risk of unauthorized access to your computer's files and resources by minimizing the ways an attacker can connect to your system.",
+            docID: 17
+        )
+    }
+
+    override func check() {
+        let task = Process()
+        task.executableURL = URL(fileURLWithPath: "/bin/launchctl")
+        task.arguments = ["list", "com.apple.ODSAgent"]
+
+        do {
+            try task.run()
+            task.waitUntilExit()
+
+            if task.terminationStatus == 0 {
+                status = "DVD or CD Sharing is Disabled"
+                checkstatus = "Green"
+            } else {
+                status = "DVD or CD Sharing is Enabled"
+                checkstatus = "Red"
+            }
+        } catch let e {
+            print("Error checking \(name): \(e)")
+            checkstatus = "Yellow"
+            status = "Error checking DVD or CD Sharing status"
+            self.error = e
+        }
+    }
+}
+</file>
+
+<file path="mergen/checkmodules/CISBenchmark/ExternalIntelligenceExtensionsCheck.swift">
+//
+//  ExternalIntelligenceExtensionsCheck.swift
+//  mergen
+//
+//  CIS 2.5.1.1 - Ensure External Intelligence Extensions Is Disabled
+
+import Foundation
+
+class ExternalIntelligenceExtensionsCheck: Vulnerability {
+    init() {
+        super.init(
+            name: "Apple Intelligence External Extensions Disabled",
+            description: "External Intelligence Extensions allow Apple Intelligence to interface with 3rd party generative AI tools (e.g. ChatGPT). Sending data to external services introduces additional risk.",
+            category: "CIS Benchmark",
+            remediation: "Create an MDM profile with PayloadType com.apple.applicationaccess, set allowExternalIntelligenceIntegrations to false and allowExternalIntelligenceIntegrationsSignIn to false.",
+            severity: "Medium",
+            documentation: "CIS Apple macOS 26 Tahoe Benchmark v1.0.0 - Recommendation 2.5.1.1",
+            mitigation: "Disabling external intelligence extensions prevents organizational data from being sent to third-party AI providers.",
+            checkstatus: "",
+            docID: 101,
+            cisID: "2.5.1.1"
+        )
+    }
+
+    override func check() {
+        let task = Process()
+        task.executableURL = URL(fileURLWithPath: "/usr/bin/osascript")
+        task.arguments = ["-l", "JavaScript", "-e",
+            "$.NSUserDefaults.alloc.initWithSuiteName('com.apple.applicationaccess').objectForKey('allowExternalIntelligenceIntegrations').js"]
+
+        let outputPipe = Pipe()
+        let errorPipe = Pipe()
+        task.standardOutput = outputPipe
+        task.standardError = errorPipe
+
+        do {
+            try task.run()
+            task.waitUntilExit()
+
+            let output = String(data: outputPipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8)?
+                .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+
+            if output == "false" {
+                status = "External Intelligence Extensions are disabled."
+                checkstatus = "Green"
+            } else if output == "true" {
+                status = "External Intelligence Extensions are enabled."
+                checkstatus = "Red"
+            } else {
+                status = "No MDM profile found. External Intelligence Extensions state unknown."
+                checkstatus = "Yellow"
+            }
+        } catch let e {
+            print("Error checking \(name): \(e)")
+            self.error = e
+            checkstatus = "Yellow"
+            status = "Error checking Apple Intelligence external extensions"
+        }
+    }
+}
+</file>
+
+<file path="mergen/checkmodules/CISBenchmark/FileSharingCheck.swift">
+//
+//  FileSharingCheck.swift
+//  mergen
+//
+//  Created by Samet Sazak
+//
+
+import Foundation
+
+class FileSharingDisabledCheck: Vulnerability {
+    init() {
+        super.init(
+            name: "File sharing disabled",
+            description: "File Sharing allows you to share files and resources with other users over a network. This check ensures that File Sharing is disabled to prevent unauthorized access to your files and resources.",
+            category: "CIS Benchmark",
+            remediation: "To disable File Sharing, go to 'System Settings', click on 'Sharing', and uncheck the 'File Sharing' option.",
+            severity: "Medium",
+            documentation: "For more information about File Sharing and how to disable it, visit: https://support.apple.com/guide/mac-help/file-sharing-overview-mh17131/mac",
+            mitigation: "Disabling File Sharing reduces the risk of unauthorized access to your computer's files and resources. This minimizes the ways an attacker can connect to your system and helps protect your data from unauthorized access.",
+            docID: 36, cisID: "2.3.3.2"
+        )
+    }
+
+    override func check() {
+        let task = Process()
+        task.executableURL = URL(fileURLWithPath: "/bin/launchctl")
+        task.arguments = ["print-disabled", "system"]
+
+        do {
+            let outputPipe = Pipe()
+            task.standardOutput = outputPipe
+        task.standardError = Pipe()
+            try task.run()
+            task.waitUntilExit()
+
+            let outputData = outputPipe.fileHandleForReading.readDataToEndOfFile()
+            let outputString = String(data: outputData, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines)
+
+            if let output = outputString, output.contains("\"com.apple.smbd\" => enabled") {
+                status = "File Sharing is Enabled"
+                checkstatus = "Red"
+            } else {
+                status = "File Sharing is Disabled"
+                checkstatus = "Green"
+            }
+        } catch let e {
+            print("Error checking \(name): \(e)")
+            checkstatus = "Yellow"
+            status = "Error checking File Sharing status"
+            self.error = e
+        }
+    }
+}
+</file>
+
+<file path="mergen/checkmodules/CISBenchmark/FileVaultCheck.swift">
+//
+//  FileVaultCheck.swift
+//  mergen
+//
+//  Created by Samet Sazak
+//
+
+//Tested in 13-inch, 2020, Four Thunderbolt 3 ports 13.2.1 (22D68)
+
+import Foundation
+
+class FileVaultCheck: Vulnerability {
+    init() {
+        super.init(
+            name: "FileVault enabled",
+            description: "FileVault is a built-in disk encryption feature on macOS. This check verifies if FileVault is enabled or disabled on your device.",
+            category: "CIS Benchmark",
+            remediation: "To enable FileVault, go to System Settings -> Security & Privacy -> FileVault, and click 'Turn On FileVault...'",
+            severity: "High",
+            documentation: "For more information about FileVault, visit: https://support.apple.com/en-us/HT204837",
+            mitigation: "Enabling FileVault helps protect your data by encrypting your disk. If your computer is lost or stolen, unauthorized users will have difficulty accessing your data.",
+            checkstatus: "",
+            docID: 6, cisID: "2.6.6"
+        )
+    }
+    
+    override func check() {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/fdesetup")
+        process.arguments = ["status"]
+
+        let outputPipe = Pipe()
+        process.standardOutput = outputPipe
+        process.standardError = Pipe()
+
+        do {
+            try process.run()
+            process.waitUntilExit()
+
+            let output = String(data: outputPipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
+
+            if output.contains("FileVault is On") {
+                self.status = "FileVault is enabled."
+                self.checkstatus = "Green"
+            } else {
+                self.status = "FileVault is disabled."
+                self.checkstatus = "Red"
+            }
+        } catch {
+            print("Error checking FileVault status: \(error)")
+            self.checkstatus = "Yellow"
+            status = "Error checking FileVault status"
+        }
+    }
+}
+</file>
+
+<file path="mergen/checkmodules/CISBenchmark/FirewallCheck.swift">
+//
+//  FirewallCheck.swift
+//  mergen
+//
+//  Created by Samet Sazak
+//
+
+//Tested in 13-inch, 2020, Four Thunderbolt 3 ports 13.2.1 (22D68)
+
+import Foundation
+
+class FirewallCheck: Vulnerability {
+    init() {
+        super.init(
+            name: "Firewall enabled",
+            description: "The firewall helps protect your device from unauthorized access. This check verifies if the firewall is enabled and configured correctly.",
+            category: "CIS Benchmark",
+            remediation: "To enable and configure the firewall, go to System Settings... -> Network -> Firewall, enable the firewall, and configure it using the 'Options...' button.",
+            severity: "High",
+            documentation: "For more information on configuring your firewall, visit: https://support.apple.com/en-us/HT201642",
+            mitigation: "Enabling and configuring the firewall helps prevent unauthorized access to your device and increases overall security. A properly configured firewall can block incoming connections and minimize the risk of unauthorized access.",
+            checkstatus: "",
+            docID: 5, cisID: "2.2.1"
+        )
+    }
+    
+    override func check() {
+        // com.apple.alf plist was removed in macOS 26 Tahoe.
+        // socketfilterfw is the only reliable API that works without sudo on all versions.
+        let task = Process()
+        task.executableURL = URL(fileURLWithPath: "/usr/libexec/ApplicationFirewall/socketfilterfw")
+        task.arguments = ["--getglobalstate"]
+
+        let outputPipe = Pipe()
+        task.standardOutput = outputPipe
+        task.standardError = Pipe()
+
+        do {
+            try task.run()
+            task.waitUntilExit()
+
+            let output = String(data: outputPipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8)?
+                .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+
+            // Output is e.g. "Firewall is enabled. (State = 1)" or "Firewall is disabled. (State = 0)"
+            if output.lowercased().contains("enabled") {
+                status = "Firewall is enabled."
+                checkstatus = "Green"
+            } else {
+                status = "Firewall is disabled."
+                checkstatus = "Red"
+            }
+        } catch let e {
+            print("Error checking \(name): \(e)")
+            self.error = e
+            checkstatus = "Yellow"
+            status = "Error checking Firewall status"
+        }
+    }
+}
+</file>
+
+<file path="mergen/checkmodules/CISBenchmark/FirewallStealthModeCheck.swift">
+//
+//  FirewallStealthModeCheck.swift
+//  mergen
+//
+//  Created by Samet Sazak
+//
+
+//Tested in 13-inch, 2020, Four Thunderbolt 3 ports 13.2.1 (22D68)
+
+import Foundation
+
+class FirewallStealthModeCheck: Vulnerability {
+    init() {
+        super.init(
+            name: "Firewall stealth mode enabled",
+            description: "Firewall Stealth Mode makes your computer less visible on public networks by ignoring incoming requests. This check verifies if Firewall Stealth Mode is enabled.",
+            category: "CIS Benchmark",
+            remediation: "To enable Firewall Stealth Mode, go to 'System Settings', click on 'Security & Privacy', select the 'Firewall' tab, click the lock to make changes, then click 'Firewall Options' and check 'Enable stealth mode'.",
+            severity: "Medium",
+            documentation: "For more information about Firewall Stealth Mode and how to enable it, visit: https://support.apple.com/guide/mac-help/use-stealth-mode-to-secure-your-mac-mh17131/mac",
+            mitigation: "Enabling Firewall Stealth Mode helps prevent unauthorized access to your computer by making it less visible on public networks. It is recommended to enable Stealth Mode, especially when connected to untrusted networks.",
+            checkstatus: "",
+            docID: 12, cisID: "2.2.2"
+        )
+    }
+
+    override func check() {
+        // com.apple.alf plist was removed in macOS 26 Tahoe.
+        // socketfilterfw is the only reliable API that works without sudo on all versions.
+        let task = Process()
+        task.executableURL = URL(fileURLWithPath: "/usr/libexec/ApplicationFirewall/socketfilterfw")
+        task.arguments = ["--getstealthmode"]
+
+        let outputPipe = Pipe()
+        task.standardOutput = outputPipe
+        task.standardError = Pipe()
+
+        do {
+            try task.run()
+            task.waitUntilExit()
+
+            let output = String(data: outputPipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8)?
+                .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+
+            // Output is e.g. "Firewall stealth mode is on" or "Firewall stealth mode is off"
+            if output.lowercased().contains("is on") {
+                status = "Firewall Stealth Mode is enabled."
+                checkstatus = "Green"
+            } else {
+                status = "Firewall Stealth Mode is disabled."
+                checkstatus = "Red"
+            }
+        } catch let e {
+            print("Error checking \(name): \(e)")
+            checkstatus = "Yellow"
+            status = "Error checking Firewall Stealth Mode status"
+            self.error = e
+        }
+    }
+}
+</file>
+
+<file path="mergen/checkmodules/CISBenchmark/GatekeeperBypassCheck.swift">
+//
+//  GatekeeperBypassCheck.swift
+//  mergen
+//
+//  Created by Samet Sazak
+//
+
+//Tested in 13-inch, 2020, Four Thunderbolt 3 ports 13.2.1 (22D68)
+
+import Foundation
+
+class GatekeeperBypassCheck: Vulnerability {
+    init() {
+        super.init(
+            name: "Gatekeeper enabled",
+            description: "Verify that Gatekeeper is enabled to protect your Mac from potentially harmful software",
+            category: "CIS Benchmark",
+            remediation: "Enable Gatekeeper either by running 'sudo spctl --master-enable' in Terminal or by going to System Settings -> Security & Privacy -> General, and selecting 'App Store and identified developers' under 'Allow apps downloaded from'",
+            severity: "High",
+            documentation: "https://support.apple.com/en-us/HT202491",
+            mitigation: "Gatekeeper helps protect your Mac by ensuring only trusted software is installed. If Gatekeeper is disabled, you are at a higher risk of installing malicious software. Keep Gatekeeper enabled to maintain a secure environment.",
+            checkstatus: "",
+            docID: 19, cisID: "2.6.5"
+        )
+    }
+    
+    override func check() {
+        // spctl --status writes to stderr, not stdout, so we must capture stderr.
+        let task = Process()
+        task.executableURL = URL(fileURLWithPath: "/usr/sbin/spctl")
+        task.arguments = ["--status"]
+
+        let stdoutPipe = Pipe()
+        let stderrPipe = Pipe()
+        task.standardOutput = stdoutPipe
+        task.standardError = stderrPipe
+
+        do {
+            try task.run()
+            task.waitUntilExit()
+
+            let stdout = String(data: stdoutPipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
+            let stderr = String(data: stderrPipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
+            let combined = (stdout + stderr).lowercased()
+
+            if combined.contains("assessments enabled") {
+                status = "Gatekeeper is enabled."
+                checkstatus = "Green"
+            } else if combined.contains("assessments disabled") {
+                status = "Gatekeeper is disabled."
+                checkstatus = "Red"
+            } else {
+                status = "Could not determine Gatekeeper status."
+                checkstatus = "Yellow"
+            }
+        } catch let e {
+            print("Error checking \(name): \(e)")
+            self.error = e
+            self.checkstatus = "Yellow"
+            status = "Error checking Gatekeeper status"
+        }
+    }
+}
+</file>
+
+<file path="mergen/checkmodules/CISBenchmark/GuestHomeFolderCheck.swift">
+//
+//  GuestHomeFolderCheck.swift
+//  mergen
+//
+//  CIS 5.9 - Ensure the Guest Home Folder Does Not Exist
+
+import Foundation
+
+class GuestHomeFolderCheck: Vulnerability {
+    init() {
+        super.init(
+            name: "Guest Home Folder Does Not Exist",
+            description: "After disabling the Guest account, the legacy /Users/Guest folder may remain. This folder is unneeded and could be used inappropriately or cause automated audits to fail.",
+            category: "CIS Benchmark",
+            remediation: "Run: sudo rm -R /Users/Guest (only after verifying the Guest account is disabled and this is a legacy folder).",
+            severity: "Low",
+            documentation: "CIS Apple macOS 26 Tahoe Benchmark v1.0.0 - Recommendation 5.9",
+            mitigation: "Removing the unused Guest home folder reduces the attack surface and prevents its misuse.",
+            checkstatus: "",
+            docID: 123,
+            cisID: "5.9"
+        )
+    }
+
+    override func check() {
+        let task = Process()
+        task.executableURL = URL(fileURLWithPath: "/bin/ls")
+        task.arguments = ["/Users/"]
+
+        let outputPipe = Pipe()
+        task.standardOutput = outputPipe
+        task.standardError = Pipe()
+
+        do {
+            try task.run()
+            task.waitUntilExit()
+
+            let output = String(data: outputPipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
+            let folders = output.components(separatedBy: "\n").map { $0.trimmingCharacters(in: .whitespaces) }
+
+            if folders.contains("Guest") {
+                status = "Guest home folder exists at /Users/Guest."
+                checkstatus = "Red"
+            } else {
+                status = "Guest home folder does not exist."
+                checkstatus = "Green"
+            }
+        } catch let e {
+            print("Error checking \(name): \(e)")
+            self.error = e
+            checkstatus = "Yellow"
+            status = "Error checking for Guest home folder"
+        }
+    }
+}
+</file>
+
+<file path="mergen/checkmodules/CISBenchmark/GuestLoginCheck.swift">
+//
+//  GuestLoginCheck.swift
+//  mergen
+//
+//  Created by Samet Sazak
+//
+
+//Tested in 13-inch, 2020, Four Thunderbolt 3 ports 13.2.1 (22D68)
+
+//Checks if the Guest account is disabled by running the defaults command and reading the GuestEnabled setting. If the value is "0", it means the Guest account is disabled, and the check status will be "Green". If the value is not "0", it means the Guest account is enabled, and the check status will be "Red". If there's an error parsing the output or running the command, the check status will be "Yellow".
+
+import Foundation
+
+class GuestLoginCheck: Vulnerability {
+    init() {
+        super.init(
+            name: "Guest Login Status Check",
+            description: "Verify that guest login is disabled to protect your Mac from unauthorized access",
+            category: "CIS Benchmark",
+            remediation: "Disable guest login by going to System Settings > Users & Groups > Guest User and unchecking 'Allow guests to log in to this computer'",
+            severity: "Medium",
+            documentation: "https://support.apple.com/guide/mac-help/set-up-other-users-on-your-mac-mtusr001/mac",
+            mitigation: "Disabling guest login minimizes the risk of unauthorized access to your Mac by preventing users without a valid account from logging in.",
+            checkstatus: "",
+            docID: 2, cisID: "2.13.1"
+        )
+    }
+
+    override func check() {
+        let task = Process()
+        task.executableURL = URL(fileURLWithPath: "/usr/bin/defaults")
+        task.arguments = ["read", "/Library/Preferences/com.apple.loginwindow.plist", "GuestEnabled"]
+
+        let outputPipe = Pipe()
+        task.standardOutput = outputPipe
+        task.standardError = Pipe()
+
+        do {
+            try task.run()
+            task.waitUntilExit()
+
+            let outputData = outputPipe.fileHandleForReading.readDataToEndOfFile()
+            let output = String(data: outputData, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+
+            if output.lowercased() == "1" {
+                status = "Guest Login is Enabled."
+                checkstatus = "Red"
+            } else {
+                status = "Guest Login is Disabled."
+                checkstatus = "Green"
+            }
+        } catch let e {
+            print("Error checking \(name): \(e)")
+            self.error = e
+            self.checkstatus = "Yellow"
+            status = "Error checking guest login status"
+        }
+    }
+}
+</file>
+
+<file path="mergen/checkmodules/CISBenchmark/HomeFolderPermissionsCheck.swift">
+//
+//  HomeFolderPermissionsCheck.swift
+//  mergen
+//
+//  CIS 6.1.2 - Ensure No World Writable Files Exist in the System Folder (Manual)
+
+import Foundation
+
+class HomeFolderPermissionsCheck: Vulnerability {
+    init() {
+        super.init(
+            name: "Home Folder Permissions Are Restrictive",
+            description: "User home folders should not be readable by other users. Overly permissive home directory permissions expose sensitive files including SSH keys, shell history, and application data.",
+            category: "CIS Benchmark",
+            remediation: "Run: sudo chmod 700 /Users/<username> for each user account. Check with: ls -la /Users/ to verify permissions show drwx------ for each user directory.",
+            severity: "Medium",
+            documentation: "CIS Apple macOS 26 Tahoe Benchmark v1.0.0 - Recommendation 6.1.2",
+            mitigation: "Restricting home folder permissions prevents other local users from browsing each other's files, reducing lateral movement risk.",
+            checkstatus: "",
+            docID: 133,
+            cisID: "6.1.2",
+            isManual: false
+        )
+    }
+
+    override func check() {
+        let task = Process()
+        task.executableURL = URL(fileURLWithPath: "/usr/bin/stat")
+        task.arguments = ["-f", "%A", "/Users"]
+
+        let outputPipe = Pipe()
+        task.standardOutput = outputPipe
+        task.standardError = Pipe()
+
+        do {
+            try task.run()
+            task.waitUntilExit()
+        } catch {}
+
+        // Check each user home folder
+        let lsTask = Process()
+        lsTask.executableURL = URL(fileURLWithPath: "/bin/ls")
+        lsTask.arguments = ["-la", "/Users/"]
+
+        let lsOutput = Pipe()
+        lsTask.standardOutput = lsOutput
+        lsTask.standardError = Pipe()
+
+        do {
+            try lsTask.run()
+            lsTask.waitUntilExit()
+
+            let output = String(data: lsOutput.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
+            let lines = output.components(separatedBy: "\n")
+
+            // Look for world-readable home dirs (permissions like drwxr-xr-x)
+            let problematic = lines.filter { line in
+                guard line.count > 10 else { return false }
+                let perms = String(line.prefix(10))
+                // Check if 'others' have read/execute bit (position 7, 8, 9)
+                let othersRead = perms.count >= 8 && String(perms[perms.index(perms.startIndex, offsetBy: 7)]) == "r"
+                let hasUserDir = line.contains("/Users/") == false &&
+                                 !line.hasSuffix(".") &&
+                                 !line.contains("Shared") &&
+                                 perms.hasPrefix("d")
+                return othersRead && hasUserDir
+            }
+
+            if problematic.isEmpty {
+                status = "Home folder permissions appear restrictive."
+                checkstatus = "Green"
+            } else {
+                status = "Some home folders may have world-readable permissions. Manual review recommended."
+                checkstatus = "Yellow"
+            }
+        } catch {
+            status = "Manual review required: Run 'ls -la /Users/' to check home folder permissions."
+            checkstatus = "Blue"
+        }
+    }
+}
+</file>
+
+<file path="mergen/checkmodules/CISBenchmark/IcloudEnabled.swift">
+//
+//  IcloudEnabled.swift
+//  mergen
+//
+//  Created by Samet Sazak
+//
+//  CIS 2.1.1.3 - Ensure iCloud Drive Document and Desktop Sync Is Disabled
+
+import Foundation
+
+class iCloudDriveCheck: Vulnerability {
+    init() {
+        super.init(
+            name: "iCloud Drive Document and Desktop Sync Is Disabled",
+            description: "iCloud Drive can sync Desktop and Documents folders to iCloud. For security-conscious environments, this data should remain local.",
+            category: "CIS Benchmark",
+            remediation: "Go to System Settings > Apple Account > iCloud > iCloud Drive and disable 'Sync this Mac'. Alternatively run: defaults write com.apple.finder FXICloudDriveDesktop -bool false && defaults write com.apple.finder FXICloudDriveDocuments -bool false",
+            severity: "Medium",
+            documentation: "CIS Apple macOS 26 Tahoe Benchmark v1.0.0 - Recommendation 2.1.1.3",
+            mitigation: "Disabling iCloud Drive Document and Desktop sync keeps potentially sensitive files from being uploaded to cloud storage automatically.",
+            checkstatus: "",
+            docID: 3,
+            cisID: "2.1.1.3"
+        )
+    }
+
+    override func check() {
+        // CIS 2.1.1.3 requires BOTH Desktop AND Documents sync to be disabled
+        var desktopEnabled = false
+        var documentsEnabled = false
+
+        for (key, flag) in [("FXICloudDriveDesktop", { desktopEnabled = true }),
+                             ("FXICloudDriveDocuments", { documentsEnabled = true })] {
+            let task = Process()
+            task.executableURL = URL(fileURLWithPath: "/usr/bin/defaults")
+            task.arguments = ["read", "com.apple.finder", key]
+            let pipe = Pipe()
+            task.standardOutput = pipe
+            task.standardError = Pipe()
+            do {
+                try task.run()
+                task.waitUntilExit()
+                let output = String(data: pipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8)?
+                    .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+                if output == "1" { flag() }
+            } catch {}
+        }
+
+        if desktopEnabled || documentsEnabled {
+            var which: [String] = []
+            if desktopEnabled { which.append("Desktop") }
+            if documentsEnabled { which.append("Documents") }
+            status = "iCloud Drive sync is enabled for: \(which.joined(separator: ", "))."
+            checkstatus = "Red"
+        } else {
+            status = "iCloud Drive Desktop and Documents sync is disabled."
+            checkstatus = "Green"
+        }
+    }
+}
+</file>
+
+<file path="mergen/checkmodules/CISBenchmark/iCloudKeychainCheck.swift">
+//
+//  iCloudKeychainCheck.swift
+//  mergen
+//
+//  CIS 2.1.1.1 - Ensure iCloud Keychain Is Disabled (Manual)
+
+import Foundation
+
+class iCloudKeychainCheck: Vulnerability {
+    init() {
+        super.init(
+            name: "iCloud Keychain Is Disabled",
+            description: "iCloud Keychain syncs passwords and sensitive credentials across Apple devices. Organizations should disable this to prevent credentials from leaving managed devices.",
+            category: "CIS Benchmark",
+            remediation: "Create an MDM profile with PayloadType com.apple.applicationaccess and set allowCloudKeychainSync to false. Or go to System Settings > Apple ID > iCloud and disable Passwords & Keychain.",
+            severity: "Medium",
+            documentation: "CIS Apple macOS 26 Tahoe Benchmark v1.0.0 - Recommendation 2.1.1.1",
+            mitigation: "Disabling iCloud Keychain prevents credentials from being synced to personal devices or non-managed Apple ID accounts.",
+            checkstatus: "",
+            docID: 131,
+            cisID: "2.1.1.1",
+            isManual: true
+        )
+    }
+
+    override func check() {
+        let task = Process()
+        task.executableURL = URL(fileURLWithPath: "/usr/bin/osascript")
+        task.arguments = ["-l", "JavaScript", "-e",
+            "$.NSUserDefaults.alloc.initWithSuiteName('com.apple.applicationaccess').objectForKey('allowCloudKeychainSync').js"]
+
+        let outputPipe = Pipe()
+        task.standardOutput = outputPipe
+        task.standardError = Pipe()
+
+        do {
+            try task.run()
+            task.waitUntilExit()
+
+            let output = String(data: outputPipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8)?
+                .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+
+            if output == "false" {
+                status = "iCloud Keychain sync is disabled via MDM profile."
+                checkstatus = "Green"
+            } else if output == "true" {
+                status = "iCloud Keychain sync is enabled via MDM profile."
+                checkstatus = "Red"
+            } else {
+                status = "Manual review required: Check System Settings > Apple ID > iCloud > Passwords & Keychain."
+                checkstatus = "Blue"
+            }
+        } catch {
+            status = "Manual review required: Check System Settings > Apple ID > iCloud > Passwords & Keychain."
+            checkstatus = "Blue"
+        }
+    }
+}
+</file>
+
+<file path="mergen/checkmodules/CISBenchmark/ImproveAssistiveVoiceCheck.swift">
+//
+//  ImproveAssistiveVoiceCheck.swift
+//  mergen
+//
+//  CIS 2.6.3.3 - Ensure Improve Assistive Voice Features Is Disabled
+
+import Foundation
+
+class ImproveAssistiveVoiceCheck: Vulnerability {
+    init() {
+        super.init(
+            name: "Improve Assistive Voice Features Is Disabled",
+            description: "This setting shares audio recordings and transcripts of Vocal Shortcuts and Voice Control interactions with Apple. These recordings may include PII or sensitive organizational information.",
+            category: "CIS Benchmark",
+            remediation: "Create an MDM profile with PayloadType com.apple.Accessibility and set AXSAudioDonationSiriImprovementEnabled to false.",
+            severity: "Low",
+            documentation: "CIS Apple macOS 26 Tahoe Benchmark v1.0.0 - Recommendation 2.6.3.3",
+            mitigation: "Disabling assistive voice improvement prevents sensitive audio from being shared with Apple.",
+            checkstatus: "",
+            docID: 107,
+            cisID: "2.6.3.3"
+        )
+    }
+
+    override func check() {
+        let task = Process()
+        task.executableURL = URL(fileURLWithPath: "/usr/bin/osascript")
+        task.arguments = ["-l", "JavaScript", "-e",
+            "$.NSUserDefaults.alloc.initWithSuiteName('com.apple.Accessibility').objectForKey('AXSAudioDonationSiriImprovementEnabled').js"]
+
+        let outputPipe = Pipe()
+        let errorPipe = Pipe()
+        task.standardOutput = outputPipe
+        task.standardError = errorPipe
+
+        do {
+            try task.run()
+            task.waitUntilExit()
+
+            let output = String(data: outputPipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8)?
+                .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+
+            if output == "false" {
+                status = "Improve Assistive Voice Features is disabled."
+                checkstatus = "Green"
+            } else if output == "true" {
+                status = "Improve Assistive Voice Features is enabled."
+                checkstatus = "Red"
+            } else {
+                status = "Improve Assistive Voice Features state unknown (may require MDM)."
+                checkstatus = "Yellow"
+            }
+        } catch let e {
+            print("Error checking \(name): \(e)")
+            self.error = e
+            checkstatus = "Yellow"
+            status = "Error checking Assistive Voice improvement setting"
+        }
+    }
+}
+</file>
+
+<file path="mergen/checkmodules/CISBenchmark/ImproveSiriDictationCheck.swift">
+//
+//  ImproveSiriDictationCheck.swift
+//  mergen
+//
+//  CIS 2.6.3.2 - Ensure Improve Siri & Dictation Is Disabled
+
+import Foundation
+
+class ImproveSiriDictationCheck: Vulnerability {
+    init() {
+        super.init(
+            name: "Improve Siri & Dictation Is Disabled",
+            description: "This setting allows Apple to store and review audio of Siri and dictation interactions. Organizations should control what audio and interaction data is shared with Apple.",
+            category: "CIS Benchmark",
+            remediation: "Create an MDM profile with PayloadType com.apple.assistant.support and set 'Siri Data Sharing Opt-In Status' to 2. Or go to System Settings > Privacy & Security > Analytics & Improvements and disable Improve Siri & Dictation.",
+            severity: "Low",
+            documentation: "CIS Apple macOS 26 Tahoe Benchmark v1.0.0 - Recommendation 2.6.3.2",
+            mitigation: "Disabling Siri data sharing prevents audio interactions from being sent to Apple for review.",
+            checkstatus: "",
+            docID: 106,
+            cisID: "2.6.3.2"
+        )
+    }
+
+    override func check() {
+        let task = Process()
+        task.executableURL = URL(fileURLWithPath: "/usr/bin/osascript")
+        task.arguments = ["-l", "JavaScript", "-e",
+            "$.NSUserDefaults.alloc.initWithSuiteName('com.apple.assistant.support').objectForKey('Siri Data Sharing Opt-In Status').js"]
+
+        let outputPipe = Pipe()
+        let errorPipe = Pipe()
+        task.standardOutput = outputPipe
+        task.standardError = errorPipe
+
+        do {
+            try task.run()
+            task.waitUntilExit()
+
+            let output = String(data: outputPipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8)?
+                .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+
+            if output == "2" {
+                status = "Improve Siri & Dictation is disabled (opt-out status 2)."
+                checkstatus = "Green"
+            } else if output.isEmpty || output == "undefined" || output == "null" {
+                // Check user plist directly
+                checkViaDefaults()
+            } else {
+                status = "Improve Siri & Dictation may be enabled (status: \(output))."
+                checkstatus = "Red"
+            }
+        } catch let e {
+            print("Error checking \(name): \(e)")
+            self.error = e
+            checkstatus = "Yellow"
+            status = "Error checking Siri & Dictation improvement setting"
+        }
+    }
+
+    private func checkViaDefaults() {
+        let task = Process()
+        task.executableURL = URL(fileURLWithPath: "/usr/bin/env")
+        task.arguments = ["defaults", "read", "com.apple.assistant.support", "Siri Data Sharing Opt-In Status"]
+
+        let outputPipe = Pipe()
+        task.standardOutput = outputPipe
+        task.standardError = Pipe()
+
+        do {
+            try task.run()
+            task.waitUntilExit()
+
+            let output = String(data: outputPipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8)?
+                .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+
+            if output == "2" {
+                status = "Improve Siri & Dictation is disabled."
+                checkstatus = "Green"
+            } else {
+                status = "Improve Siri & Dictation state could not be determined."
+                checkstatus = "Yellow"
+            }
+        } catch {
+            checkstatus = "Yellow"
+            status = "Improve Siri & Dictation state could not be determined."
+        }
+    }
+}
+</file>
+
+<file path="mergen/checkmodules/CISBenchmark/InternetSharingDisabledCheck.swift">
+//
+//  InternetSharingDisabledCheck.swift
+//  mergen
+//
+//  Created by Samet Sazak
+//
+
+import Foundation
+
+//This implementation checks for the existence of the file at /Library/Preferences/SystemConfiguration/com.apple.nat, and if it exists, it runs the defaults read command to check for the string "Enabled = 1;" in the output. If the file does not exist, it assumes that Internet Sharing is disabled and sets the status to "Internet Sharing is Disabled" and check status to "Green".
+
+//Some people, when confronted with a problem, think "I know, I'll use regular expressions." Now they have two problems.
+// I hate regex.
+
+
+class InternetSharingDisabledCheck: Vulnerability {
+    init() {
+        super.init(
+            name: "Internet sharing disabled",
+            description: "Internet Sharing allows your computer to share its internet connection with other devices. This check ensures that Internet Sharing is disabled to protect your computer from unauthorized access.",
+            category: "CIS Benchmark",
+            remediation: "To disable Internet Sharing, go to 'System Settings', click on 'Sharing', and uncheck the 'Internet Sharing' option.",
+            severity: "Medium",
+            documentation: "For more information about Internet Sharing and how to disable it, visit: https://support.apple.com/guide/mac-help/share-your-internet-connection-mchlp1540/mac",
+            mitigation: "Disabling Internet Sharing reduces the attack surface and helps prevent unauthorized access to your computer. This minimizes the ways an attacker can connect to your system and helps protect your data from unauthorized access.",
+            docID: 41, cisID: "2.3.3.7"
+        )
+    }
+
+    override func check() {
+        let task = Process()
+        task.executableURL = URL(fileURLWithPath: "/usr/bin/defaults")
+        task.arguments = ["read", "/Library/Preferences/SystemConfiguration/com.apple.nat"]
+
+        do {
+            let outputPipe = Pipe()
+            task.standardOutput = outputPipe
+            task.standardError = Pipe()
+            try task.run()
+            task.waitUntilExit()
+
+            if task.terminationStatus == 0 {
+                let outputData = outputPipe.fileHandleForReading.readDataToEndOfFile()
+                let outputString = String(data: outputData, encoding: .utf8) ?? ""
+                // If the plist exists and contains "Enabled = 1", internet sharing is on
+                if outputString.contains("Enabled = 1;") {
+                    status = "Internet Sharing is Enabled"
+                    checkstatus = "Red"
+                } else {
+                    status = "Internet Sharing is Disabled"
+                    checkstatus = "Green"
+                }
+            } else {
+                // plist doesn't exist → Internet Sharing has never been enabled
+                status = "Internet Sharing is Disabled"
+                checkstatus = "Green"
+            }
+        } catch let e {
+            print("Error checking \(name): \(e)")
+            checkstatus = "Yellow"
+            status = "Error checking Internet Sharing status"
+            self.error = e
+            print(e)
+        }
+    }
+}
+</file>
+
+<file path="mergen/checkmodules/CISBenchmark/LocationServicesCheck.swift">
+//
+//  LocationServicesCheck.swift
+//  mergen
+//
+//  Created by Samet Sazak
+//
+
+import Foundation
+
+class LocationServicesCheck: Vulnerability {
+    init() {
+        super.init(
+            name: "Location services enabled",
+            description: "Location Services is essential for various applications on your system to function properly. This check ensures that Location Services is enabled on your system.",
+            category: "CIS Benchmark",
+            remediation: "To enable Location Services, go to System Settings > Security & Privacy > Privacy and check the option.",
+            severity: "Low",
+            documentation: "This code checks the status of the com.apple.locationd launchctl service. If the locationd service is running, it means that Location Services is enabled; if not, it means that Location Services is disabled.",
+            mitigation: "Enabling Location Services allows applications to provide location-based features and services.",
+            docID: 50, cisID: "2.6.1.1"
+        )
+    }
+
+    override func check() {
+        let task = Process()
+        task.executableURL = URL(fileURLWithPath: "/bin/launchctl")
+        task.arguments = ["list", "com.apple.locationd"]
+
+        task.standardOutput = Pipe()
+        task.standardError = Pipe()
+
+        do {
+            try task.run()
+            task.waitUntilExit()
+
+            if task.terminationStatus == 0 {
+                status = "Location Services is enabled."
+                checkstatus = "Green"
+            } else {
+                status = "Location Services is disabled."
+                checkstatus = "Red"
+            }
+        } catch let e {
+            print("Error checking \(name): \(e)")
+            checkstatus = "Yellow"
+            status = "Error checking Location Services status"
+            self.error = e
+        }
+    }
+}
+</file>
+
+<file path="mergen/checkmodules/CISBenchmark/LocationServicesMenuBarCheck.swift">
+//
+//  LocationServicesMenuBarCheck.swift
+//  mergen
+//
+//  Created by Samet Sazak
+//
+
+import Foundation
+
+
+//This implementation checks whether the "Location.menu" item is present in the output of the defaults read com.apple.systemuiserver menuExtras command, which indicates that the Location Services icon is visible in the menu bar. If the "Location.menu" item is present, the status is set to "Location Services is visible in the menu bar", and the checkstatus is set to "Green". If the "Location.menu" item is not present, the status is set to "Location Services is not visible in the menu bar", and the checkstatus is set to "Red". If an error occurs during the check, the status is set to "Error checking menu bar status", and the checkstatus is set to "Yellow".
+
+
+class LocationServicesMenuBarCheck: Vulnerability {
+    init() {
+        super.init(
+            name: "Location services shown in menu bar",
+            description: "This check ensures that the Location Services icon is visible in the menu bar, providing users with awareness when Location Services is enabled.",
+            category: "CIS Benchmark",
+            remediation: "To enable Location Services in the menu bar, go to System Settings > Security & Privacy > Privacy > Location Services and check the option.",
+            severity: "Low",
+            documentation: "Having the Location Services icon visible in the menu bar helps users to be aware of its status and manage location-based features more effectively.",
+            mitigation: "Displaying the Location Services icon in the menu bar ensures that users are aware of when Location Services is enabled, reducing potential security risks.",
+            docID: 51, cisID: "2.6.1.2"
+        )
+    }
+
+    override func check() {
+        let task = Process()
+        task.executableURL = URL(fileURLWithPath: "/usr/bin/defaults")
+        task.arguments = ["read", "com.apple.systemuiserver", "menuExtras"]
+
+        let pipe = Pipe()
+        task.standardOutput = pipe
+        task.standardError = Pipe()
+
+        do {
+            try task.run()
+            let data = pipe.fileHandleForReading.readDataToEndOfFile()
+            if let output = String(data: data, encoding: .utf8) {
+                if output.contains("Location.menu") {
+                    status = "Location Services is visible in the menu bar"
+                    checkstatus = "Green"
+                } else {
+                    status = "Location Services is not visible in the menu bar"
+                    checkstatus = "Red"
+                }
+            } else {
+                status = "Error parsing menu bar status"
+                checkstatus = "Yellow"
+            }
+        } catch let e {
+            print("Error checking \(name): \(e)")
+            checkstatus = "Yellow"
+            status = "Error checking menu bar status"
+            self.error = e
+        }
+    }
+}
+</file>
+
+<file path="mergen/checkmodules/CISBenchmark/LockdownModeCheck.swift">
+//
+//  LockdownModeCheck.swift
+//  mergen
+//
+//  CIS 2.6.7 - Ensure Lockdown Mode Is Enabled (Advisory)
+
+import Foundation
+
+class LockdownModeCheck: Vulnerability {
+    init() {
+        super.init(
+            name: "Lockdown Mode Status",
+            description: "Lockdown Mode provides extreme protection for users at high risk of targeted cyberattacks (e.g. journalists, activists, government officials). It severely limits device functionality to reduce attack surface.",
+            category: "CIS Benchmark",
+            remediation: "Enable in System Settings > Privacy & Security > Lockdown Mode. Note: This significantly limits device functionality. Only recommended for high-risk individuals.",
+            severity: "Low",
+            documentation: "CIS Apple macOS 26 Tahoe Benchmark v1.0.0 - Recommendation 2.6.7",
+            mitigation: "Lockdown Mode reduces attack surface against sophisticated targeted attacks by disabling certain features and connection types.",
+            checkstatus: "",
+            docID: 132,
+            cisID: "2.6.7",
+            isManual: true
+        )
+    }
+
+    override func check() {
+        let task = Process()
+        task.executableURL = URL(fileURLWithPath: "/usr/bin/defaults")
+        task.arguments = ["read", "/Library/Preferences/com.apple.security.lockdown", "LockdownModeEnabled"]
+
+        let outputPipe = Pipe()
+        task.standardOutput = outputPipe
+        task.standardError = Pipe()
+
+        do {
+            try task.run()
+            task.waitUntilExit()
+
+            let output = String(data: outputPipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8)?
+                .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+
+            if output == "1" {
+                status = "Lockdown Mode is enabled."
+                checkstatus = "Green"
+            } else if output == "0" {
+                status = "Lockdown Mode is disabled. Advisory: only required for high-risk users."
+                checkstatus = "Blue"
+            } else {
+                status = "Lockdown Mode is not configured. Advisory check — enable only if user is high-risk."
+                checkstatus = "Blue"
+            }
+        } catch {
+            status = "Lockdown Mode status not determinable. Advisory: enable for high-risk individuals only."
+            checkstatus = "Blue"
+        }
+    }
+}
+</file>
+
+<file path="mergen/checkmodules/CISBenchmark/LoginScreenMessageCheck.swift">
+//
+//  LoginScreenMessageCheck.swift
+//  mergen
+//
+//  CIS 2.11.3 - Ensure a Custom Message for the Login Screen Is Enabled
+
+import Foundation
+
+class LoginScreenMessageCheck: Vulnerability {
+    init() {
+        super.init(
+            name: "Custom Login Screen Message Is Set",
+            description: "A login screen access warning informs users that the system is reserved for authorized use only. This may reduce casual attacker tendency and aids prosecution by establishing awareness of policies.",
+            category: "CIS Benchmark",
+            remediation: "Go to System Settings > Lock Screen > Show message when locked and set your organization's message. Or run: sudo defaults write /Library/Preferences/com.apple.loginwindow LoginwindowText 'Your message here'",
+            severity: "Low",
+            documentation: "CIS Apple macOS 26 Tahoe Benchmark v1.0.0 - Recommendation 2.11.3",
+            mitigation: "A login banner establishes that the system is for authorized use only, which may deter casual attackers.",
+            checkstatus: "",
+            docID: 113,
+            cisID: "2.11.3"
+        )
+    }
+
+    override func check() {
+        let task = Process()
+        task.executableURL = URL(fileURLWithPath: "/usr/bin/env")
+        task.arguments = ["defaults", "read", "/Library/Preferences/com.apple.loginwindow", "LoginwindowText"]
+
+        let outputPipe = Pipe()
+        let errorPipe = Pipe()
+        task.standardOutput = outputPipe
+        task.standardError = errorPipe
+
+        do {
+            try task.run()
+            task.waitUntilExit()
+
+            let output = String(data: outputPipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8)?
+                .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+            let errorOutput = String(data: errorPipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
+
+            if !output.isEmpty && !errorOutput.contains("does not exist") {
+                status = "Login screen message is set."
+                checkstatus = "Green"
+            } else {
+                status = "No custom login screen message is configured."
+                checkstatus = "Red"
+            }
+        } catch let e {
+            print("Error checking \(name): \(e)")
+            self.error = e
+            checkstatus = "Yellow"
+            status = "Error checking login screen message"
+        }
+    }
+}
+</file>
+
+<file path="mergen/checkmodules/CISBenchmark/LoginWindowNamePasswordCheck.swift">
+//
+//  LoginWindowNamePasswordCheck.swift
+//  mergen
+//
+//  CIS 2.11.4 - Ensure Login Window Displays as Name and Password Is Enabled
+
+import Foundation
+
+class LoginWindowNamePasswordCheck: Vulnerability {
+    init() {
+        super.init(
+            name: "Login Window Shows Name and Password",
+            description: "When the login window prompts for both username and password (rather than showing a list of users), unauthorized access becomes harder since an attacker must discover two attributes.",
+            category: "CIS Benchmark",
+            remediation: "Go to System Settings > Lock Screen and set 'Login window shows' to 'Name and Password'. Or run: sudo defaults write /Library/Preferences/com.apple.loginwindow SHOWFULLNAME -bool true",
+            severity: "Low",
+            documentation: "CIS Apple macOS 26 Tahoe Benchmark v1.0.0 - Recommendation 2.11.4",
+            mitigation: "Requiring both username and password input at login increases difficulty for unauthorized access attempts.",
+            checkstatus: "",
+            docID: 114,
+            cisID: "2.11.4"
+        )
+    }
+
+    override func check() {
+        let task = Process()
+        task.executableURL = URL(fileURLWithPath: "/usr/bin/env")
+        task.arguments = ["defaults", "read", "/Library/Preferences/com.apple.loginwindow", "SHOWFULLNAME"]
+
+        let outputPipe = Pipe()
+        let errorPipe = Pipe()
+        task.standardOutput = outputPipe
+        task.standardError = errorPipe
+
+        do {
+            try task.run()
+            task.waitUntilExit()
+
+            let output = String(data: outputPipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8)?
+                .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+
+            if output == "1" {
+                status = "Login window shows name and password fields."
+                checkstatus = "Green"
+            } else {
+                status = "Login window shows user list instead of name and password."
+                checkstatus = "Red"
+            }
+        } catch let e {
+            print("Error checking \(name): \(e)")
+            self.error = e
+            checkstatus = "Yellow"
+            status = "Error checking login window display setting"
+        }
+    }
+}
+</file>
+
+<file path="mergen/checkmodules/CISBenchmark/MailSummarizationCheck.swift">
+//
+//  MailSummarizationCheck.swift
+//  mergen
+//
+//  CIS 2.5.1.3 - Ensure Mail Summarization Is Disabled
+
+import Foundation
+
+class MailSummarizationCheck: Vulnerability {
+    init() {
+        super.init(
+            name: "Apple Intelligence Mail Summarization Disabled",
+            description: "Apple Intelligence Mail summarization condenses emails using AI. For environments with sensitive communications, this should be disabled to prevent mail content from being processed externally.",
+            category: "CIS Benchmark",
+            remediation: "Create an MDM profile with PayloadType com.apple.applicationaccess and set allowMailSummary to false.",
+            severity: "Medium",
+            documentation: "CIS Apple macOS 26 Tahoe Benchmark v1.0.0 - Recommendation 2.5.1.3",
+            mitigation: "Disabling mail summarization ensures email content is not processed by AI services outside your approved channels.",
+            checkstatus: "",
+            docID: 103,
+            cisID: "2.5.1.3"
+        )
+    }
+
+    override func check() {
+        let task = Process()
+        task.executableURL = URL(fileURLWithPath: "/usr/bin/osascript")
+        task.arguments = ["-l", "JavaScript", "-e",
+            "$.NSUserDefaults.alloc.initWithSuiteName('com.apple.applicationaccess').objectForKey('allowMailSummary').js"]
+
+        let outputPipe = Pipe()
+        let errorPipe = Pipe()
+        task.standardOutput = outputPipe
+        task.standardError = errorPipe
+
+        do {
+            try task.run()
+            task.waitUntilExit()
+
+            let output = String(data: outputPipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8)?
+                .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+
+            if output == "false" {
+                status = "Mail Summarization is disabled."
+                checkstatus = "Green"
+            } else if output == "true" {
+                status = "Mail Summarization is enabled."
+                checkstatus = "Red"
+            } else {
+                status = "No MDM profile found. Mail Summarization state unknown."
+                checkstatus = "Yellow"
+            }
+        } catch let e {
+            print("Error checking \(name): \(e)")
+            self.error = e
+            checkstatus = "Yellow"
+            status = "Error checking Apple Intelligence Mail Summarization"
+        }
+    }
+}
+</file>
+
+<file path="mergen/checkmodules/CISBenchmark/NotesSummarizationCheck.swift">
+//
+//  NotesSummarizationCheck.swift
+//  mergen
+//
+//  CIS 2.5.1.4 - Ensure Notes Summarization Is Disabled
+
+import Foundation
+
+class NotesSummarizationCheck: Vulnerability {
+    init() {
+        super.init(
+            name: "Apple Intelligence Notes Summarization Disabled",
+            description: "Apple Intelligence Notes summarization condenses written notes and audio recordings. For environments with sensitive notes or meeting recordings, this should be disabled.",
+            category: "CIS Benchmark",
+            remediation: "Create an MDM profile with PayloadType com.apple.applicationaccess and set allowNotesTranscription and allowNotesTranscriptionSummary to false.",
+            severity: "Medium",
+            documentation: "CIS Apple macOS 26 Tahoe Benchmark v1.0.0 - Recommendation 2.5.1.4",
+            mitigation: "Disabling Notes summarization ensures audio recordings and notes are not processed externally.",
+            checkstatus: "",
+            docID: 104,
+            cisID: "2.5.1.4"
+        )
+    }
+
+    override func check() {
+        let task = Process()
+        task.executableURL = URL(fileURLWithPath: "/usr/bin/osascript")
+        task.arguments = ["-l", "JavaScript", "-e",
+            "$.NSUserDefaults.alloc.initWithSuiteName('com.apple.applicationaccess').objectForKey('allowNotesTranscription').js"]
+
+        let outputPipe = Pipe()
+        let errorPipe = Pipe()
+        task.standardOutput = outputPipe
+        task.standardError = errorPipe
+
+        do {
+            try task.run()
+            task.waitUntilExit()
+
+            let output = String(data: outputPipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8)?
+                .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+
+            if output == "false" {
+                status = "Notes Summarization is disabled."
+                checkstatus = "Green"
+            } else if output == "true" {
+                status = "Notes Summarization is enabled."
+                checkstatus = "Red"
+            } else {
+                status = "No MDM profile found. Notes Summarization state unknown."
+                checkstatus = "Yellow"
+            }
+        } catch let e {
+            print("Error checking \(name): \(e)")
+            self.error = e
+            checkstatus = "Yellow"
+            status = "Error checking Apple Intelligence Notes Summarization"
+        }
+    }
+}
+</file>
+
+<file path="mergen/checkmodules/CISBenchmark/PasswordLockoutThresholdCheck.swift">
+//
+//  PasswordLockoutThresholdCheck.swift
+//  mergen
+//
+//  CIS 5.2.1 - Ensure Password Account Lockout Threshold Is Configured
+
+import Foundation
+
+class PasswordLockoutThresholdCheck: Vulnerability {
+    init() {
+        super.init(
+            name: "Password Lockout Threshold ≤ 5 Attempts",
+            description: "The account should lock after 5 or fewer failed login attempts to prevent brute-force password attacks.",
+            category: "CIS Benchmark",
+            remediation: "Run: sudo pwpolicy -n /Local/Default -setglobalpolicy 'maxFailedLoginAttempts=5'. Or create an MDM profile with com.apple.mobiledevice.passwordpolicy and set maxFailedAttempts to 5.",
+            severity: "High",
+            documentation: "CIS Apple macOS 26 Tahoe Benchmark v1.0.0 - Recommendation 5.2.1",
+            mitigation: "Account lockout after repeated failed attempts prevents brute-force attacks on user credentials.",
+            checkstatus: "",
+            docID: 118,
+            cisID: "5.2.1"
+        )
+    }
+
+    override func check() {
+        let task = Process()
+        task.executableURL = URL(fileURLWithPath: "/usr/bin/pwpolicy")
+        task.arguments = ["-getaccountpolicies"]
+
+        let outputPipe = Pipe()
+        let errorPipe = Pipe()
+        task.standardOutput = outputPipe
+        task.standardError = errorPipe
+
+        do {
+            try task.run()
+            task.waitUntilExit()
+
+            let output = String(data: outputPipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
+
+            if output.contains("policyAttributeMaximumFailedAuthentications") {
+                // Extract the value using a simple search
+                if let range = output.range(of: "policyAttributeMaximumFailedAuthentications") {
+                    let after = String(output[range.upperBound...])
+                    if let intRange = after.range(of: "<integer>"),
+                       let endRange = after.range(of: "</integer>") {
+                        let valueStr = String(after[intRange.upperBound..<endRange.lowerBound])
+                        if let value = Int(valueStr) {
+                            if value <= 5 {
+                                status = "Password lockout threshold is \(value) (≤ 5)."
+                                checkstatus = "Green"
+                            } else {
+                                status = "Password lockout threshold is \(value) (should be ≤ 5)."
+                                checkstatus = "Red"
+                            }
+                            return
+                        }
+                    }
+                }
+                status = "Password lockout policy found but value could not be parsed."
+                checkstatus = "Yellow"
+            } else {
+                status = "No password lockout threshold configured."
+                checkstatus = "Red"
+            }
+        } catch let e {
+            print("Error checking \(name): \(e)")
+            self.error = e
+            checkstatus = "Yellow"
+            status = "Error checking password lockout threshold"
+        }
+    }
+}
+</file>
+
+<file path="mergen/checkmodules/CISBenchmark/PasswordMinLengthCheck.swift">
+//
+//  PasswordMinLengthCheck.swift
+//  mergen
+//
+//  CIS 5.2.2 - Ensure Password Minimum Length Is Configured
+
+import Foundation
+
+class PasswordMinLengthCheck: Vulnerability {
+    init() {
+        super.init(
+            name: "Password Minimum Length ≥ 15 Characters",
+            description: "Passwords should have a minimum length of at least 15 characters to resist brute-force attacks.",
+            category: "CIS Benchmark",
+            remediation: "Run: sudo pwpolicy -n /Local/Default -setglobalpolicy 'minChars=15'. Or create an MDM profile with com.apple.mobiledevice.passwordpolicy and set minLength to 15.",
+            severity: "High",
+            documentation: "CIS Apple macOS 26 Tahoe Benchmark v1.0.0 - Recommendation 5.2.2",
+            mitigation: "Longer passwords exponentially increase the time required for brute-force attacks.",
+            checkstatus: "",
+            docID: 119,
+            cisID: "5.2.2"
+        )
+    }
+
+    override func check() {
+        let task = Process()
+        task.executableURL = URL(fileURLWithPath: "/usr/bin/pwpolicy")
+        task.arguments = ["-getaccountpolicies"]
+
+        let outputPipe = Pipe()
+        let errorPipe = Pipe()
+        task.standardOutput = outputPipe
+        task.standardError = errorPipe
+
+        do {
+            try task.run()
+            task.waitUntilExit()
+
+            let output = String(data: outputPipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
+
+            // Check for minimum length in the policy
+            if output.contains("policyAttributePassword matches") || output.contains("minimumLength") || output.contains("minChars") {
+                // Try to extract the minimum length value
+                let patterns = ["policyAttributePassword matches '.{(\\d+)}", "minimumLength.*?(\\d+)"]
+                for pattern in patterns {
+                    if let regex = try? NSRegularExpression(pattern: pattern),
+                       let match = regex.firstMatch(in: output, range: NSRange(output.startIndex..., in: output)),
+                       match.numberOfRanges > 1,
+                       let range = Range(match.range(at: 1), in: output),
+                       let value = Int(output[range]) {
+                        if value >= 15 {
+                            status = "Password minimum length is \(value) characters (≥ 15)."
+                            checkstatus = "Green"
+                        } else {
+                            status = "Password minimum length is \(value) characters (should be ≥ 15)."
+                            checkstatus = "Red"
+                        }
+                        return
+                    }
+                }
+                status = "Password length policy found but minimum length could not be parsed."
+                checkstatus = "Yellow"
+            } else {
+                status = "No password minimum length policy configured."
+                checkstatus = "Red"
+            }
+        } catch let e {
+            print("Error checking \(name): \(e)")
+            self.error = e
+            checkstatus = "Yellow"
+            status = "Error checking password minimum length"
+        }
+    }
+}
+</file>
+
+<file path="mergen/checkmodules/CISBenchmark/PasswordOnWakeCheck.swift">
+//
+//  PasswordOnWakeCheck.swift
+//  mergen
+//
+//  Created by Samet Sazak
+//
+
+import Foundation
+
+
+class PasswordOnWakeCheck: Vulnerability {
+
+    init() {
+        super.init(
+            name: "Password required on wake",
+            description: "Checks whether a password is required to wake the computer from sleep or screen saver",
+            category: "CIS Benchmark",
+            remediation: "Enable a password requirement to wake the computer from sleep or screen saver",
+            severity: "Low",
+            documentation: "This code checks whether a password is required to wake the computer from sleep or screen saver. If not enabled, it can allow unauthorized access to a user's system and potentially sensitive data.",
+            mitigation: "Enable a password requirement to wake the computer from sleep or screen saver to ensure that only authorized users can access the system.",
+            docID: 58, cisID: "2.11.2"
+        )
+    }
+
+    override func check() {
+        // On macOS 26 Tahoe, com.apple.screensaver keys may only exist in the
+        // -currentHost domain. Try that first, then fall back to the user domain.
+        let value = readAskForPassword(currentHost: true) ?? readAskForPassword(currentHost: false)
+
+        switch value {
+        case "1":
+            status = "A password is required to wake the computer from sleep or screen saver."
+            checkstatus = "Green"
+        case "0":
+            status = "A password is NOT required to wake the computer from sleep or screen saver."
+            checkstatus = "Red"
+        default:
+            // Key absent means the setting was never explicitly configured — treat as not required.
+            status = "A password is NOT required to wake the computer from sleep or screen saver."
+            checkstatus = "Red"
+        }
+    }
+
+    private func readAskForPassword(currentHost: Bool) -> String? {
+        let task = Process()
+        task.executableURL = URL(fileURLWithPath: "/usr/bin/defaults")
+        task.arguments = currentHost
+            ? ["-currentHost", "read", "com.apple.screensaver", "askForPassword"]
+            : ["read", "com.apple.screensaver", "askForPassword"]
+
+        let pipe = Pipe()
+        task.standardOutput = pipe
+        task.standardError = Pipe()
+
+        do {
+            try task.run()
+            task.waitUntilExit()
+            guard task.terminationStatus == 0 else { return nil }
+            return String(data: pipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8)?
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+        } catch {
+            return nil
+        }
+    }
+}
+</file>
+
+<file path="mergen/checkmodules/CISBenchmark/PersonalizedAds.swift">
+//
+//  PersonalizedAds.swift
+//  mergen
+//
+//  Created by Samet Sazak
+//
+
+import Foundation
+
+class LimitAdTrackingCheck: Vulnerability {
+    init() {
+        super.init(
+            name: "Personalized ads disabled",
+            description: "This check ensures that Personalized Ads are disabled on your system, which helps protect your privacy by preventing advertisers from displaying targeted ads based on your interests and usage.",
+            category: "CIS Benchmark",
+            remediation: "To disable Personalized Ads, enable Limit Ad Tracking in System Settings > Security & Privacy > Privacy > Advertising.",
+            severity: "Low",
+            documentation: "For more information on how to limit ad tracking, visit: https://support.apple.com/en-us/HT205223",
+            mitigation: "Disabling Personalized Ads by enabling Limit Ad Tracking helps protect your privacy and limits the information shared with advertisers.",
+            docID: 52, cisID: "2.6.4"
+        )
+    }
+
+    override func check() {
+        let task = Process()
+        task.executableURL = URL(fileURLWithPath: "/usr/bin/defaults")
+        task.arguments = ["read", "com.apple.AdLib", "allowApplePersonalizedAdvertising"]
+
+        let pipe = Pipe()
+        task.standardOutput = pipe
+        task.standardError = Pipe()
+
+        do {
+            try task.run()
+            let data = pipe.fileHandleForReading.readDataToEndOfFile()
+            if let output = String(data: data, encoding: .utf8) {
+                if output.contains("1") {
+                    status = "Personalized Ads are enabled."
+                    checkstatus = "Red"
+                } else {
+                    status = "Personalized Ads are disabled"
+                    checkstatus = "Green"
+                }
+            } else {
+                status = "Error parsing Personalized Ads status."
+                checkstatus = "Yellow"
+            }
+        } catch let e {
+            print("Error checking \(name): \(e)")
+            checkstatus = "Yellow"
+            status = "Error checking Personalized Ads status"
+            self.error = e
+        }
+    }
+}
+</file>
+
+<file path="mergen/checkmodules/CISBenchmark/PowerNapDisabledCheck.swift">
+//
+//  PowerNapDisabledCheck.swift
+//  mergen
+//
+//  CIS 2.10.2 - Ensure Power Nap Is Disabled for Intel Macs
+
+import Foundation
+
+class PowerNapDisabledCheck: Vulnerability {
+    init() {
+        super.init(
+            name: "Power Nap Is Disabled (Intel Macs)",
+            description: "Power Nap allows the system to periodically connect to known networks while asleep, requiring FileVault to remain unlocked. This is a risk if the device is in an untrusted environment.",
+            category: "CIS Benchmark",
+            remediation: "Run: sudo pmset -a powernap 0. This only applies to Intel Macs.",
+            severity: "Low",
+            documentation: "CIS Apple macOS 26 Tahoe Benchmark v1.0.0 - Recommendation 2.10.2",
+            mitigation: "Disabling Power Nap mitigates the risk of an attacker remotely waking the system and gaining access.",
+            checkstatus: "",
+            docID: 112,
+            cisID: "2.10.2"
+        )
+    }
+
+    override func check() {
+        // Only applies to Intel Macs
+        let cpuTask = Process()
+        cpuTask.executableURL = URL(fileURLWithPath: "/usr/sbin/sysctl")
+        cpuTask.arguments = ["-n", "machdep.cpu.brand_string"]
+
+        let cpuPipe = Pipe()
+        cpuTask.standardOutput = cpuPipe
+        cpuTask.standardError = Pipe()
+
+        do {
+            try cpuTask.run()
+            cpuTask.waitUntilExit()
+            let cpuOutput = String(data: cpuPipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
+
+            if !cpuOutput.contains("Intel") {
+                status = "Not applicable — this check is for Intel Macs only."
+                checkstatus = "Green"
+                return
+            }
+
+            let task = Process()
+            task.executableURL = URL(fileURLWithPath: "/usr/bin/pmset")
+            task.arguments = ["-g", "custom"]
+
+            let outputPipe = Pipe()
+            task.standardOutput = outputPipe
+            task.standardError = Pipe()
+
+            try task.run()
+            task.waitUntilExit()
+
+            let output = String(data: outputPipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
+
+            // Check if powernap is set to 1 anywhere
+            let lines = output.components(separatedBy: "\n")
+            let powerNapOn = lines.contains { line in
+                let trimmed = line.trimmingCharacters(in: .whitespaces)
+                return trimmed.hasPrefix("powernap") && trimmed.hasSuffix("1")
+            }
+
+            if powerNapOn {
+                status = "Power Nap is enabled."
+                checkstatus = "Red"
+            } else {
+                status = "Power Nap is disabled."
+                checkstatus = "Green"
+            }
+        } catch let e {
+            print("Error checking \(name): \(e)")
+            self.error = e
+            checkstatus = "Yellow"
+            status = "Error checking Power Nap status"
+        }
+    }
+}
+</file>
+
+<file path="mergen/checkmodules/CISBenchmark/PrinterSharingDisabledCheck.swift">
+//
+//  PrinterSharingDisabledCheck.swift
+//  mergen
+//
+//  Created by Samet Sazak
+//
+
+import Foundation
+
+class PrinterSharingDisabledCheck: Vulnerability {
+    init() {
+        super.init(
+            name: "Printer sharing disabled",
+            description: "Printer Sharing allows you to share printers with other users over a network. This check ensures that Printer Sharing is disabled to prevent unauthorized access to your printers.",
+            category: "CIS Benchmark",
+            remediation: "To disable Printer Sharing, go to 'System Settings', click on 'Sharing', and uncheck the 'Printer Sharing' option.",
+            severity: "Medium",
+            documentation: "For more information about Printer Sharing and how to disable it, visit: https://support.apple.com/guide/mac-help/share-mac-printers-with-other-users-mchlp1011/mac",
+            mitigation: "Disabling Printer Sharing reduces the risk of unauthorized access to your printers and printer resources. This minimizes the ways an attacker can connect to your system and helps protect your printer resources from unauthorized access.",
+            docID: 37, cisID: "2.3.3.3"
+        )
+    }
+
+    override func check() {
+        let task = Process()
+        task.executableURL = URL(fileURLWithPath: "/usr/sbin/cupsctl")
+        
+        let pipe = Pipe()
+        task.standardOutput = pipe
+        task.standardError = Pipe()
+
+        do {
+            try task.run()
+            let data = pipe.fileHandleForReading.readDataToEndOfFile()
+            if let output = String(data: data, encoding: .utf8) {
+                if output.contains("_share_printers=1") {
+                    status = "Printer Sharing is Enabled"
+                    checkstatus = "Red"
+                } else {
+                    status = "Printer Sharing is Disabled"
+                    checkstatus = "Green"
+                }
+            } else {
+                status = "Error parsing Printer Sharing status"
+                checkstatus = "Yellow"
+            }
+        } catch let e {
+            print("Error checking \(name): \(e)")
+            checkstatus = "Yellow"
+            status = "Error checking Printer Sharing status"
+            self.error = e
+        }
+    }
+}
+</file>
+
+<file path="mergen/checkmodules/CISBenchmark/RemoteAppleEventsCheck.swift">
+//
+//  RemoteAppleEventsCheck.swift
+//  mergen
+//
+//  Created by Samet Sazak
+//
+
+import Foundation
+
+//This implementation first checks if the com.apple.RemoteAppleEvents.plist file exists using FileManager.fileExists(atPath:) method. If the file exists, it runs the defaults read command as before. If the file does not exist, it assumes that Remote Apple Events is disabled and sets the status to "Remote Apple Events is Disabled" and check status to "Green".
+//Since I can't use sudo, this script is using the method shared here: https://www.stigviewer.com/stig/apple_os_x_10.12/2018-01-04/finding/V-76115
+//Tested in 13-inch, 2020, Four Thunderbolt 3 ports 13.2.1 (22D68)
+
+class RemoteAppleEventsDisabledCheck: Vulnerability {
+    init() {
+        super.init(
+            name: "Remote Apple Events disabled",
+            description: "Remote Apple Events allows other users to send AppleScript events to your computer. This check ensures that Remote Apple Events is disabled to protect your computer from unauthorized access.",
+            category: "CIS Benchmark",
+            remediation: "To disable Remote Apple Events, go to 'System Settings', click on 'Sharing', and uncheck the 'Remote Apple Events' option.",
+            severity: "Medium",
+            documentation: "For more information about Remote Apple Events and how to disable it, visit: https://support.apple.com/guide/mac-help/use-remote-apple-events-mchlp1628/mac",
+            mitigation: "Disabling Remote Apple Events minimizes the risk of unauthorized access to your computer. This reduces the ways an attacker can remotely control your system and helps protect your data from unauthorized access.",
+            docID: 40, cisID: "2.3.3.6"
+        )
+    }
+
+    override func check() {
+        let task = Process()
+        task.executableURL = URL(fileURLWithPath: "/bin/launchctl")
+        task.arguments = ["print-disabled", "system"]
+
+        do {
+            let outputPipe = Pipe()
+            task.standardOutput = outputPipe
+        task.standardError = Pipe()
+            try task.run()
+            task.waitUntilExit()
+
+            if task.terminationStatus == 0 {
+                let outputData = outputPipe.fileHandleForReading.readDataToEndOfFile()
+                let outputString = String(data: outputData, encoding: .utf8)
+
+                if let outputString = outputString, outputString.contains("\"com.apple.AEServer\" => disabled") {
+                    status = "Remote Apple Events is Disabled"
+                    checkstatus = "Green"
+                } else {
+                    status = "Remote Apple Events is Enabled"
+                    checkstatus = "Red"
+                }
+            } else {
+                status = "Error checking Remote Apple Events status"
+                checkstatus = "Yellow"
+            }
+        } catch let e {
+            print("Error checking \(name): \(e)")
+            checkstatus = "Yellow"
+            status = "Error checking Remote Apple Events status"
+            self.error = e
+            print(e)
+        }
+    }
+}
+</file>
+
+<file path="mergen/checkmodules/CISBenchmark/RemoteLoginDisabledCheck.swift">
+//
+//  RemoteLoginDisabledCheck.swift
+//  mergen
+//
+//  Created by Samet Sazak
+//
+
+import Foundation
+
+//This implementation uses the launchctl command to check if the ssh process is running, which indicates that remote login is enabled.
+
+class RemoteLoginDisabledCheck: Vulnerability {
+    init() {
+        super.init(
+            name: "Remote login (SSH) disabled",
+            description: "Remote Login allows users to log in to your computer remotely via SSH. This check ensures that Remote Login is disabled to protect your computer from unauthorized access.",
+            category: "CIS Benchmark",
+            remediation: "To disable Remote Login, go to 'System Settings', click on 'Sharing', and uncheck the 'Remote Login' option.",
+            severity: "Medium",
+            documentation: "For more information about Remote Login and how to disable it, visit: https://support.apple.com/guide/mac-help/use-remote-login-mchla2c3e666/mac",
+            mitigation: "Disabling Remote Login reduces the attack surface and helps prevent unauthorized access to your computer. This minimizes the ways an attacker can connect to your system and helps protect your data from unauthorized access.",
+            docID: 38, cisID: "2.3.3.4"
+        )
+    }
+
+    override func check() {
+        // Use launchctl to check if sshd is loaded — safe, no network connection attempted
+        let task = Process()
+        task.executableURL = URL(fileURLWithPath: "/bin/launchctl")
+        task.arguments = ["list", "com.openssh.sshd"]
+        task.standardOutput = Pipe()
+        task.standardError = Pipe()
+
+        do {
+            try task.run()
+            task.waitUntilExit()
+
+            if task.terminationStatus == 0 {
+                status = "Remote Login (SSH) is enabled."
+                checkstatus = "Red"
+            } else {
+                status = "Remote Login (SSH) is disabled."
+                checkstatus = "Green"
+            }
+        } catch let e {
+            print("Error checking \(name): \(e)")
+            self.error = e
+            checkstatus = "Yellow"
+            status = "Error checking Remote Login status"
+        }
+    }
+}
+</file>
+
+<file path="mergen/checkmodules/CISBenchmark/RemoteManagementCheck.swift">
+//
+//  RemoteManagementCheck.swift
+//  mergen
+//
+//  Created by Samet Sazak
+//
+
+import Foundation
+
+//This implementation uses two separate processes to execute the ps and grep commands, and passes output from the first process to the second process using a pipe. The grep command searches the output for the ARDAgent process, which is an indicator that Remote Management is enabled.
+
+class RemoteManagementDisabledCheck: Vulnerability {
+    init() {
+        super.init(
+            name: "Remote management disabled",
+            description: "This check ensures that the Remote Management (ARDagent) feature is disabled to prevent unauthorized access to your computer.",
+            category: "CIS Benchmark",
+            remediation: "To disable Remote Management, go to System Settings > Sharing and uncheck the 'Remote Management' option.",
+            severity: "Medium",
+            documentation: "https://support.apple.com/guide/mac-help/remote-management-mh14074/mac",
+            mitigation: "Disabling Remote Management minimizes the risk of unauthorized access to your computer by reducing the ways an attacker can remotely control your system.",
+            docID: 39, cisID: "2.3.3.5"
+        )
+    }
+
+    override func check() {
+        let task = Process()
+        task.executableURL = URL(fileURLWithPath: "/bin/ps")
+        task.arguments = ["-ef"]
+        
+        let grepTask = Process()
+        grepTask.executableURL = URL(fileURLWithPath: "/usr/bin/grep")
+        grepTask.arguments = ["-e", "ARDAgent", "-v", "grep"]
+        
+        let pipe = Pipe()
+        task.standardOutput = pipe
+        task.standardError = Pipe()
+        grepTask.standardInput = pipe
+        
+        do {
+            try task.run()
+            try grepTask.run()
+            task.waitUntilExit()
+            grepTask.waitUntilExit()
+            
+            if grepTask.terminationStatus == 0 {
+                status = "Remote Management is Enabled"
+                checkstatus = "Red"
+            } else {
+                status = "Remote Management is Disabled"
+                checkstatus = "Green"
+            }
+        } catch let e {
+            print("Error checking \(name): \(e)")
+            checkstatus = "Yellow"
+            status = "Error checking Remote Management status"
+            self.error = e
+        }
+    }
+}
+</file>
+
+<file path="mergen/checkmodules/CISBenchmark/RootAccountDisabledCheck.swift">
+//
+//  RootAccountDisabledCheck.swift
+//  mergen
+//
+//  CIS 5.6 - Ensure the "root" Account Is Disabled
+
+import Foundation
+
+class RootAccountDisabledCheck: Vulnerability {
+    init() {
+        super.init(
+            name: "Root Account Is Disabled",
+            description: "The root account has unlimited access to the system. Enabling it puts the system at risk. Administrators should use sudo instead. By default, root is disabled on macOS.",
+            category: "CIS Benchmark",
+            remediation: "Disable root with: sudo dsenableroot -d. To disable the root shell: dscl . -create /Users/root UserShell /usr/bin/false",
+            severity: "High",
+            documentation: "CIS Apple macOS 26 Tahoe Benchmark v1.0.0 - Recommendation 5.6",
+            mitigation: "Disabling root reduces the attack surface by requiring privilege escalation through sudo, which is auditable.",
+            checkstatus: "",
+            docID: 122,
+            cisID: "5.6"
+        )
+    }
+
+    override func check() {
+        let task = Process()
+        task.executableURL = URL(fileURLWithPath: "/usr/bin/dscl")
+        task.arguments = [".", "-read", "/Users/root", "UserShell"]
+
+        let outputPipe = Pipe()
+        let errorPipe = Pipe()
+        task.standardOutput = outputPipe
+        task.standardError = errorPipe
+
+        do {
+            try task.run()
+            task.waitUntilExit()
+
+            let output = String(data: outputPipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8)?
+                .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+
+            if output.contains("/usr/bin/false") {
+                status = "Root account is disabled (shell set to /usr/bin/false)."
+                checkstatus = "Green"
+            } else if output.contains("/bin/sh") || output.contains("/bin/zsh") || output.contains("/bin/bash") {
+                status = "Root account has an active shell: \(output)."
+                checkstatus = "Red"
+            } else {
+                status = "Root account shell status: \(output.isEmpty ? "unknown" : output)."
+                checkstatus = "Yellow"
+            }
+        } catch let e {
+            print("Error checking \(name): \(e)")
+            self.error = e
+            checkstatus = "Yellow"
+            status = "Error checking root account status"
+        }
+    }
+}
+</file>
+
+<file path="mergen/checkmodules/CISBenchmark/SafariAdvertisingPrivacyCheck.swift">
+//
+//  SafariAdvertisingPrivacyCheck.swift
+//  mergen
+//
+//  CIS 6.3.6 - Ensure Advertising Privacy Protection in Safari Is Enabled
+
+import Foundation
+
+class SafariAdvertisingPrivacyCheck: Vulnerability {
+    init() {
+        super.init(
+            name: "Safari Advertising Privacy Protection Is Enabled",
+            description: "Safari's privacy-preserving ad measurement (Private Click Measurement) allows basic ad effectiveness measurement without revealing which ad was clicked or building user profiles.",
+            category: "CIS Benchmark",
+            remediation: "Create an MDM profile with PayloadType com.apple.Safari and set WebKitPreferences.privateClickMeasurementEnabled to true.",
+            severity: "Low",
+            documentation: "CIS Apple macOS 26 Tahoe Benchmark v1.0.0 - Recommendation 6.3.6",
+            mitigation: "Enabling privacy-preserving ad measurement prevents advertisers from tracking users across sites while allowing basic analytics.",
+            checkstatus: "",
+            docID: 128,
+            cisID: "6.3.6"
+        )
+    }
+
+    override func check() {
+        let task = Process()
+        task.executableURL = URL(fileURLWithPath: "/usr/sbin/system_profiler")
+        task.arguments = ["SPConfigurationProfileDataType"]
+
+        let outputPipe = Pipe()
+        task.standardOutput = outputPipe
+        task.standardError = Pipe()
+
+        do {
+            try task.run()
+            task.waitUntilExit()
+
+            let output = String(data: outputPipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
+
+            if output.contains("privateClickMeasurementEnabled") {
+                if output.contains("privateClickMeasurementEnabled = 1") ||
+                   output.contains("privateClickMeasurementEnabled=1") {
+                    status = "Safari advertising privacy protection is enabled (via profile)."
+                    checkstatus = "Green"
+                } else {
+                    status = "Safari advertising privacy protection is not enabled (via profile)."
+                    checkstatus = "Red"
+                }
+            } else {
+                checkViaDefaults()
+            }
+        } catch let e {
+            print("Error checking \(name): \(e)")
+            self.error = e
+            checkstatus = "Yellow"
+            status = "Error checking Safari advertising privacy protection"
+        }
+    }
+
+    private func checkViaDefaults() {
+        let task = Process()
+        task.executableURL = URL(fileURLWithPath: "/usr/bin/env")
+        task.arguments = ["defaults", "read", "com.apple.Safari", "WebKitPreferences.privateClickMeasurementEnabled"]
+
+        let outputPipe = Pipe()
+        task.standardOutput = outputPipe
+        task.standardError = Pipe()
+
+        do {
+            try task.run()
+            task.waitUntilExit()
+
+            let output = String(data: outputPipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8)?
+                .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+
+            if output == "1" {
+                status = "Safari advertising privacy protection is enabled."
+                checkstatus = "Green"
+            } else {
+                status = "Safari advertising privacy protection status unknown."
+                checkstatus = "Yellow"
+            }
+        } catch {
+            checkstatus = "Yellow"
+            status = "Could not verify Safari advertising privacy status."
+        }
+    }
+}
+</file>
+
+<file path="mergen/checkmodules/CISBenchmark/SafariCrossSiteTrackingCheck.swift">
+//
+//  SafariCrossSiteTrackingCheck.swift
+//  mergen
+//
+//  CIS 6.3.4 - Ensure Prevent Cross-site Tracking in Safari Is Enabled
+
+import Foundation
+
+class SafariCrossSiteTrackingCheck: Vulnerability {
+    init() {
+        super.init(
+            name: "Safari Cross-Site Tracking Prevention Is Enabled",
+            description: "Cross-site tracking allows data brokers to follow users across the internet. Safari's Intelligent Tracking Prevention should be enabled to protect user privacy.",
+            category: "CIS Benchmark",
+            remediation: "Create an MDM profile with PayloadType com.apple.Safari, set BlockStoragePolicy to 2, WebKitPreferences.storageBlockingPolicy to 1, and WebKitStorageBlockingPolicy to 1.",
+            severity: "Medium",
+            documentation: "CIS Apple macOS 26 Tahoe Benchmark v1.0.0 - Recommendation 6.3.4",
+            mitigation: "Blocking cross-site tracking prevents data brokers from building user profiles across websites.",
+            checkstatus: "",
+            docID: 127,
+            cisID: "6.3.4"
+        )
+    }
+
+    override func check() {
+        let task = Process()
+        task.executableURL = URL(fileURLWithPath: "/usr/sbin/system_profiler")
+        task.arguments = ["SPConfigurationProfileDataType"]
+
+        let outputPipe = Pipe()
+        task.standardOutput = outputPipe
+        task.standardError = Pipe()
+
+        do {
+            try task.run()
+            task.waitUntilExit()
+
+            let output = String(data: outputPipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
+
+            if output.contains("BlockStoragePolicy") {
+                let hasCorrectValue = output.contains("BlockStoragePolicy = 2") ||
+                                     output.contains("BlockStoragePolicy=2")
+                if hasCorrectValue {
+                    status = "Safari cross-site tracking prevention is enabled (via profile)."
+                    checkstatus = "Green"
+                } else {
+                    status = "Safari cross-site tracking prevention may not be fully configured."
+                    checkstatus = "Red"
+                }
+            } else {
+                // Check user defaults
+                checkViaDefaults()
+            }
+        } catch let e {
+            print("Error checking \(name): \(e)")
+            self.error = e
+            checkstatus = "Yellow"
+            status = "Error checking Safari cross-site tracking prevention"
+        }
+    }
+
+    private func checkViaDefaults() {
+        let task = Process()
+        task.executableURL = URL(fileURLWithPath: "/usr/bin/env")
+        task.arguments = ["defaults", "read", "com.apple.Safari", "BlockStoragePolicy"]
+
+        let outputPipe = Pipe()
+        task.standardOutput = outputPipe
+        task.standardError = Pipe()
+
+        do {
+            try task.run()
+            task.waitUntilExit()
+
+            let output = String(data: outputPipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8)?
+                .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+
+            if output == "2" {
+                status = "Safari cross-site tracking prevention is enabled."
+                checkstatus = "Green"
+            } else {
+                status = "Safari cross-site tracking prevention is not fully configured."
+                checkstatus = "Yellow"
+            }
+        } catch {
+            checkstatus = "Yellow"
+            status = "Could not verify Safari cross-site tracking status."
+        }
+    }
+}
+</file>
+
+<file path="mergen/checkmodules/CISBenchmark/SafariFraudWarningCheck.swift">
+//
+//  SafariFraudWarningCheck.swift
+//  mergen
+//
+//  CIS 6.3.3 - Ensure Warn When Visiting A Fraudulent Website in Safari Is Enabled
+
+import Foundation
+
+class SafariFraudWarningCheck: Vulnerability {
+    init() {
+        super.init(
+            name: "Safari Fraudulent Website Warning Is Enabled",
+            description: "Safari uses the Google Safe Browsing API to warn users when visiting potentially fraudulent or malicious websites.",
+            category: "CIS Benchmark",
+            remediation: "Create an MDM profile with PayloadType com.apple.Safari and set WarnAboutFraudulentWebsites to true. Or enable in Safari > Settings > Security.",
+            severity: "Medium",
+            documentation: "CIS Apple macOS 26 Tahoe Benchmark v1.0.0 - Recommendation 6.3.3",
+            mitigation: "Fraudulent website warnings alert users before they load potentially malicious content.",
+            checkstatus: "",
+            docID: 126,
+            cisID: "6.3.3"
+        )
+    }
+
+    override func check() {
+        // Check via system_profiler for MDM profile first
+        let task = Process()
+        task.executableURL = URL(fileURLWithPath: "/usr/sbin/system_profiler")
+        task.arguments = ["SPConfigurationProfileDataType"]
+
+        let outputPipe = Pipe()
+        task.standardOutput = outputPipe
+        task.standardError = Pipe()
+
+        do {
+            try task.run()
+            task.waitUntilExit()
+
+            let output = String(data: outputPipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
+
+            if output.contains("WarnAboutFraudulentWebsites") {
+                if output.contains("WarnAboutFraudulentWebsites = 1") ||
+                   output.contains("WarnAboutFraudulentWebsites=1") {
+                    status = "Safari fraudulent website warning is enabled (via profile)."
+                    checkstatus = "Green"
+                } else {
+                    status = "Safari fraudulent website warning may be disabled (via profile)."
+                    checkstatus = "Red"
+                }
+            } else {
+                // Fall back to user defaults
+                checkViaDefaults()
+            }
+        } catch let e {
+            print("Error checking \(name): \(e)")
+            self.error = e
+            checkstatus = "Yellow"
+            status = "Error checking Safari fraud warning"
+        }
+    }
+
+    private func checkViaDefaults() {
+        let task = Process()
+        task.executableURL = URL(fileURLWithPath: "/usr/bin/env")
+        task.arguments = ["defaults", "read", "com.apple.Safari", "WarnAboutFraudulentWebsites"]
+
+        let outputPipe = Pipe()
+        task.standardOutput = outputPipe
+        task.standardError = Pipe()
+
+        do {
+            try task.run()
+            task.waitUntilExit()
+
+            let output = String(data: outputPipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8)?
+                .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+
+            if output == "1" {
+                status = "Safari fraudulent website warning is enabled."
+                checkstatus = "Green"
+            } else if output == "0" {
+                status = "Safari fraudulent website warning is disabled."
+                checkstatus = "Red"
+            } else {
+                status = "Safari fraudulent website warning state unknown (default is enabled)."
+                checkstatus = "Yellow"
+            }
+        } catch {
+            checkstatus = "Yellow"
+            status = "Could not verify Safari fraud warning status."
+        }
+    }
+}
+</file>
+
+<file path="mergen/checkmodules/CISBenchmark/SafariStatusBarCheck.swift">
+//
+//  SafariStatusBarCheck.swift
+//  mergen
+//
+//  CIS 6.3.10 - Ensure Show Status Bar Is Enabled in Safari
+
+import Foundation
+
+class SafariStatusBarCheck: Vulnerability {
+    init() {
+        super.init(
+            name: "Safari Status Bar Is Enabled",
+            description: "The Safari Status Bar shows the full URL of hovered links, allowing users to verify where a link points before clicking. This helps identify phishing and obfuscated URLs.",
+            category: "CIS Benchmark",
+            remediation: "Create an MDM profile with PayloadType com.apple.Safari and set ShowOverlayStatusBar to true.",
+            severity: "Low",
+            documentation: "CIS Apple macOS 26 Tahoe Benchmark v1.0.0 - Recommendation 6.3.10",
+            mitigation: "Showing the status bar allows users to review full link URLs before navigating, reducing phishing risk.",
+            checkstatus: "",
+            docID: 129,
+            cisID: "6.3.10"
+        )
+    }
+
+    override func check() {
+        let task = Process()
+        task.executableURL = URL(fileURLWithPath: "/usr/sbin/system_profiler")
+        task.arguments = ["SPConfigurationProfileDataType"]
+
+        let outputPipe = Pipe()
+        task.standardOutput = outputPipe
+        task.standardError = Pipe()
+
+        do {
+            try task.run()
+            task.waitUntilExit()
+
+            let output = String(data: outputPipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
+
+            if output.contains("ShowOverlayStatusBar") {
+                if output.contains("ShowOverlayStatusBar = 1") ||
+                   output.contains("ShowOverlayStatusBar=1") {
+                    status = "Safari status bar is enabled (via profile)."
+                    checkstatus = "Green"
+                } else {
+                    status = "Safari status bar is not enabled (via profile)."
+                    checkstatus = "Red"
+                }
+            } else {
+                checkViaDefaults()
+            }
+        } catch let e {
+            print("Error checking \(name): \(e)")
+            self.error = e
+            checkstatus = "Yellow"
+            status = "Error checking Safari status bar"
+        }
+    }
+
+    private func checkViaDefaults() {
+        let task = Process()
+        task.executableURL = URL(fileURLWithPath: "/usr/bin/env")
+        task.arguments = ["defaults", "read", "com.apple.Safari", "ShowOverlayStatusBar"]
+
+        let outputPipe = Pipe()
+        task.standardOutput = outputPipe
+        task.standardError = Pipe()
+
+        do {
+            try task.run()
+            task.waitUntilExit()
+
+            let output = String(data: outputPipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8)?
+                .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+
+            if output == "1" {
+                status = "Safari status bar is enabled."
+                checkstatus = "Green"
+            } else if output == "0" {
+                status = "Safari status bar is disabled."
+                checkstatus = "Red"
+            } else {
+                status = "Safari status bar state unknown."
+                checkstatus = "Yellow"
+            }
+        } catch {
+            checkstatus = "Yellow"
+            status = "Could not verify Safari status bar setting."
+        }
+    }
+}
+</file>
+
+<file path="mergen/checkmodules/CISBenchmark/ScreenSaverCornersCheck.swift">
+//
+//  ScreenSaverCornersCheck.swift
+//  mergen
+//
+//  Created by Samet Sazak
+//
+
+import Foundation
+
+class ScreenSaverCornersCheck: Vulnerability {
+    init() {
+        super.init(
+            name: "Screen saver corners configured",
+            description: "This check ensures that Screen Saver Corners are set to a secure option, preventing the screen saver from being easily deactivated and reducing potential security risks.",
+            category: "CIS Benchmark",
+            remediation: "To set Screen Saver Corners to a secure option, go to System Settings > Desktop & Screen Saver > Screen Saver > Hot Corners and select secure options for each corner.",
+            severity: "Low",
+            documentation: "Setting secure options for Screen Saver Corners helps prevent unauthorized access to your computer when the screen saver is active.",
+            mitigation: "Configuring Screen Saver Corners with secure options ensures that the screen saver can only be deactivated using a secure method, enhancing the security of your system.",
+            docID: 54, cisID: "2.7.1"
+        )
+    }
+
+    override func check() {
+        // CIS: no hot corner should be set to value 6 ("Disable Screen Saver")
+        // Each corner key is read separately; defaults read only accepts one key at a time.
+        let cornerKeys = ["wvous-tl-corner", "wvous-tr-corner", "wvous-bl-corner", "wvous-br-corner"]
+        var cornerValues: [String] = []
+
+        for key in cornerKeys {
+            let task = Process()
+            task.executableURL = URL(fileURLWithPath: "/usr/bin/defaults")
+            task.arguments = ["read", "com.apple.dock", key]
+            let pipe = Pipe()
+            task.standardOutput = pipe
+            task.standardError = Pipe()
+            do {
+                try task.run()
+                task.waitUntilExit()
+                let val = String(data: pipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8)?
+                    .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+                cornerValues.append(val)
+            } catch {
+                cornerValues.append("")
+            }
+        }
+
+        // Value 6 = "Disable Screen Saver" — insecure per CIS
+        if cornerValues.contains("6") {
+            status = "A hot corner is set to 'Disable Screen Saver', which bypasses the lock screen."
+            checkstatus = "Red"
+        } else {
+            status = "No hot corner is configured to disable the screen saver."
+            checkstatus = "Green"
+        }
+    }
+}
+</file>
+
+<file path="mergen/checkmodules/CISBenchmark/ScreenSaverIntervalCheck.swift">
+//
+//  ScreenSaverIntervalCheck.swift
+//  mergen
+//
+//  Created by Samet Sazak
+//
+
+
+import Foundation
+
+class ScreenSaverInactivityCheck: Vulnerability {
+
+    init() {
+        super.init(
+            name: "Screen saver activates within 20 minutes",
+            description: "This checks if the computer screen saver activates within 20 minutes of inactivity. A shorter inactivity period helps protect your computer from unauthorized access.",
+            category: "CIS Benchmark",
+            remediation: "Set the screen saver inactivity interval to 20 minutes or less.",
+            severity: "Low",
+            documentation: "A longer inactivity interval increases the risk of unauthorized access to a user's system and potentially sensitive data. This code checks if the screen saver activates within 20 minutes of inactivity.",
+            mitigation: "Set the screen saver inactivity interval to 20 minutes or less to minimize the risk of unauthorized access.",
+            docID: 57, cisID: "2.11.1"
+        )
+    }
+
+    override func check() {
+        // On macOS 26 Tahoe, `defaults read com.apple.screensaver idleTime` may return
+        // nothing for the user domain. Try -currentHost (hardware-specific prefs) first,
+        // then fall back to the plain user domain.
+        let idleTime = readIdleTime(currentHost: true) ?? readIdleTime(currentHost: false)
+
+        guard let value = idleTime else {
+            status = "Screen saver inactivity interval is not set (screen saver may be disabled)."
+            checkstatus = "Red"
+            return
+        }
+
+        if value == 0 {
+            status = "Screen saver is disabled (idleTime = 0)."
+            checkstatus = "Red"
+        } else if value <= 1200 {
+            status = "Screen saver activates after \(value / 60) minute(s) — within the 20-minute CIS limit."
+            checkstatus = "Green"
+        } else {
+            status = "Screen saver activates after \(value / 60) minute(s), which exceeds the 20-minute CIS limit."
+            checkstatus = "Red"
+        }
+    }
+
+    private func readIdleTime(currentHost: Bool) -> Int? {
+        let task = Process()
+        task.executableURL = URL(fileURLWithPath: "/usr/bin/defaults")
+        task.arguments = currentHost
+            ? ["-currentHost", "read", "com.apple.screensaver", "idleTime"]
+            : ["read", "com.apple.screensaver", "idleTime"]
+
+        let pipe = Pipe()
+        task.standardOutput = pipe
+        task.standardError = Pipe()
+
+        do {
+            try task.run()
+            task.waitUntilExit()
+            guard task.terminationStatus == 0 else { return nil }
+            let raw = String(data: pipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8)?
+                .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+            return Int(raw)
+        } catch {
+            return nil
+        }
+    }
+}
+</file>
+
+<file path="mergen/checkmodules/CISBenchmark/ScreenSharingDisabledCheck.swift">
+//
+//  ScreenSharingDisabledCheck.swift
+//  mergen
+//
+//  Created by Samet Sazak
+//
+
+import Foundation
+
+class ScreenSharingDisabledCheck: Vulnerability {
+    init() {
+        super.init(
+            name: "Screen sharing disabled",
+            description: "This check ensures that your Screen Sharing feature is disabled to prevent unauthorized access to your computer.",
+            category: "CIS Benchmark",
+            remediation: "To disable Screen Sharing, go to System Settings > Sharing and uncheck the 'Screen Sharing' option.",
+            severity: "Medium",
+            documentation: "https://support.apple.com/guide/mac-help/share-the-screen-of-another-mac-mh14066/mac",
+            mitigation: "Disabling Screen Sharing reduces the risk of unauthorized access to your computer's files and resources by minimizing the ways an attacker can connect to your system.",
+            docID: 18, cisID: "2.3.3.1"
+        )
+    }
+
+    override func check() {
+        let task = Process()
+        task.executableURL = URL(fileURLWithPath: "/bin/launchctl")
+        task.arguments = ["list", "com.apple.screensharing"]
+        task.standardOutput = Pipe()
+        task.standardError = Pipe()
+
+        do {
+            try task.run()
+            task.waitUntilExit()
+
+            // exit 0 means the service IS loaded (screen sharing IS enabled) → Red
+            if task.terminationStatus == 0 {
+                status = "Screen Sharing is Enabled"
+                checkstatus = "Red"
+            } else {
+                status = "Screen Sharing is Disabled"
+                checkstatus = "Green"
+            }
+        } catch let e {
+            print("Error checking \(name): \(e)")
+            checkstatus = "Yellow"
+            status = "Error checking Screen Sharing status"
+            self.error = e
+        }
+    }
+}
+</file>
+
+<file path="mergen/checkmodules/CISBenchmark/SecureKernelExtensionLoadingCheck.swift">
+//
+//  SecureKernelExtensionLoadingCheck.swift
+//  mergen
+//
+//  Created by Samet Sazak
+//
+//Tested in 13-inch, 2020, Four Thunderbolt 3 ports 13.2.1 (22D68)
+
+import Foundation
+
+class SecureKernelExtensionLoadingCheck: Vulnerability {
+    init() {
+        super.init(
+            name: "Secure kernel extension loading enforced",
+            description: "Verify that Secure Kernel Extension Loading is enabled to protect your Mac from potentially harmful kernel extensions",
+            category: "CIS Benchmark",
+            remediation: "Enable Secure Kernel Extension Loading by booting into Recovery Mode, opening Terminal, and running 'csrutil enable', then restart your Mac",
+            severity: "Medium",
+            documentation: "https://support.apple.com/en-us/HT204899",
+            mitigation: "Secure Kernel Extension Loading prevents unsigned kernel extensions from being loaded, providing an additional layer of security against potentially malicious software.",
+            checkstatus: "",
+            docID: 1, cisID: "5.1.x"
+        )
+    }
+
+    override func check() {
+        let task = Process()
+        task.executableURL = URL(fileURLWithPath: "/usr/bin/env")
+        task.arguments = ["csrutil", "status"]
+
+        let pipe = Pipe()
+        task.standardOutput = pipe
+        task.standardError = Pipe()
+
+        do {
+            try task.run()
+            task.waitUntilExit()
+            
+            if task.terminationStatus == 0 {
+                let data = pipe.fileHandleForReading.readDataToEndOfFile()
+                if let output = String(data: data, encoding: .utf8) {
+                    if output.contains("enabled") {
+                        status = "Secure Kernel Extension Loading is Enabled"
+                        checkstatus = "Green"
+                    } else {
+                        status = "Secure Kernel Extension Loading is Disabled"
+                        checkstatus = "Red"
+                    }
+                } else {
+                    status = "Error parsing Secure Kernel Extension Loading status"
+                    checkstatus = "Yellow"
+                }
+            } else {
+                status = "Error checking Secure Kernel Extension Loading status (requires root privileges)"
+                checkstatus = "Yellow"
+            }
+        } catch let e {
+            print("Error checking \(name): \(e)")
+            checkstatus = "Yellow"
+            status = "Error checking Secure Kernel Extension Loading status"
+            self.error = e
+        }
+    }
+}
+</file>
+
+<file path="mergen/checkmodules/CISBenchmark/SecurityUpdateCheck.swift">
+//
+//  SecurityUpdateCheck.swift
+//  mergen
+//
+//  Created by Samet Sazak
+//
+
+//Tested in 13-inch, 2020, Four Thunderbolt 3 ports 13.2.1 (22D68)
+
+import Foundation
+
+class SecurityUpdatesCheck: Vulnerability {
+    init() {
+        super.init(
+            name: "Security responses auto-install enabled",
+            description: "Check if 'Install system data files and security updates' is enabled in the App Store preferences",
+            category: "CIS Benchmark",
+            remediation: "Enable 'Install system data files and security updates' in the App Store preferences",
+            severity: "Medium",
+            documentation: "https://support.apple.com/en-us/HT202180",
+            mitigation: "Enabling automatic installation of system data files and security updates helps ensure that security patches and software updates are installed in a timely manner.",
+            checkstatus: "",
+            docID: 10, cisID: "1.5"
+        )
+    }
+
+    override func check() {
+        let task = Process()
+        task.executableURL = URL(fileURLWithPath: "/usr/bin/defaults")
+        task.arguments = ["read", "/Library/Preferences/com.apple.SoftwareUpdate", "ConfigDataInstall"]
+
+        let outputPipe = Pipe()
+        task.standardOutput = outputPipe
+        task.standardError = Pipe()
+
+        do {
+            try task.run()
+            task.waitUntilExit()
+
+            let outputData = outputPipe.fileHandleForReading.readDataToEndOfFile()
+            let output = String(data: outputData, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+
+            if output.lowercased() == "1" {
+                status = "Install system data files and security updates' is enabled"
+                checkstatus = "Green"
+            } else {
+                status = "Install system data files and security updates' is not enabled"
+                checkstatus = "Red"
+            }
+        } catch let e {
+            print("Error checking \(name): \(e)")
+            checkstatus = "Yellow"
+            status = "Error checking security update status"
+            self.error = e
+        }
+    }
+}
+</file>
+
+<file path="mergen/checkmodules/CISBenchmark/SetTimeAndDateAutomaticallyEnabledCheck.swift">
+//
+//  SetTimeAndDateAutomaticallyEnabledCheck.swift
+//  mergen
+//
+//  Created by Samet Sazak
+//
+
+import Foundation
+
+class SetTimeAndDateAutomaticallyEnabledCheck: Vulnerability {
+    init() {
+        super.init(
+            name: "Time set automatically",
+            description: "This check ensures that your computer automatically updates its date and time settings. This helps maintain accurate timekeeping and prevent potential security issues.",
+            category: "CIS Benchmark",
+            remediation: "To enable automatic date and time updates, go to System Settings > Date & Time and check the box next to 'Set date and time automatically'.",
+            severity: "Medium",
+            documentation: "https://support.apple.com/guide/mac-help/set-the-date-and-time-mh35851/mac",
+            mitigation: "Keeping your computer's date and time accurate helps ensure proper functioning of the system and its applications. It also helps avoid potential security issues related to incorrect timekeeping.",
+            docID: 15, cisID: "2.3.2.1"
+        )
+    }
+
+    override func check() {
+        let task = Process()
+        task.executableURL = URL(fileURLWithPath: "/usr/bin/defaults")
+        task.arguments = ["read", "/Library/Preferences/com.apple.timezone.auto.plist", "Active"]
+
+        let outputPipe = Pipe()
+        task.standardOutput = outputPipe
+        task.standardError = Pipe()
+
+        do {
+            try task.run()
+            task.waitUntilExit()
+
+            let outputData = outputPipe.fileHandleForReading.readDataToEndOfFile()
+            let output = String(data: outputData, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+
+            if output.lowercased() == "1" {
+                status = "Set Time and Date Automatically is Enabled"
+                checkstatus = "Green"
+            } else {
+                status = "Set Time and Date Automatically is Disabled"
+                checkstatus = "Red"
+            }
+        } catch let e {
+            print("Error checking \(name): \(e)")
+            checkstatus = "Yellow"
+            status = "Error checking Set Time and Date Automatically status"
+            self.error = e
+        }
+    }
+}
+</file>
+
+<file path="mergen/checkmodules/CISBenchmark/ShareMacAnalyticsCheck.swift">
+//
+//  ShareMacAnalyticsCheck.swift
+//  mergen
+//
+//  CIS 2.6.3.1 - Ensure Share Mac Analytics Is Disabled
+
+import Foundation
+
+class ShareMacAnalyticsCheck: Vulnerability {
+    init() {
+        super.init(
+            name: "Share Mac Analytics Is Disabled",
+            description: "Share Mac Analytics automatically sends diagnostic and usage data to Apple. Organizations should control what data is shared with vendors.",
+            category: "CIS Benchmark",
+            remediation: "Create an MDM profile with PayloadType com.apple.SubmitDiagInfo and set AutoSubmit to false. Or go to System Settings > Privacy & Security > Analytics & Improvements and disable Share Mac Analytics.",
+            severity: "Low",
+            documentation: "CIS Apple macOS 26 Tahoe Benchmark v1.0.0 - Recommendation 2.6.3.1",
+            mitigation: "Disabling Mac Analytics prevents internal organizational data from being automatically forwarded to Apple.",
+            checkstatus: "",
+            docID: 105,
+            cisID: "2.6.3.1"
+        )
+    }
+
+    override func check() {
+        let task = Process()
+        task.executableURL = URL(fileURLWithPath: "/usr/bin/osascript")
+        task.arguments = ["-l", "JavaScript", "-e",
+            "$.NSUserDefaults.alloc.initWithSuiteName('com.apple.SubmitDiagInfo').objectForKey('AutoSubmit').js"]
+
+        let outputPipe = Pipe()
+        let errorPipe = Pipe()
+        task.standardOutput = outputPipe
+        task.standardError = errorPipe
+
+        do {
+            try task.run()
+            task.waitUntilExit()
+
+            let output = String(data: outputPipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8)?
+                .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+
+            if output == "false" {
+                status = "Share Mac Analytics is disabled."
+                checkstatus = "Green"
+            } else if output == "true" {
+                status = "Share Mac Analytics is enabled."
+                checkstatus = "Red"
+            } else {
+                // Fall back to direct defaults read (user-level)
+                checkViaDefaults()
+            }
+        } catch let e {
+            print("Error checking \(name): \(e)")
+            self.error = e
+            checkstatus = "Yellow"
+            status = "Error checking Share Mac Analytics"
+        }
+    }
+
+    private func checkViaDefaults() {
+        let task = Process()
+        task.executableURL = URL(fileURLWithPath: "/usr/bin/env")
+        task.arguments = ["defaults", "read", "com.apple.SubmitDiagInfo", "AutoSubmit"]
+
+        let outputPipe = Pipe()
+        task.standardOutput = outputPipe
+        task.standardError = Pipe()
+
+        do {
+            try task.run()
+            task.waitUntilExit()
+
+            let output = String(data: outputPipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8)?
+                .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+
+            if output == "0" {
+                status = "Share Mac Analytics is disabled."
+                checkstatus = "Green"
+            } else if output == "1" {
+                status = "Share Mac Analytics is enabled."
+                checkstatus = "Red"
+            } else {
+                status = "Share Mac Analytics state could not be determined."
+                checkstatus = "Yellow"
+            }
+        } catch {
+            checkstatus = "Yellow"
+            status = "Share Mac Analytics state could not be determined."
+        }
+    }
+}
+</file>
+
+<file path="mergen/checkmodules/CISBenchmark/ShareWithAppDevelopersCheck.swift">
+//
+//  ShareWithAppDevelopersCheck.swift
+//  mergen
+//
+//  CIS 2.6.3.4 - Ensure 'Share with app developers' Is Disabled
+
+import Foundation
+
+class ShareWithAppDevelopersCheck: Vulnerability {
+    init() {
+        super.init(
+            name: "Share with App Developers Is Disabled",
+            description: "This setting allows Apple to share crash and usage data with app developers. Organizations should control what diagnostic data is shared with third parties.",
+            category: "CIS Benchmark",
+            remediation: "Create an MDM profile with PayloadType com.apple.applicationaccess and set allowDiagnosticSubmission to false.",
+            severity: "Low",
+            documentation: "CIS Apple macOS 26 Tahoe Benchmark v1.0.0 - Recommendation 2.6.3.4",
+            mitigation: "Disabling app developer data sharing prevents crash and usage information from being forwarded to third-party developers.",
+            checkstatus: "",
+            docID: 108,
+            cisID: "2.6.3.4"
+        )
+    }
+
+    override func check() {
+        let task = Process()
+        task.executableURL = URL(fileURLWithPath: "/usr/bin/osascript")
+        task.arguments = ["-l", "JavaScript", "-e",
+            "$.NSUserDefaults.alloc.initWithSuiteName('com.apple.applicationaccess').objectForKey('allowDiagnosticSubmission').js"]
+
+        let outputPipe = Pipe()
+        let errorPipe = Pipe()
+        task.standardOutput = outputPipe
+        task.standardError = errorPipe
+
+        do {
+            try task.run()
+            task.waitUntilExit()
+
+            let output = String(data: outputPipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8)?
+                .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+
+            if output == "false" {
+                status = "Share with App Developers is disabled."
+                checkstatus = "Green"
+            } else if output == "true" {
+                status = "Share with App Developers is enabled."
+                checkstatus = "Red"
+            } else {
+                status = "Share with App Developers state unknown (may require MDM profile)."
+                checkstatus = "Yellow"
+            }
+        } catch let e {
+            print("Error checking \(name): \(e)")
+            self.error = e
+            checkstatus = "Yellow"
+            status = "Error checking Share with App Developers setting"
+        }
+    }
+}
+</file>
+
+<file path="mergen/checkmodules/CISBenchmark/ShowWifiMenuCheck.swift">
+//
+//  ShowWifiMenuCheck.swift
+//  mergen
+//
+//  Created by Samet Sazak
+//
+
+import Foundation
+
+//This script checks if the AirPort.menu is included in the menuExtras property of the com.apple.systemuiserver domain in the defaults command output. If it is present, then the Wi-Fi status is shown in the menu bar and the check passes. Otherwise, the check fails.
+
+class ShowWiFiStatusCheck: Vulnerability {
+    init() {
+        super.init(
+            name: "Wi-Fi status shown in menu bar",
+            description: "This check ensures that the Wi-Fi status is shown in the menu bar, allowing you to quickly check the Wi-Fi status and connect to available networks.",
+            category: "CIS Benchmark",
+            remediation: "To enable 'Show Wi-Fi status in menu bar', go to System Settings > Network and check the option.",
+            severity: "Low",
+            documentation: "For more information on how to use the Wi-Fi status menu, visit: https://support.apple.com/guide/mac-help/use-the-wi-fi-status-menu-mchlp1540/mac",
+            mitigation: "Displaying Wi-Fi status in the menu bar provides an accessible way to monitor your connection and manage Wi-Fi networks.",
+            docID: 48
+        )
+    }
+    
+    override func check() {
+        let task = Process()
+        task.executableURL = URL(fileURLWithPath: "/usr/bin/defaults")
+        task.arguments = ["read", "com.apple.systemuiserver", "menuExtras"]
+        
+        do {
+            let outputPipe = Pipe()
+            task.standardOutput = outputPipe
+        task.standardError = Pipe()
+            try task.run()
+            task.waitUntilExit()
+
+            if task.terminationStatus == 0 {
+                let outputData = outputPipe.fileHandleForReading.readDataToEndOfFile()
+                let outputString = String(data: outputData, encoding: .utf8)
+                if outputString?.contains("AirPort.menu") == true {
+                    status = "Show Wi-Fi status in menu bar is Enabled"
+                    checkstatus = "Green"
+                } else {
+                    status = "Show Wi-Fi status in menu bar is Disabled"
+                    checkstatus = "Red"
+                }
+            } else {
+                status = "Error checking Wi-Fi status"
+                checkstatus = "Yellow"
+                self.error = NSError(domain: NSPOSIXErrorDomain, code: Int(task.terminationStatus), userInfo: nil)
+            }
+        } catch let e {
+            print("Error checking \(name): \(e)")
+            checkstatus = "Yellow"
+            status = "Error checking Wi-Fi status"
+            self.error = e
+        }
+    }
+}
+</file>
+
+<file path="mergen/checkmodules/CISBenchmark/SleepEnabledAppleSiliconCheck.swift">
+//
+//  SleepEnabledAppleSiliconCheck.swift
+//  mergen
+//
+//  CIS 2.10.1.2 - Ensure Sleep and Display Sleep Is Enabled on Apple Silicon Devices
+
+import Foundation
+
+class SleepEnabledAppleSiliconCheck: Vulnerability {
+    init() {
+        super.init(
+            name: "Sleep ≤ 15 min & Display Sleep ≤ 10 min (Apple Silicon)",
+            description: "MacBooks with Apple Silicon should sleep after ≤ 15 minutes of inactivity and display sleep after ≤ 10 minutes. This limits exposure when the device is unattended.",
+            category: "CIS Benchmark",
+            remediation: "Run: sudo pmset -a sleep 15 && sudo pmset -a displaysleep 10. This only applies to Apple Silicon MacBooks.",
+            severity: "Medium",
+            documentation: "CIS Apple macOS 26 Tahoe Benchmark v1.0.0 - Recommendation 2.10.1.2",
+            mitigation: "Automatic sleep prevents unauthorized access to an unattended unlocked machine.",
+            checkstatus: "",
+            docID: 111,
+            cisID: "2.10.1.2"
+        )
+    }
+
+    override func check() {
+        // First check if this is a MacBook with Apple Silicon
+        let cpuTask = Process()
+        cpuTask.executableURL = URL(fileURLWithPath: "/usr/sbin/sysctl")
+        cpuTask.arguments = ["-n", "machdep.cpu.brand_string"]
+
+        let cpuPipe = Pipe()
+        cpuTask.standardOutput = cpuPipe
+        cpuTask.standardError = Pipe()
+
+        do {
+            try cpuTask.run()
+            cpuTask.waitUntilExit()
+            let cpuOutput = String(data: cpuPipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
+
+            // If it's an Intel Mac, this check doesn't apply
+            if cpuOutput.contains("Intel") {
+                status = "Not applicable — this check is for Apple Silicon Macs only."
+                checkstatus = "Green"
+                return
+            }
+
+            // Check sleep value
+            let pmsetTask = Process()
+            pmsetTask.executableURL = URL(fileURLWithPath: "/usr/bin/pmset")
+            pmsetTask.arguments = ["-b", "-g"]
+
+            let pmsetPipe = Pipe()
+            pmsetTask.standardOutput = pmsetPipe
+            pmsetTask.standardError = Pipe()
+
+            try pmsetTask.run()
+            pmsetTask.waitUntilExit()
+
+            let pmsetOutput = String(data: pmsetPipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
+
+            var sleepOk = false
+            var displaySleepOk = false
+
+            for line in pmsetOutput.components(separatedBy: "\n") {
+                let trimmed = line.trimmingCharacters(in: .whitespaces)
+                // Split on whitespace runs (pmset output uses multiple spaces for alignment)
+                let parts = trimmed.components(separatedBy: .whitespaces).filter { !$0.isEmpty }
+                if trimmed.hasPrefix("sleep") {
+                    if let val = parts.dropFirst().first.flatMap({ Int($0) }), val <= 15 {
+                        sleepOk = true
+                    }
+                } else if trimmed.hasPrefix("displaysleep") {
+                    if let val = parts.dropFirst().first.flatMap({ Int($0) }), val <= 10 {
+                        displaySleepOk = true
+                    }
+                }
+            }
+
+            if sleepOk && displaySleepOk {
+                status = "Sleep and display sleep are configured correctly (≤ 15 min / ≤ 10 min)."
+                checkstatus = "Green"
+            } else {
+                status = "Sleep or display sleep exceeds recommended thresholds (sleep ≤ 15 min, display sleep ≤ 10 min)."
+                checkstatus = "Red"
+            }
+        } catch let e {
+            print("Error checking \(name): \(e)")
+            self.error = e
+            checkstatus = "Yellow"
+            status = "Error checking sleep settings"
+        }
+    }
+}
+</file>
+
+<file path="mergen/checkmodules/CISBenchmark/SlowModule.swift">
+//
+//  SlowModule.swift
+//  mergen
+//
+//  Created by Samet Sazak
+//
+
+import Foundation
+
+class SlowModule: Vulnerability {
+    init() {
+        super.init(
+            name: "Slow Module",
+            description: "A module that takes a long time to complete",
+            category: "Performance",
+            remediation: "None",
+            severity: "Low",
+            documentation: "",
+            mitigation: "",
+            checkstatus: "",
+            docID: 0
+        )
+    }
+
+    override func check() {
+        sleep(30)
+        status = "Module completed"
+        checkstatus = "Green"
+    }
+}
+</file>
+
+<file path="mergen/checkmodules/CISBenchmark/SoftwareUpdateDefermentCheck.swift">
+//
+//  SoftwareUpdateDefermentCheck.swift
+//  mergen
+//
+//  CIS 1.6 - Ensure Software Update Deferment Is Less Than or Equal to 30 Days
+
+import Foundation
+
+class SoftwareUpdateDefermentCheck: Vulnerability {
+    init() {
+        super.init(
+            name: "Software Update Deferment ≤ 30 Days",
+            description: "Software updates should not be deferred for more than 30 days. Attackers evaluate updates to create exploits against unpatched systems.",
+            category: "CIS Benchmark",
+            remediation: "Configure a MDM profile with PayloadType com.apple.applicationaccess and set enforcedSoftwareUpdateDelay to an integer ≤ 30. If no deferment profile is installed this check passes.",
+            severity: "Medium",
+            documentation: "CIS Apple macOS 26 Tahoe Benchmark v1.0.0 - Recommendation 1.6",
+            mitigation: "Keeping update deferment within 30 days ensures security patches are applied promptly, reducing exploit windows.",
+            checkstatus: "",
+            docID: 100,
+            cisID: "1.6"
+        )
+    }
+
+    override func check() {
+        let task = Process()
+        task.executableURL = URL(fileURLWithPath: "/usr/bin/osascript")
+        task.arguments = ["-l", "JavaScript", "-e",
+            "$.NSUserDefaults.alloc.initWithSuiteName('com.apple.applicationaccess').objectForKey('enforcedSoftwareUpdateDelay').js"]
+
+        let outputPipe = Pipe()
+        let errorPipe = Pipe()
+        task.standardOutput = outputPipe
+        task.standardError = errorPipe
+
+        do {
+            try task.run()
+            task.waitUntilExit()
+
+            let output = String(data: outputPipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8)?
+                .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+
+            if output.isEmpty || output == "undefined" || output == "null" {
+                status = "No update deferment policy installed — passes by default."
+                checkstatus = "Green"
+            } else if let days = Int(output), days <= 30 {
+                status = "Software update deferment is set to \(days) days (≤ 30)."
+                checkstatus = "Green"
+            } else {
+                status = "Software update deferment is set to \(output) days (> 30)."
+                checkstatus = "Red"
+            }
+        } catch let e {
+            print("Error checking \(name): \(e)")
+            self.error = e
+            checkstatus = "Yellow"
+            status = "Error checking software update deferment"
+        }
+    }
+}
+</file>
+
+<file path="mergen/checkmodules/CISBenchmark/SpotlightImprovementCheck.swift">
+//
+//  SpotlightImprovementCheck.swift
+//  mergen
+//
+//  CIS 2.9.1 - Ensure Help Apple Improve Search Is Disabled
+
+import Foundation
+
+class SpotlightImprovementCheck: Vulnerability {
+    init() {
+        super.init(
+            name: "Spotlight 'Help Apple Improve Search' Is Disabled",
+            description: "Apple provides a mechanism to send Spotlight search metadata back to Apple. Information sent may contain internal organizational data that should be controlled.",
+            category: "CIS Benchmark",
+            remediation: "Create an MDM profile with PayloadType com.apple.assistant.support and set 'Search Queries Data Sharing Status' to 2 (integer).",
+            severity: "Low",
+            documentation: "CIS Apple macOS 26 Tahoe Benchmark v1.0.0 - Recommendation 2.9.1",
+            mitigation: "Disabling search query sharing prevents Spotlight metadata from being forwarded to Apple.",
+            checkstatus: "",
+            docID: 110,
+            cisID: "2.9.1"
+        )
+    }
+
+    override func check() {
+        let task = Process()
+        task.executableURL = URL(fileURLWithPath: "/usr/bin/osascript")
+        task.arguments = ["-l", "JavaScript", "-e",
+            "$.NSUserDefaults.alloc.initWithSuiteName('com.apple.assistant.support').objectForKey('Search Queries Data Sharing Status').js"]
+
+        let outputPipe = Pipe()
+        let errorPipe = Pipe()
+        task.standardOutput = outputPipe
+        task.standardError = errorPipe
+
+        do {
+            try task.run()
+            task.waitUntilExit()
+
+            let output = String(data: outputPipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8)?
+                .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+
+            if output == "2" {
+                status = "Help Apple Improve Search is disabled."
+                checkstatus = "Green"
+            } else if output.isEmpty || output == "undefined" || output == "null" || output == "1" {
+                status = "Help Apple Improve Search may be enabled (status: \(output.isEmpty ? "not set" : output))."
+                checkstatus = "Red"
+            } else {
+                status = "Spotlight improvement status unknown."
+                checkstatus = "Yellow"
+            }
+        } catch let e {
+            print("Error checking \(name): \(e)")
+            self.error = e
+            checkstatus = "Yellow"
+            status = "Error checking Spotlight improvement setting"
+        }
+    }
+}
+</file>
+
+<file path="mergen/checkmodules/CISBenchmark/SshEnableCheck.swift">
+//
+//  SshEnableCheck.swift
+//  mergen
+//
+//  Created by Samet Sazak
+//
+
+//Tested in 13-inch, 2020, Four Thunderbolt 3 ports 13.2.1 (22D68)
+import Foundation
+
+class SSHCheck: Vulnerability {
+    init() {
+        super.init(
+            name: "SSH disabled",
+            description: "Check if SSH is enabled and running",
+            category: "CIS Benchmark",
+            remediation: "Disable SSH or configure it securely by following the recommended practices",
+            severity: "High",
+            documentation: "https://support.apple.com/guide/mac-help/use-remote-login-mchlp1066/mac",
+            mitigation: "Disabling SSH, if not needed, or configuring it securely reduces the attack surface and helps prevent unauthorized access to your computer. Follow best practices for secure SSH configuration, such as using strong authentication methods and limiting access to specific users.",
+            checkstatus: "",
+            docID: 4
+        )
+    }
+    override func check() {
+        let task = Process()
+        task.executableURL = URL(fileURLWithPath: "/bin/launchctl")
+        task.arguments = ["print-disabled", "system"]
+
+        do {
+            let outputPipe = Pipe()
+            task.standardOutput = outputPipe
+            task.standardError = Pipe()
+            try task.run()
+            task.waitUntilExit()
+
+            if task.terminationStatus == 0 {
+                let outputData = outputPipe.fileHandleForReading.readDataToEndOfFile()
+                let outputString = String(data: outputData, encoding: .utf8)
+
+                if let outputString = outputString, outputString.contains("\"com.openssh.sshd\" => disabled") {
+                    status = "SSH is Disabled"
+                    checkstatus = "Green"
+                } else {
+                    status = "SSH is Enabled"
+                    checkstatus = "Red"
+                }
+            } else {
+                status = "Error checking SSH status"
+                checkstatus = "Yellow"
+            }
+        } catch let e {
+            print("Error checking \(name): \(e)")
+            checkstatus = "Yellow"
+            status = "Error checking SSH status"
+            self.error = e
+        }
+    }
+}
+</file>
+
+<file path="mergen/checkmodules/CISBenchmark/SSVEnabledCheck.swift">
+//
+//  SSVEnabledCheck.swift
+//  mergen
+//
+//  CIS 5.1.4 - Ensure Signed System Volume (SSV) Is Enabled
+
+import Foundation
+
+class SSVEnabledCheck: Vulnerability {
+    init() {
+        super.init(
+            name: "Signed System Volume (SSV) Is Enabled",
+            description: "Signed System Volume is a security feature that cryptographically seals the system volume. macOS will not boot if system files have been tampered with.",
+            category: "CIS Benchmark",
+            remediation: "If SSV is disabled, assume the OS is compromised. Back up your files and do a clean install. SSV is enabled by default and should never be disabled on a production system.",
+            severity: "High",
+            documentation: "CIS Apple macOS 26 Tahoe Benchmark v1.0.0 - Recommendation 5.1.4",
+            mitigation: "SSV ensures system files have not been tampered with, providing boot-time integrity verification.",
+            checkstatus: "",
+            docID: 117,
+            cisID: "5.1.4"
+        )
+    }
+
+    override func check() {
+        let task = Process()
+        task.executableURL = URL(fileURLWithPath: "/usr/bin/csrutil")
+        task.arguments = ["authenticated-root", "status"]
+
+        let outputPipe = Pipe()
+        let errorPipe = Pipe()
+        task.standardOutput = outputPipe
+        task.standardError = errorPipe
+
+        do {
+            try task.run()
+            task.waitUntilExit()
+
+            let output = (String(data: outputPipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? "") +
+                         (String(data: errorPipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? "")
+
+            if output.lowercased().contains("enabled") {
+                status = "Signed System Volume is enabled."
+                checkstatus = "Green"
+            } else if output.lowercased().contains("disabled") {
+                status = "Signed System Volume is DISABLED — system may be compromised."
+                checkstatus = "Red"
+            } else {
+                status = "SSV status could not be determined."
+                checkstatus = "Yellow"
+            }
+        } catch let e {
+            print("Error checking \(name): \(e)")
+            self.error = e
+            checkstatus = "Yellow"
+            status = "Error checking Signed System Volume status"
+        }
+    }
+}
+</file>
+
+<file path="mergen/checkmodules/CISBenchmark/SudoLoggingCheck.swift">
+//
+//  SudoLoggingCheck.swift
+//  mergen
+//
+//  CIS 5.11 - Ensure Logging Is Enabled for Sudo
+
+import Foundation
+
+class SudoLoggingCheck: Vulnerability {
+    init() {
+        super.init(
+            name: "Sudo Logging Is Enabled",
+            description: "Logging sudo commands captures all privileged activity in the unified log. In macOS 26, sudo logging is disabled by default and must be explicitly enabled.",
+            category: "CIS Benchmark",
+            remediation: "Add 'Defaults log_allowed' to a file in /etc/sudoers.d/ using: sudo visudo -f /etc/sudoers.d/cis_sudoconfig",
+            severity: "Medium",
+            documentation: "CIS Apple macOS 26 Tahoe Benchmark v1.0.0 - Recommendation 5.11",
+            mitigation: "Logging sudo commands provides an audit trail of privileged operations, which is essential for incident response.",
+            checkstatus: "",
+            docID: 125,
+            cisID: "5.11"
+        )
+    }
+
+    override func check() {
+        // On macOS Tahoe, sudo -V no longer shows full configuration.
+        // Primary: check for the sudoers.d drop-in file written by our fix.
+        // Fallback: parse sudo -V for older macOS / non-standard configs.
+        if FileManager.default.fileExists(atPath: "/etc/sudoers.d/cis_logging") {
+            status = "Sudo logging is enabled."
+            checkstatus = "Green"
+            return
+        }
+
+        let task = Process()
+        task.executableURL = URL(fileURLWithPath: "/usr/bin/sudo")
+        task.arguments = ["-V"]
+
+        let outputPipe = Pipe()
+        let errorPipe = Pipe()
+        task.standardOutput = outputPipe
+        task.standardError = errorPipe
+
+        do {
+            try task.run()
+            task.waitUntilExit()
+
+            let output = String(data: outputPipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
+
+            if output.contains("Log when a command is allowed by sudoers") {
+                status = "Sudo logging is enabled."
+                checkstatus = "Green"
+            } else {
+                status = "Sudo logging is not enabled — add 'Defaults log_allowed' to sudoers configuration."
+                checkstatus = "Red"
+            }
+        } catch let e {
+            print("Error checking \(name): \(e)")
+            self.error = e
+            checkstatus = "Yellow"
+            status = "Error checking sudo logging configuration"
+        }
+    }
+}
+</file>
+
+<file path="mergen/checkmodules/CISBenchmark/SudoTimeoutCheck.swift">
+//
+//  SudoTimeoutCheck.swift
+//  mergen
+//
+//  CIS 5.4 - Ensure the Sudo Timeout Period Is Set to Zero
+
+import Foundation
+
+class SudoTimeoutCheck: Vulnerability {
+    init() {
+        super.init(
+            name: "Sudo Timeout Period Is Zero",
+            description: "By default, sudo caches credentials for a period of time after use. Setting the timeout to zero requires the user to enter their password every time sudo is used, preventing privilege escalation by background processes.",
+            category: "CIS Benchmark",
+            remediation: "Add 'Defaults timestamp_timeout=0' to a file in /etc/sudoers.d/ using: sudo visudo -f /etc/sudoers.d/cis_sudoconfig",
+            severity: "Medium",
+            documentation: "CIS Apple macOS 26 Tahoe Benchmark v1.0.0 - Recommendation 5.4",
+            mitigation: "A zero sudo timeout prevents a window during which elevated privileges can be exploited by malicious processes.",
+            checkstatus: "",
+            docID: 120,
+            cisID: "5.4"
+        )
+    }
+
+    override func check() {
+        // On macOS Tahoe, sudo -V no longer shows full configuration.
+        // Primary: check for the sudoers.d drop-in file written by our fix.
+        // Fallback: parse sudo -V for older macOS / non-standard configs.
+        if FileManager.default.fileExists(atPath: "/etc/sudoers.d/cis_timeout") {
+            status = "Sudo timeout is set to zero — password required every time."
+            checkstatus = "Green"
+            return
+        }
+
+        let task = Process()
+        task.executableURL = URL(fileURLWithPath: "/usr/bin/sudo")
+        task.arguments = ["-V"]
+
+        let outputPipe = Pipe()
+        let errorPipe = Pipe()
+        task.standardOutput = outputPipe
+        task.standardError = errorPipe
+
+        do {
+            try task.run()
+            task.waitUntilExit()
+
+            let output = String(data: outputPipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
+
+            if output.contains("Authentication timestamp timeout: 0.0 minutes") {
+                status = "Sudo timeout is set to zero — password required every time."
+                checkstatus = "Green"
+            } else {
+                status = "Sudo timeout is not zero — credentials may be cached after use."
+                checkstatus = "Red"
+            }
+        } catch let e {
+            print("Error checking \(name): \(e)")
+            self.error = e
+            checkstatus = "Yellow"
+            status = "Error checking sudo timeout configuration"
+        }
+    }
+}
+</file>
+
+<file path="mergen/checkmodules/CISBenchmark/SudoTTYTicketsCheck.swift">
+//
+//  SudoTTYTicketsCheck.swift
+//  mergen
+//
+//  CIS 5.5 - Ensure a Separate Timestamp Is Enabled for Each User/tty Combo
+
+import Foundation
+
+class SudoTTYTicketsCheck: Vulnerability {
+    init() {
+        super.init(
+            name: "Sudo Uses Per-TTY Timestamps",
+            description: "Using tty tickets ensures a user must enter the sudo password in each Terminal session separately, preventing background processes from inheriting elevated privileges.",
+            category: "CIS Benchmark",
+            remediation: "Add 'Defaults timestamp_type=tty' to a file in /etc/sudoers.d/ using: sudo visudo -f /etc/sudoers.d/cis_sudoconfig",
+            severity: "Medium",
+            documentation: "CIS Apple macOS 26 Tahoe Benchmark v1.0.0 - Recommendation 5.5",
+            mitigation: "Per-TTY sudo timestamps prevent privilege escalation by background processes spawned in different terminal sessions.",
+            checkstatus: "",
+            docID: 121,
+            cisID: "5.5"
+        )
+    }
+
+    override func check() {
+        // On macOS Tahoe, sudo -V no longer shows full configuration.
+        // Primary: check for the sudoers.d drop-in file written by our fix.
+        // Fallback: parse sudo -V for older macOS / non-standard configs.
+        if FileManager.default.fileExists(atPath: "/etc/sudoers.d/cis_tty") {
+            status = "Sudo uses per-TTY timestamps."
+            checkstatus = "Green"
+            return
+        }
+
+        let task = Process()
+        task.executableURL = URL(fileURLWithPath: "/usr/bin/sudo")
+        task.arguments = ["-V"]
+
+        let outputPipe = Pipe()
+        let errorPipe = Pipe()
+        task.standardOutput = outputPipe
+        task.standardError = errorPipe
+
+        do {
+            try task.run()
+            task.waitUntilExit()
+
+            let output = String(data: outputPipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
+
+            if output.contains("Type of authentication timestamp record: tty") {
+                status = "Sudo uses per-TTY timestamps."
+                checkstatus = "Green"
+            } else {
+                status = "Sudo does not use per-TTY timestamps — configure Defaults timestamp_type=tty."
+                checkstatus = "Red"
+            }
+        } catch let e {
+            print("Error checking \(name): \(e)")
+            self.error = e
+            checkstatus = "Yellow"
+            status = "Error checking sudo TTY ticket configuration"
+        }
+    }
+}
+</file>
+
+<file path="mergen/checkmodules/CISBenchmark/TerminalSecureKeyboardCheck.swift">
+//
+//  TerminalSecureKeyboardCheck.swift
+//  mergen
+//
+//  CIS 6.4.1 - Ensure Secure Keyboard Entry Terminal.app Is Enabled
+
+import Foundation
+
+class TerminalSecureKeyboardCheck: Vulnerability {
+    init() {
+        super.init(
+            name: "Terminal Secure Keyboard Entry Is Enabled",
+            description: "Secure Keyboard Entry in Terminal prevents other applications or network sniffers from detecting keystrokes typed in Terminal sessions. This protects passwords and commands entered in the terminal.",
+            category: "CIS Benchmark",
+            remediation: "Create an MDM profile with PayloadType com.apple.Terminal and set SecureKeyboardEntry to true. Or enable in Terminal > Settings > Profiles > Keyboard > Use Secure Keyboard Entry.",
+            severity: "Medium",
+            documentation: "CIS Apple macOS 26 Tahoe Benchmark v1.0.0 - Recommendation 6.4.1",
+            mitigation: "Secure keyboard entry minimizes the risk of key loggers capturing terminal input, protecting sensitive commands and passwords.",
+            checkstatus: "",
+            docID: 130,
+            cisID: "6.4.1"
+        )
+    }
+
+    override func check() {
+        let task = Process()
+        task.executableURL = URL(fileURLWithPath: "/usr/bin/osascript")
+        task.arguments = ["-l", "JavaScript", "-e",
+            "$.NSUserDefaults.alloc.initWithSuiteName('com.apple.Terminal').objectForKey('SecureKeyboardEntry').js"]
+
+        let outputPipe = Pipe()
+        let errorPipe = Pipe()
+        task.standardOutput = outputPipe
+        task.standardError = errorPipe
+
+        do {
+            try task.run()
+            task.waitUntilExit()
+
+            let output = String(data: outputPipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8)?
+                .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+
+            if output == "true" {
+                status = "Terminal Secure Keyboard Entry is enabled."
+                checkstatus = "Green"
+            } else if output == "false" {
+                status = "Terminal Secure Keyboard Entry is disabled."
+                checkstatus = "Red"
+            } else {
+                // Fall back to user defaults
+                checkViaDefaults()
+            }
+        } catch let e {
+            print("Error checking \(name): \(e)")
+            self.error = e
+            checkstatus = "Yellow"
+            status = "Error checking Terminal Secure Keyboard Entry"
+        }
+    }
+
+    private func checkViaDefaults() {
+        let task = Process()
+        task.executableURL = URL(fileURLWithPath: "/usr/bin/env")
+        task.arguments = ["defaults", "read", "com.apple.Terminal", "SecureKeyboardEntry"]
+
+        let outputPipe = Pipe()
+        task.standardOutput = outputPipe
+        task.standardError = Pipe()
+
+        do {
+            try task.run()
+            task.waitUntilExit()
+
+            let output = String(data: outputPipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8)?
+                .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+
+            if output == "1" {
+                status = "Terminal Secure Keyboard Entry is enabled."
+                checkstatus = "Green"
+            } else if output == "0" {
+                status = "Terminal Secure Keyboard Entry is disabled."
+                checkstatus = "Red"
+            } else {
+                status = "Terminal Secure Keyboard Entry state unknown."
+                checkstatus = "Yellow"
+            }
+        } catch {
+            checkstatus = "Yellow"
+            status = "Could not verify Terminal Secure Keyboard Entry status."
+        }
+    }
+}
+</file>
+
+<file path="mergen/checkmodules/CISBenchmark/TimeMachineVolumesEncryptedCheck.swift">
+//
+//  TimeMachineVolumesEncryptedCheck.swift
+//  mergen
+//
+//  Created by Samet Sazak
+//
+
+import Foundation
+
+class TimeMachineVolumesEncryptedCheck: Vulnerability {
+    init() {
+        super.init(
+            name: "Time Machine volumes encrypted",
+            description: "Check if Time Machine volumes are encrypted when Time Machine is enabled",
+            category: "CIS Benchmark",
+            remediation: "Enable encryption for Time Machine volumes",
+            severity: "Medium",
+            documentation: "https://support.apple.com/guide/mac-help/encrypt-time-machine-backup-disks-mh15141/mac",
+            mitigation: "Encrypting Time Machine volumes helps protect your backup data from unauthorized access in case your backup disk is lost or stolen.",
+            docID: 47
+        )
+    }
+    
+    override func check() {
+        let task = Process()
+        task.executableURL = URL(fileURLWithPath: "/usr/bin/defaults")
+        task.arguments = ["read", "/Library/Preferences/com.apple.TimeMachine.plist"]
+        
+        let pipe = Pipe()
+        task.standardOutput = pipe
+        
+        do {
+            try task.run()
+            task.waitUntilExit()
+            
+            if task.terminationStatus == 0 {
+                let outputData = pipe.fileHandleForReading.readDataToEndOfFile()
+                let outputString = String(data: outputData, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines)
+                
+                if let searchString = outputString, searchString.contains("NotEncrypted") {
+                    status = "Time Machine volumes are Not Encrypted"
+                    checkstatus = "Red"
+                } else {
+                    status = "Time Machine volumes are Encrypted"
+                    checkstatus = "Green"
+                }
+            } else {
+                status = "Error checking Time Machine encryption status"
+                checkstatus = "Yellow"
+                self.error = NSError(domain: NSPOSIXErrorDomain, code: Int(task.terminationStatus), userInfo: nil)
+            }
+        } catch let e {
+            print("Error checking \(name): \(e)")
+            checkstatus = "Yellow"
+            status = "Error checking Time Machine encryption status"
+            self.error = e
+        }
+    }
+}
+</file>
+
+<file path="mergen/checkmodules/CISBenchmark/TimeWithinLimitsCheck.swift">
+//
+//  TimeWithinLimitsCheck.swift
+//  mergen
+//
+//  Created by Samet Sazak
+
+import Foundation
+
+class TimeWithinLimitsCheck: Vulnerability {
+    init() {
+        super.init(
+            name: "Time within appropriate limits",
+            description: "This check verifies that your computer's system time is set within acceptable limits. Accurate system time is essential for the proper functioning of various applications and security features.",
+            category: "CIS Benchmark",
+            remediation: "To set the system time correctly, go to System Settings > Date & Time, and make sure the 'Set date and time automatically' option is enabled. If necessary, manually adjust the date and time to match the current time.",
+            severity: "High",
+            documentation: "https://support.apple.com/guide/mac-help/set-the-date-and-time-mh35851/mac",
+            mitigation: "Maintaining accurate system time is crucial for the proper operation of your computer and its applications. It also helps prevent potential security issues related to incorrect timekeeping, such as expired certificates or time-sensitive authentication mechanisms.",
+            docID: 16, cisID: "2.3.2.2"
+        )
+    }
+
+    override func check() {
+        let maxTimeDelta = 300 // 5 minutes
+        let now = Date()
+        let task = Process()
+        task.executableURL = URL(fileURLWithPath: "/bin/date")
+        task.arguments = ["+%s"]
+
+        let outputPipe = Pipe()
+        task.standardOutput = outputPipe
+        task.standardError = Pipe()
+
+        do {
+            try task.run()
+            task.waitUntilExit()
+
+            let outputData = outputPipe.fileHandleForReading.readDataToEndOfFile()
+            let output = String(data: outputData, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+
+            if let timestamp = Double(output) {
+                let timeDelta = abs(now.timeIntervalSince1970 - timestamp)
+                if timeDelta <= Double(maxTimeDelta) {
+                    status = "The system time within the appropriate limits"
+                    checkstatus = "Green"
+                } else {
+                    status = "The system time is not within the appropriate limits"
+                    checkstatus = "Red"
+                }
+            } else {
+                status = "The system time is not within the appropriate limits"
+                checkstatus = "Red"
+            }
+        } catch let e {
+            print("Error checking \(name): \(e)")
+            checkstatus = "Yellow"
+            status = "Error checking system time"
+            self.error = e
+        }
+    }
+}
+</file>
+
+<file path="mergen/checkmodules/CISBenchmark/UniversalControlCheck.swift">
+//
+//  UniversalControlCheck.swift
+//  mergen
+//
+//  Created by Samet Sazak
+//
+
+import Foundation
+
+class UniversalControlCheck: Vulnerability {
+    init() {
+        super.init(
+            name: "Universal control disabled",
+            description: "This check ensures that Universal Control is disabled on your system, preventing unauthorized access to your computer and potentially sensitive data.",
+            category: "CIS Benchmark",
+            remediation: "To disable Universal Control, go to System Settings > Displays > Advanced and uncheck the 'Universal Control' option.",
+            severity: "Low",
+            documentation: "Disabling Universal Control helps protect your system by limiting the ways other devices can connect and interact with it.",
+            mitigation: "By disabling Universal Control, you ensure that only authorized devices can connect to your system, reducing potential security risks.",
+            docID: 55, cisID: "2.8.1"
+        )
+    }
+
+    override func check() {
+        let task = Process()
+        task.executableURL = URL(fileURLWithPath: "/usr/bin/defaults")
+        task.arguments = ["-currentHost", "read", "com.apple.universalcontrol", "Disable"]
+
+        let outputPipe = Pipe()
+        task.standardOutput = outputPipe
+        task.standardError = Pipe()
+
+        do {
+            try task.run()
+            task.waitUntilExit()
+
+            let output = String(data: outputPipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8)?
+                .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+
+            if output == "1" {
+                status = "Universal Control is disabled."
+                checkstatus = "Green"
+            } else if task.terminationStatus != 0 {
+                // Key absent = Universal Control is enabled (default)
+                status = "Universal Control is enabled."
+                checkstatus = "Red"
+            } else {
+                status = "Universal Control is enabled (Disable = 0)."
+                checkstatus = "Red"
+            }
+        } catch let e {
+            print("Error checking \(name): \(e)")
+            checkstatus = "Yellow"
+            status = "Error checking Universal Control status"
+            self.error = e
+        }
+    }
+}
+</file>
+
+<file path="mergen/checkmodules/CISBenchmark/WakeForNetworkAccessCheck.swift">
+//
+//  WakeForNetworkAccessCheck.swift
+//  mergen
+//
+//  Created by Samet Sazak
+//
+
+
+//This script checks if the value of "womp" is 0 in the output of pmset command and sets the status accordingly.
+
+
+import Foundation
+
+class WakeForNetworkAccessCheck: Vulnerability {
+
+    init() {
+        super.init(
+            name: "Wake for network access disabled",
+            description: "Checks if Wake for Network Access is disabled to prevent unauthorized access",
+            category: "CIS Benchmark",
+            remediation: "To disable Wake for Network Access, open Terminal and run the following command:\n\nsudo pmset -a womp 0\n\nThis command disables Wake for Network Access for both battery and AC power.",
+            severity: "Low",
+            documentation: "This code verifies if Wake for Network Access is disabled on your system. When enabled, Wake for Network Access may allow unauthorized access to your system and potentially expose sensitive data.",
+            mitigation: "To protect your system, disable Wake for Network Access, ensuring that only authorized devices can connect.",
+            docID: 56, cisID: "2.10.3"
+        )
+    }
+
+    override func check() {
+        let task = Process()
+        task.executableURL = URL(fileURLWithPath: "/usr/bin/pmset")
+        task.arguments = ["-g", "custom"]
+
+        let pipe = Pipe()
+        task.standardOutput = pipe
+        task.standardError = Pipe()
+
+        do {
+            try task.run()
+            task.waitUntilExit()
+            let output = String(data: pipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
+            let lines = output.components(separatedBy: .newlines)
+
+            // All womp lines must be 0 — any line with womp 1 means Wake for Network is on
+            let wompLines = lines.filter { $0.contains("womp") }
+            let anyEnabled = wompLines.contains { $0.contains("1") }
+
+            if wompLines.isEmpty {
+                status = "Wake for Network Access setting not found (may not apply to this hardware)."
+                checkstatus = "Yellow"
+            } else if anyEnabled {
+                status = "Wake for Network Access is enabled for at least one power mode."
+                checkstatus = "Red"
+            } else {
+                status = "Wake for Network Access is disabled for all power modes."
+                checkstatus = "Green"
+            }
+        } catch let e {
+            print("Error checking \(name): \(e)")
+            checkstatus = "Yellow"
+            status = "Error checking Wake for Network Access status"
+            self.error = e
+        }
+    }
+}
+</file>
+
+<file path="mergen/checkmodules/CISBenchmark/WritingToolsCheck.swift">
+//
+//  WritingToolsCheck.swift
+//  mergen
+//
+//  CIS 2.5.1.2 - Ensure Writing Tools Is Disabled
+
+import Foundation
+
+class WritingToolsCheck: Vulnerability {
+    init() {
+        super.init(
+            name: "Apple Intelligence Writing Tools Disabled",
+            description: "Apple Intelligence Writing Tools use AI to enhance text. While mostly on-device, they may leverage Apple's private cloud infrastructure. Organizations handling sensitive data should disable this.",
+            category: "CIS Benchmark",
+            remediation: "Create an MDM profile with PayloadType com.apple.applicationaccess and set allowWritingTools to false.",
+            severity: "Medium",
+            documentation: "CIS Apple macOS 26 Tahoe Benchmark v1.0.0 - Recommendation 2.5.1.2",
+            mitigation: "Disabling Writing Tools prevents text content from potentially being sent off-device for AI processing.",
+            checkstatus: "",
+            docID: 102,
+            cisID: "2.5.1.2"
+        )
+    }
+
+    override func check() {
+        let task = Process()
+        task.executableURL = URL(fileURLWithPath: "/usr/bin/osascript")
+        task.arguments = ["-l", "JavaScript", "-e",
+            "$.NSUserDefaults.alloc.initWithSuiteName('com.apple.applicationaccess').objectForKey('allowWritingTools').js"]
+
+        let outputPipe = Pipe()
+        let errorPipe = Pipe()
+        task.standardOutput = outputPipe
+        task.standardError = errorPipe
+
+        do {
+            try task.run()
+            task.waitUntilExit()
+
+            let output = String(data: outputPipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8)?
+                .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+
+            if output == "false" {
+                status = "Writing Tools are disabled."
+                checkstatus = "Green"
+            } else if output == "true" {
+                status = "Writing Tools are enabled."
+                checkstatus = "Red"
+            } else {
+                status = "No MDM profile found. Writing Tools state unknown."
+                checkstatus = "Yellow"
+            }
+        } catch let e {
+            print("Error checking \(name): \(e)")
+            self.error = e
+            checkstatus = "Yellow"
+            status = "Error checking Apple Intelligence Writing Tools"
+        }
+    }
+}
+</file>
+
+<file path="mergen/checkmodules/CISBenchmark/XProtectStatusCheck.swift">
+//
+//  XProtectStatusCheck.swift
+//  mergen
+//
+//  CIS 5.10 - Ensure XProtect Is Running and Updated
+
+import Foundation
+
+class XProtectStatusCheck: Vulnerability {
+    init() {
+        super.init(
+            name: "XProtect Is Running and Updated",
+            description: "XProtect is Apple's native signature-based antivirus that blocks known malware. It should always be running with current signatures. XProtect can only be disabled if SIP is also disabled.",
+            category: "CIS Benchmark",
+            remediation: "Run: sudo launchctl load -w /Library/Apple/System/Library/LaunchDaemons/com.apple.XProtect.daemon.scan.plist to re-enable XProtect if disabled.",
+            severity: "High",
+            documentation: "CIS Apple macOS 26 Tahoe Benchmark v1.0.0 - Recommendation 5.10",
+            mitigation: "XProtect provides baseline malware protection and should always be running with current signatures.",
+            checkstatus: "",
+            docID: 124,
+            cisID: "5.10"
+        )
+    }
+
+    override func check() {
+        let task = Process()
+        task.executableURL = URL(fileURLWithPath: "/usr/bin/xprotect")
+        task.arguments = ["status"]
+
+        let outputPipe = Pipe()
+        let errorPipe = Pipe()
+        task.standardOutput = outputPipe
+        task.standardError = errorPipe
+
+        do {
+            try task.run()
+            task.waitUntilExit()
+
+            let output = String(data: outputPipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
+            let errorOutput = String(data: errorPipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
+            let combined = output + errorOutput
+
+            if combined.contains("enabled") && !combined.contains("disabled") {
+                status = "XProtect is running."
+                checkstatus = "Green"
+            } else if combined.contains("disabled") {
+                status = "XProtect is disabled — system may be compromised."
+                checkstatus = "Red"
+            } else {
+                // Fall back to checking if xprotect binary exists (older approach)
+                checkViaLaunchctl()
+            }
+        } catch {
+            // xprotect command may not exist on older systems, try launchctl
+            checkViaLaunchctl()
+        }
+    }
+
+    private func checkViaLaunchctl() {
+        let task = Process()
+        task.executableURL = URL(fileURLWithPath: "/bin/launchctl")
+        task.arguments = ["list", "com.apple.XProtect.daemon.scan"]
+
+        let outputPipe = Pipe()
+        task.standardOutput = outputPipe
+        task.standardError = Pipe()
+
+        do {
+            try task.run()
+            task.waitUntilExit()
+
+            if task.terminationStatus == 0 {
+                status = "XProtect service is running."
+                checkstatus = "Green"
+            } else {
+                status = "XProtect service not found — system may be compromised or SIP disabled."
+                checkstatus = "Yellow"
+            }
+        } catch {
+            checkstatus = "Yellow"
+            status = "Error checking XProtect status"
+        }
+    }
+}
+</file>
+
+<file path="mergen/checkmodules/DiagnosticDataCheck.swift">
+//
+//  DiagnosticDataCheck.swift
+//  mergen
+//
+//  Created by Samet Sazak
+//
+
+import Foundation
+
+class DiagnosticDataCheck: Vulnerability {
+    init() {
+        super.init(
+            name: "Diagnostic data sharing disabled",
+            description: "Check if sending diagnostic and usage data to Apple is disabled",
+            category: "Privacy",
+            remediation: "Go to System Settings > Security & Privacy > Privacy > Analytics & Improvements, and select 'Off' for 'Share Mac Analytics'",
+            severity: "Low",
+            documentation: "This code checks if your system is set to send diagnostic and usage data to Apple. While sharing this data helps Apple improve its products and services, it may also expose sensitive information about your usage patterns.",
+            mitigation: "To protect your privacy and prevent potential information leakage, you can disable sending diagnostic and usage data to Apple. To do this, go to System Settings > Security & Privacy > Privacy > Analytics & Improvements, and select 'Off' for 'Share Mac Analytics'.",
+            checkstatus: "",
+            docID: 24
+        )
+    }
+
+    override func check() {
+        let task = Process()
+        task.executableURL = URL(fileURLWithPath: "/usr/bin/defaults")
+        task.arguments = ["read", "/Library/Application Support/CrashReporter/DiagnosticMessagesHistory.plist", "AutoSubmit"]
+
+        let outputPipe = Pipe()
+        task.standardOutput = outputPipe
+        task.standardError = Pipe()
+
+        do {
+            try task.run()
+            task.waitUntilExit()
+
+            let outputData = outputPipe.fileHandleForReading.readDataToEndOfFile()
+            let output = String(data: outputData, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+
+            if output.lowercased() == "0" {
+                status = "Apple data share is disabled."
+                checkstatus = "Green"
+            } else {
+                status = "Apple data share is enabled."
+                checkstatus = "Red"
+            }
+        } catch let e {
+            print("Error checking \(name): \(e)")
+            self.error = e
+            checkstatus = "Yellow"
+            status = "Error checking diagnostic data status"
+        }
+    }
+}
+</file>
+
+<file path="mergen/checkmodules/EfiCheck.swift">
+//
+//  EfiCheck.swift
+//  mergen
+//
+//  Created by Samet Sazak
+//
+
+import Foundation
+
+//This implementation uses the system_profiler command to obtain information about the system hardware, including the EFI version. The code checks whether the EFI version is outdated and at risk of firmware attacks, and whether the last EFI firmware update check was performed within the last 30 days. If the EFI version is valid and the last update check was performed within the last 30 days, the status is set to "EFI version is valid and being regularly checked", and the checkstatus is set to "Green". If the last update check was performed more than 30 days ago, the status is set to "EFI version is valid but last firmware update check was more than 30 days ago", and the checkstatus is set to "Yellow".
+
+class EFIVersionCheck: Vulnerability {
+    
+    init() {
+        super.init(
+            name: "EFI version valid and regularly checked",
+            description: "Check if the EFI version is valid and being regularly checked on the system",
+            category: "CIS Benchmark",
+            remediation: "Upgrade to the latest EFI version and enable automatic checks",
+            severity: "Medium",
+            documentation: "This code checks the current EFI version of the system and the date of the last EFI firmware update check. If the EFI version is outdated or the last update check is too long ago, it means that the system is at risk of EFI firmware attacks.",
+            mitigation: "Upgrade to the latest EFI version and enable automatic checks to ensure that the system is protected from EFI firmware attacks.",
+            docID: 26
+        )
+    }
+
+    override func check() {
+        let task = Process()
+        task.executableURL = URL(fileURLWithPath: "/usr/sbin/system_profiler")
+        task.arguments = ["SPHardwareDataType", "-xml"]
+
+        let pipe = Pipe()
+        task.standardOutput = pipe
+        task.standardError = Pipe()
+
+        do {
+            try task.run()
+            let data = pipe.fileHandleForReading.readDataToEndOfFile()
+            let xmlOutput = String(data: data, encoding: .utf8)
+
+            if let efiVersion = xmlOutput?.components(separatedBy: "<key>boot_rom_version</key><string>").last?.components(separatedBy: "</string>").first {
+                
+                let currentDate = Date()
+                
+                let defaults = UserDefaults.standard
+                
+                if let lastCheckDate = defaults.object(forKey: "LastEFICheckDate") as? Date {
+                    let calendar = Calendar.current
+                    let components = calendar.dateComponents([.day], from: lastCheckDate, to: currentDate)
+                    let daysSinceLastCheck = components.day ?? 0
+                    
+                    if daysSinceLastCheck <= 30 {
+                        status = "EFI version is valid and being regularly checked"
+                        checkstatus = "Green"
+                    } else {
+                        status = "EFI version is valid but last firmware update check was more than 30 days ago"
+                        checkstatus = "Green"
+                    }
+                    
+                } else {
+                    status = "EFI version is valid but firmware update check has never been performed"
+                    checkstatus = "Red"
+                }
+                
+                defaults.set(currentDate, forKey: "LastEFICheckDate")
+                
+                if efiVersion.hasPrefix("MM") {
+                    status = "EFI version is outdated and at risk of firmware attacks"
+                    checkstatus = "Red"
+                }
+                
+            } else {
+                status = "Error checking EFI version"
+                checkstatus = "Yellow"
+            }
+            
+        } catch let e {
+            print("Error checking \(name): \(e)")
+            checkstatus = "Yellow"
+            status = "Error checking EFI version"
+            self.error = e
+        }
+    }
+    
+}
+</file>
+
+<file path="mergen/checkmodules/FastUserSwitchingCheck.swift">
+//
+//  FastUserSwitchingCheck.swift
+//  mergen
+//
+//  Created by Samet Sazak
+//
+
+import Foundation
+
+class FastUserSwitchingCheck: Vulnerability {
+    init() {
+        super.init(
+            name: "Fast user switching disabled",
+            description: "This check ensures that Fast User Switching is disabled on your system, which helps prevent unauthorized access to your computer.",
+            category: "Security",
+            remediation: "To disable Fast User Switching, go to System Settings > Users & Groups > Login Options, and uncheck the 'Show fast user switching menu as' option.",
+            severity: "Medium",
+            documentation: "For more information on disabling Fast User Switching, visit: https://support.apple.com/guide/mac-help/manage-users-groups-mtusr001/mac",
+            mitigation: "By disabling Fast User Switching, you reduce the risk of unauthorized access to your computer when multiple user accounts are in use, enhancing its security.",
+            docID: 35 // latest
+        )
+    }
+    override func check() {
+          let task = Process()
+          task.executableURL = URL(fileURLWithPath: "/usr/bin/defaults")
+          task.arguments = ["read", "/Library/Preferences/.GlobalPreferences", "MultipleSessionEnabled"]
+
+          let outputPipe = Pipe()
+          task.standardOutput = outputPipe
+        task.standardError = Pipe()
+
+          do {
+              try task.run()
+              task.waitUntilExit()
+
+              let outputData = outputPipe.fileHandleForReading.readDataToEndOfFile()
+              let output = String(data: outputData, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+
+              if output.lowercased() == "0" {
+                  status = "Fast User Switching is disabled"
+                  checkstatus = "Green"
+              } else {
+                  status = "Fast User Switching is enabled."
+                  checkstatus = "Red"
+              }
+          } catch let e {
+              print("Error checking \(name): \(e)")
+              checkstatus = "Yellow"
+              status = "Error checking Fast User Switching status"
+              self.error = e
+          }
+      }
+  }
+</file>
+
+<file path="mergen/checkmodules/FileExtentionCheck.swift">
+//
+//  FileExtentionCheck.swift
+//  mergen
+//
+//  Created by Samet Sazak
+//
+
+import Foundation
+
+class FilenameExtensionsCheck: Vulnerability {
+    init() {
+        super.init(
+            name: "Filename extensions shown",
+            description: "This check ensures that filename extensions are turned on in your system, which helps prevent users from accidentally running malicious files.",
+            category: "CIS Benchmark",
+            remediation: "To turn on filename extensions, go to Finder > Preferences > Advanced, and check the 'Show all filename extensions' option.",
+            severity: "Low",
+            documentation: "For more information on turning on filename extensions, visit: https://support.apple.com/guide/mac-help/show-or-hide-filename-extensions-on-mac-mh26782/mac",
+            mitigation: "By turning on filename extensions, you help users identify and avoid accidentally running malicious files, enhancing the system's security.",
+            docID: 32, cisID: "6.1.1"
+        )
+    }
+
+    override func check() {
+        let task = Process()
+        task.executableURL = URL(fileURLWithPath: "/usr/bin/defaults")
+        task.arguments = ["read", "NSGlobalDomain", "AppleShowAllExtensions"]
+
+        let outputPipe = Pipe()
+        task.standardOutput = outputPipe
+        task.standardError = Pipe()
+
+        do {
+            try task.run()
+            task.waitUntilExit()
+
+            let outputData = outputPipe.fileHandleForReading.readDataToEndOfFile()
+            let output = String(data: outputData, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+
+            if output.lowercased() == "1" {
+                status = "Filename extension is enabled."
+                checkstatus = "Green"
+            } else {
+                status = "Filename extensions are hidden."
+                checkstatus = "Red"
+            }
+        } catch let e {
+            print("Error checking \(name): \(e)")
+            status = "Error checking filename extensions status"
+            checkstatus = "Yellow"
+            self.error = e
+        }
+    }
+}
+</file>
+
+<file path="mergen/checkmodules/GuestConnectCheck.swift">
+//
+//  GuestConnectCheck.swift
+//  mergen
+//
+//  Created by Samet Sazak
+//
+
+import Foundation
+
+class GuestConnectCheck: Vulnerability {
+    init() {
+        super.init(
+            name: "Guest access to shared folders disabled",
+            description: "This check ensures that the 'Allow guests to connect to shared folders' option is disabled on your system, which helps protect against unauthorized access to your computer.",
+            category: "CIS Benchmark",
+            remediation: "To disable 'Allow guests to connect to shared folders', go to System Settings > Sharing, and uncheck the 'Allow guests to connect to shared folders' option.",
+            severity: "Medium",
+            documentation: "For more information on disabling 'Allow guests to connect to shared folders', visit: https://support.apple.com/guide/mac-help/share-mac-files-with-windows-users-mh14132/mac",
+            mitigation: "By disabling 'Allow guests to connect to shared folders', you reduce the risk of unauthorized access to your computer's shared folders, enhancing its security.",
+            docID: 31, cisID: "2.13.2"
+        )
+    }
+
+    override func check() {
+        let task = Process()
+        task.executableURL = URL(fileURLWithPath: "/usr/bin/defaults")
+        task.arguments = ["read", "/Library/Preferences/com.apple.AppleFileServer", "guestAccess"]
+
+        let outputPipe = Pipe()
+        task.standardOutput = outputPipe
+        task.standardError = Pipe()
+
+        do {
+            try task.run()
+            task.waitUntilExit()
+
+            let outputData = outputPipe.fileHandleForReading.readDataToEndOfFile()
+            let output = String(data: outputData, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+
+            // defaults read returns "0" (disabled) or "1" (enabled)
+            if output == "0" || task.terminationStatus != 0 {
+                status = "Guest access to shared folders is disabled"
+                checkstatus = "Green"
+            } else {
+                status = "Guest access to shared folders is enabled"
+                checkstatus = "Red"
+            }
+        } catch let e {
+            print("Error checking \(name): \(e)")
+            self.error = e
+            checkstatus = "Yellow"
+            status = "Error checking guest connect status"
+        }
+    }
+}
+</file>
+
+<file path="mergen/checkmodules/Java6Check.swift">
+//
+//  Java6Check.swift
+//  mergen
+//
+//  Created by Samet Sazak
+//
+
+import Foundation
+
+class Java6Check: Vulnerability {
+    init() {
+        super.init(
+            name: "Java 6 runtime disabled",
+            description: "Check if Java 6 is the default Java runtime. Java 6 is an outdated version and may expose your system to security risks.",
+            category: "Security",
+            remediation: "Install a newer version of Java and set it as the default runtime. Follow the instructions at https://www.java.com/en/download/help/download_options.xml to download and install the latest version of Java.",
+            severity: "High",
+            documentation: "https://www.java.com/en/download/help/download_options.xml",
+            mitigation: "Using the latest version of Java helps protect your system against security vulnerabilities and ensures compatibility with the latest software.",
+            checkstatus: "",
+            docID: 25
+        )
+    }
+
+    override func check() {
+        let task = Process()
+        task.executableURL = URL(fileURLWithPath: "/usr/bin/java")
+        task.arguments = ["-version"]
+
+        let outputPipe = Pipe()
+        task.standardError = outputPipe
+
+        do {
+            try task.run()
+            task.waitUntilExit()
+
+            let outputData = outputPipe.fileHandleForReading.readDataToEndOfFile()
+            let output = String(data: outputData, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+
+            if output.lowercased().contains("java 1.6") {
+                status = "Update Java Version."
+                checkstatus = "Red"
+            } else {
+                status = "Java is up-to-date."
+                checkstatus = "Green"
+            }
+        } catch let e {
+            print("Error checking \(name): \(e)")
+            self.error = e
+            checkstatus = "Yellow"
+            status = "Error checking Java 6 status"
+        }
+    }
+}
+</file>
+
+<file path="mergen/checkmodules/NfsServerCheck.swift">
+//
+//  NfsServerCheck.swift
+//  mergen
+//
+//  Created by Samet Sazak
+//
+
+import Foundation
+
+class NfsServerCheck: Vulnerability {
+    init() {
+        super.init(
+            name: "NFS server disabled",
+            description: "This check ensures that the NFS server is not running on your system, which helps protect against potential security vulnerabilities.",
+            category: "CIS Benchmark",
+            remediation: "To disable the NFS server or configure it securely, follow the instructions in the provided documentation link.",
+            severity: "Medium",
+            documentation: "For more information on disabling or configuring the NFS server securely, visit: https://support.apple.com/en-us/HT210060",
+            mitigation: "Disabling or securely configuring the NFS server helps protect your system from security vulnerabilities associated with running an NFS server.",
+            docID: 29, cisID: "4.3"
+        )
+    }
+
+    override func check() {
+        let task = Process()
+        task.executableURL = URL(fileURLWithPath: "/bin/launchctl")
+        task.arguments = ["list", "com.apple.nfsd"]
+
+        task.standardOutput = Pipe()
+        task.standardError = Pipe()
+
+        do {
+            try task.run()
+            task.waitUntilExit()
+
+            if task.terminationStatus == 0 {
+                status = "NFS Server is enabled."
+                checkstatus = "Red"
+            } else {
+                status = "NFS Server is disabled."
+                checkstatus = "Green"
+            }
+        } catch let e {
+            print("Error checking \(name): \(e)")
+            self.error = e
+            checkstatus = "Yellow"
+            status = "Error checking NFS server status"
+        }
+    }
+}
+</file>
+
+<file path="mergen/checkmodules/PasswordHintsCheck.swift">
+//
+//  PasswordHintsCheck.swift
+//  mergen
+//
+//  Created by Samet Sazak
+//
+
+import Foundation
+
+class PasswordHintsCheck: Vulnerability {
+    init() {
+        super.init(
+            name: "Password hints disabled",
+            description: "This check verifies if the 'Show password hints' option is disabled on your system, which helps protect against unauthorized access to your computer.",
+            category: "CIS Benchmark",
+            remediation: "To disable 'Show password hints', go to System Settings > Users & Groups > Login Options, and uncheck the 'Show password hints' option.",
+            severity: "Medium",
+            documentation: "For more information on disabling 'Show password hints', visit: https://support.apple.com/guide/mac-help/change-password-preferences-mchlp2818/mac",
+            mitigation: "By disabling 'Show password hints', you reduce the risk of unauthorized access to your computer, enhancing its security.",
+            docID: 30, cisID: "2.11.5"
+        )
+    }
+
+    override func check() {
+        let task = Process()
+        task.executableURL = URL(fileURLWithPath: "/usr/bin/defaults")
+        task.arguments = ["read", "/Library/Preferences/com.apple.loginwindow.plist", "RetriesUntilHint"]
+
+        let outputPipe = Pipe()
+        task.standardOutput = outputPipe
+        task.standardError = Pipe()
+
+        do {
+            try task.run()
+            task.waitUntilExit()
+
+            let outputData = outputPipe.fileHandleForReading.readDataToEndOfFile()
+            let output = String(data: outputData, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+
+            if output.lowercased() == "0" {
+                status = "Password Hint is Disabled"
+                checkstatus = "Green"
+            } else {
+                status = "Password Hint is Enabled"
+                checkstatus = "Red"
+            }
+        } catch let e {
+            print("Error checking \(name): \(e)")
+            self.error = e
+            checkstatus = "Yellow"
+            status = "Error checking password hints status"
+        }
+    }
+}
+</file>
+
+<file path="mergen/checkmodules/SafariInternetPluginCheck.swift">
+//
+//  SafariInternetPluginCheck.swift
+//  mergen
+//
+//  Created by Samet Sazak
+//
+
+import Foundation
+
+class SafariInternetPluginsCheck: Vulnerability {
+    init() {
+        super.init(
+            name: "Safari Internet plugins disabled",
+            description: "This check ensures that Internet plugins are disabled for global use in Safari, which helps prevent the execution of malicious code.",
+            category: "Security",
+            remediation: "To disable Internet plugins for global use in Safari, go to Safari > Preferences > Security, and uncheck the 'Allow Plug-ins' option.",
+            severity: "Medium",
+            documentation: "For more information on disabling Internet plugins for global use in Safari, visit: https://support.apple.com/guide/safari/preference-settings-for-security-ibrw1093/mac",
+            mitigation: "By disabling Internet plugins for global use, you reduce the risk of malicious code execution through vulnerable plugins, enhancing your system's security.",
+            docID: 34
+        )
+    }
+
+    override func check() {
+        let task = Process()
+        task.executableURL = URL(fileURLWithPath: "/usr/bin/defaults")
+        task.arguments = ["read", "com.apple.Safari", "PlugInFirstVisitPolicy"]
+
+        let outputPipe = Pipe()
+        task.standardOutput = outputPipe
+
+        do {
+            try task.run()
+            task.waitUntilExit()
+
+            let outputData = outputPipe.fileHandleForReading.readDataToEndOfFile()
+            let output = String(data: outputData, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+
+            if output.lowercased() == "2" {
+                status = "Internet plugins are disabled for global use in Safari"
+                checkstatus = "Green"
+            } else {
+                status = "Internet plugins are enabled for global use in Safari"
+                checkstatus = "Red"
+            }
+        } catch let e {
+            print("Error checking \(name): \(e)")
+            checkstatus = "Yellow"
+            status = "Error checking Safari Internet plugins status"
+            self.error = e
+        }
+    }
+}
+</file>
+
+<file path="mergen/checkmodules/SafariSafeFileChecks.swift">
+//
+//  SafariSafeFileChecks.swift
+//  mergen
+//
+//  Created by Samet Sazak
+//
+
+import Foundation
+
+class SafariSafeFilesCheck: Vulnerability {
+    init() {
+        super.init(
+            name: "Safari auto-open safe files disabled",
+            description: "This check ensures that the automatic run of safe files in Safari is disabled, which helps prevent the execution of malicious code.",
+            category: "CIS Benchmark",
+            remediation: "Open Safari > Settings > General and uncheck Open safe files after downloading. On macOS Tahoe, Safari preferences are sandboxed and cannot be changed via command line.",
+            severity: "Medium",
+            documentation: "For more information on disabling the automatic run of safe files in Safari, visit: https://support.apple.com/guide/safari/preference-settings-for-security-ibrw1093/mac",
+            mitigation: "Disabling the automatic run of safe files helps protect your system from the execution of malicious code that may be disguised as a safe file.",
+            docID: 33, cisID: "6.3.1"
+        )
+    }
+
+    override func check() {
+            // On macOS Tahoe, Safari preferences are fully sandboxed.
+            // External processes cannot read or write them via defaults.
+            // Read the container plist directly; if the write was blocked by cfprefsd
+            // the key will be absent, which means Safari is using its default (enabled).
+            let task = Process()
+            task.executableURL = URL(fileURLWithPath: "/usr/bin/defaults")
+            task.arguments = ["read", "com.apple.Safari", "AutoOpenSafeDownloads"]
+
+            let outputPipe = Pipe()
+            task.standardOutput = outputPipe
+            task.standardError = Pipe()
+
+            do {
+                try task.run()
+                task.waitUntilExit()
+
+                let output = String(data: outputPipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+
+                if output.lowercased() == "0" {
+                    status = "Automatic run of safe files in Safari is disabled."
+                    checkstatus = "Green"
+                } else if task.terminationStatus != 0 || output.isEmpty {
+                    // Key absent — cannot verify from outside Safari's sandbox.
+                    // Manual review required: check Safari > Settings > General.
+                    status = "Cannot verify from outside Safari's sandbox. Check Safari > Settings > General > uncheck 'Open safe files after downloading'."
+                    checkstatus = "Yellow"
+                } else {
+                    status = "Safari auto-open safe files is enabled — change in Safari > Settings > General."
+                    checkstatus = "Red"
+                }
+            } catch let e {
+                print("Error checking \(name): \(e)")
+                checkstatus = "Yellow"
+                status = "Error checking Safari safe files status"
+                self.error = e
+            }
+        }
+    }
+</file>
+
+<file path="mergen/checkmodules/SIPCheck.swift">
+//
+//  SIPCheck.swift
+//  mergen
+//
+//  Created by Samet Sazak
+//
+
+import Foundation
+
+class SIPStatusCheck: Vulnerability {
+    init() {
+        super.init(
+            name: "System Integrity Protection enabled",
+            description: "This check verifies if System Integrity Protection (SIP) is enabled on your computer. SIP helps protect your computer from unauthorized changes and enhances security.",
+            category: "CIS Benchmark",
+            remediation: "To enable SIP, restart your computer in Recovery Mode and run `csrutil enable` in Terminal.",
+            severity: "High",
+            documentation: "For more information about SIP and how to enable it, visit: https://support.apple.com/en-us/HT204899",
+            mitigation: "System Integrity Protection is a crucial security feature and should remain enabled to protect your system from unauthorized changes.",
+            docID: 20, cisID: "5.1.2"
+        )
+    }
+    
+    override func check() {
+        let task = Process()
+        task.executableURL = URL(fileURLWithPath: "/usr/bin/csrutil")
+        task.arguments = ["status"]
+        
+        let outputPipe = Pipe()
+        task.standardOutput = outputPipe
+        task.standardError = Pipe()
+        
+        do {
+            try task.run()
+            task.waitUntilExit()
+            
+            let outputData = outputPipe.fileHandleForReading.readDataToEndOfFile()
+            let output = String(data: outputData, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+            
+            if output.lowercased().contains("enabled.") {
+                status = "SIP is enabled."
+                checkstatus = "Green"
+            } else {
+                status = "SIP is not enabled."
+                checkstatus = "Red"
+            }
+        } catch let e {
+            print("Error checking \(name): \(e)")
+            self.error = e
+            checkstatus = "Yellow"
+            status = "Error checking SIP status"
+        }
+    }
+}
+</file>
+
+<file path="mergen/checkmodules/SiriStatusCheck.swift">
+//
+//  SiriStatusCheck.swift
+//  mergen
+//
+//  Created by Samet Sazak
+//
+
+import Foundation
+
+class SiriEnabledCheck: Vulnerability {
+    init() {
+        super.init(
+            name: "Siri disabled",
+            description: "Check if Siri is enabled",
+            category: "CIS Benchmark",
+            remediation: "Disable Siri by going to System Settings > Siri and unchecking 'Enable Ask Siri'",
+            severity: "Low",
+            documentation: "This code checks if Siri, Apple's voice assistant, is enabled on your system. While Siri can be helpful, it can also potentially be exploited by unauthorized individuals to access sensitive information or perform actions without your consent.",
+            mitigation: "To reduce the risk of unauthorized voice commands, you can disable Siri. To do this, go to System Settings > Siri and uncheck the 'Enable Ask Siri' option.",
+            checkstatus: "",
+            docID: 23, cisID: "2.5.2.1"
+        )
+    }
+
+    override func check() {
+        let task = Process()
+        task.executableURL = URL(fileURLWithPath: "/usr/bin/defaults")
+        task.arguments = ["read", "com.apple.Siri", "SiriProfessionalEnabled"]
+
+        let outputPipe = Pipe()
+        task.standardOutput = outputPipe
+        task.standardError = Pipe()
+
+        do {
+            try task.run()
+            task.waitUntilExit()
+
+            let output = String(data: outputPipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8)?
+                .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+
+            // Key absent or 0 means Siri is disabled
+            if output == "1" {
+                status = "Siri is Enabled"
+                checkstatus = "Red"
+            } else {
+                status = "Siri is Disabled"
+                checkstatus = "Green"
+            }
+        } catch let e {
+            print("Error checking \(name): \(e)")
+            self.error = e
+            checkstatus = "Yellow"
+            status = "Error checking Siri status"
+        }
+    }
+}
+</file>
+
+<file path="mergen/checkmodules/XProtectAndMRTCheck.swift">
+//
+//  XProtectAndMRTCheck.swift
+//  mergen
+//
+//  Created by Samet Sazak
+//
+
+import Foundation
+
+class XProtectAndMRTCheck: Vulnerability {
+    init() {
+        super.init(
+            name: "XProtect protection enabled",
+            description: "This check verifies if XProtect and MRT are enabled on your system, providing additional protection against malware and other security threats.",
+            category: "Security",
+            remediation: "To enable XProtect and MRT, go to System Settings > Security & Privacy > General, and check the 'Automatically update built-in system data files' option.",
+            severity: "High",
+            documentation: "For more information about XProtect and MRT, visit: https://support.apple.com/en-us/HT202491",
+            mitigation: "Enabling XProtect and MRT helps protect your system by detecting and removing known malware and addressing other security threats.",
+            docID: 21
+        )
+    }
+    
+    override func check() {
+        let task = Process()
+        task.executableURL = URL(fileURLWithPath: "/usr/bin/xattr")
+        task.arguments = ["-pl", "/System/Library/CoreServices/XProtect.bundle/Contents/Resources/XProtect.plist"]
+        
+        let outputPipe = Pipe()
+        task.standardOutput = outputPipe
+        
+        do {
+            try task.run()
+            task.waitUntilExit()
+            
+            let outputData = outputPipe.fileHandleForReading.readDataToEndOfFile()
+            let output = String(data: outputData, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+            
+            if output.lowercased().contains("com.apple.quarantine") {
+                status = "Xprotect is enabled."
+                checkstatus = "Green"
+            } else {
+                status = "Xprotect is not enabled."
+                checkstatus = "Red"
+            }
+        } catch let e {
+            print("Error checking \(name): \(e)")
+            self.error = e
+            checkstatus = "Yellow"
+        }
+    }
+}
+</file>
+
+<file path="mergen/ContentView.swift">
+//
+//  ContentView.swift
+//  mergen
+//
+
+import SwiftUI
+import AppKit
+
+struct ContentView: View {
+    @StateObject private var scanManager = ScanManager()
+    @State private var selectedVulnerability: Vulnerability? = nil
+    @State private var searchText = ""
+    @State private var showLogViewer = false
+
+    private var isWelcome: Bool {
+        scanManager.scanResults.isEmpty && !scanManager.scanning
+    }
+
+    var body: some View {
+        Group {
+            if isWelcome {
+                WelcomeView {
+                    scanManager.startScan(category: nil)
+                }
+            } else {
+                VStack(spacing: 0) {
+                    ResultsTopBar(scanManager: scanManager)
+
+                    Divider()
+
+                    HStack(spacing: 0) {
+                        ResultsListView(
+                            scanManager: scanManager,
+                            selectedCategory: nil,
+                            selectedVulnerability: $selectedVulnerability,
+                            searchText: $searchText
+                        )
+                        .frame(minWidth: 300, idealWidth: 380)
+
+                        Divider()
+
+                        DetailPanelView(
+                            vulnerability: selectedVulnerability,
+                            scanManager: scanManager
+                        )
+                        .frame(minWidth: 280)
+                    }
+                }
+            }
+        }
+        .frame(minWidth: 840, minHeight: 520)
+        .toolbar {
+            ToolbarItem(placement: .automatic) {
+                Button { showLogViewer = true } label: {
+                    Label("Audit Log", systemImage: "doc.text.magnifyingglass")
+                        .font(.system(size: 12))
+                }
+                .help("View audit log — scan results and fix history")
+                .sheet(isPresented: $showLogViewer) {
+                    LogViewerSheet()
+                }
+            }
+        }
+    }
+}
+
+// MARK: - Results Top Bar
+
+struct ResultsTopBar: View {
+    @ObservedObject var scanManager: ScanManager
+    @State private var showFixSheet = false
+
+    private let accent = Color(red: 0.42, green: 0.26, blue: 0.88)
+
+    private var automated: [Vulnerability] { scanManager.scanResults.filter { !$0.isManual && $0.checkstatus != "Blue" } }
+    private var passCount: Int { automated.filter { $0.checkstatus == "Green" }.count }
+    private var failCount: Int { scanManager.scanResults.filter { $0.checkstatus == "Red" }.count }
+    private var warnCount: Int { scanManager.scanResults.filter { $0.checkstatus == "Yellow" }.count }
+    private var score:     Double { automated.isEmpty ? 0 : Double(passCount) / Double(automated.count) }
+    private var fixable:   Int { scanManager.scanResults.filter { $0.isAutoFixable }.count }
+
+    private var scoreColor: Color {
+        score >= 0.8 ? Color(red: 0.07, green: 0.66, blue: 0.47)
+            : score >= 0.5 ? Color(red: 0.80, green: 0.55, blue: 0.10)
+            : Color(red: 0.85, green: 0.25, blue: 0.25)
+    }
+    private var scoreLabel: String {
+        score >= 0.8 ? "GOOD" : score >= 0.5 ? "FAIR" : "AT RISK"
+    }
+
+    var body: some View {
+        HStack(spacing: 0) {
+
+            // ── Branding ───────────────────────────────────────────────────
+            HStack(spacing: 7) {
+                Image(systemName: "shield.fill")
+                    .font(.system(size: 14))
+                    .foregroundStyle(LinearGradient(
+                        colors: [Color(red: 0.65, green: 0.52, blue: 1.00), accent],
+                        startPoint: .top, endPoint: .bottom
+                    ))
+                Text("Mergen")
+                    .font(.system(size: 13, weight: .bold, design: .rounded))
+                    .foregroundColor(.primary)
+            }
+            .padding(.horizontal, 16)
+
+            divider()
+
+            // ── Score ring ─────────────────────────────────────────────────
+            HStack(spacing: 8) {
+                ZStack {
+                    Circle()
+                        .stroke(Color.primary.opacity(0.10), lineWidth: 3)
+                        .frame(width: 32, height: 32)
+                    Circle()
+                        .trim(from: 0, to: score)
+                        .stroke(scoreColor, style: StrokeStyle(lineWidth: 3, lineCap: .round))
+                        .frame(width: 32, height: 32)
+                        .rotationEffect(.degrees(-90))
+                        .animation(.spring(response: 1.1, dampingFraction: 0.82), value: score)
+                    Text("\(Int(score * 100))")
+                        .font(.system(size: 8, weight: .bold, design: .rounded))
+                        .foregroundColor(scoreColor)
+                }
+                VStack(alignment: .leading, spacing: 0) {
+                    Text("\(Int(score * 100))%")
+                        .font(.system(size: 13, weight: .bold, design: .rounded))
+                        .foregroundColor(scoreColor)
+                    Text(scoreLabel)
+                        .font(.system(size: 8, weight: .semibold))
+                        .foregroundColor(.secondary)
+                        .tracking(0.6)
+                }
+            }
+            .padding(.horizontal, 14)
+
+            divider()
+
+            // ── Stats ──────────────────────────────────────────────────────
+            HStack(spacing: 20) {
+                statChip(passCount, "Passed",   Color(red: 0.07, green: 0.66, blue: 0.47))
+                statChip(failCount, "Failed",   Color(red: 0.85, green: 0.25, blue: 0.25))
+                statChip(warnCount, "Warnings", Color(red: 0.80, green: 0.55, blue: 0.10))
+            }
+            .padding(.horizontal, 14)
+
+            Spacer()
+
+            // ── Scanning progress ──────────────────────────────────────────
+            if scanManager.scanning {
+                HStack(spacing: 7) {
+                    ProgressView()
+                        .scaleEffect(0.6)
+                        .frame(width: 14, height: 14)
+                    Text("Scanning… \(Int(scanManager.progress * 100))%")
+                        .font(.system(size: 11))
+                        .foregroundColor(.secondary)
+                        .monospacedDigit()
+                }
+                .padding(.horizontal, 14)
+            }
+
+            // ── Actions ────────────────────────────────────────────────────
+            if !scanManager.scanning {
+                HStack(spacing: 6) {
+                    if fixable > 0 {
+                        Button { showFixSheet = true } label: {
+                            Label("Fix \(fixable)", systemImage: "bolt.fill")
+                                .font(.system(size: 11, weight: .semibold))
+                        }
+                        .buttonStyle(.borderedProminent)
+                        .controlSize(.small)
+                        .tint(Color(red: 0.85, green: 0.25, blue: 0.25))
+                        .sheet(isPresented: $showFixSheet) {
+                            FixAllSheet(scanManager: scanManager)
+                        }
+                    }
+
+                    Button { scanManager.startScan(category: nil) } label: {
+                        Label("Rescan", systemImage: "arrow.clockwise")
+                            .font(.system(size: 11))
+                    }
+                    .buttonStyle(.bordered)
+                    .controlSize(.small)
+
+                    Button { scanManager.resetScan() } label: {
+                        Image(systemName: "xmark")
+                            .font(.system(size: 11))
+                    }
+                    .buttonStyle(.bordered)
+                    .controlSize(.small)
+                    .help("Reset")
+
+                    divider()
+
+                    ExportButtons(scanResults: scanManager.scanResults)
+                }
+                .padding(.horizontal, 12)
+            }
+        }
+        .frame(height: 52)
+        .background(Color(NSColor.windowBackgroundColor))
+    }
+
+    @ViewBuilder
+    private func divider() -> some View {
+        Rectangle()
+            .fill(Color.primary.opacity(0.08))
+            .frame(width: 1, height: 24)
+    }
+
+    @ViewBuilder
+    private func statChip(_ count: Int, _ label: String, _ color: Color) -> some View {
+        HStack(spacing: 5) {
+            Text("\(count)")
+                .font(.system(size: 14, weight: .bold, design: .rounded))
+                .foregroundColor(color)
+                .monospacedDigit()
+            Text(label)
+                .font(.system(size: 11))
+                .foregroundColor(.secondary)
+        }
+    }
+}
+
+// MARK: - Welcome View
+
+struct WelcomeView: View {
+    let onScan: () -> Void
+
+    @State private var pulse1     = false
+    @State private var pulse2     = false
+    @State private var appeared   = false
+    @State private var btnHovered = false
+    @State private var btnGlow    = false
+
+    var body: some View {
+        VStack(spacing: 24) {
+            Spacer(minLength: 0)
+
+            // ── Hero ──────────────────────────────────────────────────────
+            ZStack {
+                // Outer pulse ring
+                Circle()
+                    .stroke(Color.gray.opacity(pulse2 ? 0 : 0.10), lineWidth: 1)
+                    .frame(width: 130, height: 130)
+                    .scaleEffect(pulse2 ? 1.45 : 1.0)
+                    .animation(.easeOut(duration: 2.8).repeatForever(autoreverses: false), value: pulse2)
+
+                // Inner pulse ring
+                Circle()
+                    .stroke(Color.gray.opacity(pulse1 ? 0 : 0.16), lineWidth: 1)
+                    .frame(width: 105, height: 105)
+                    .scaleEffect(pulse1 ? 1.38 : 1.0)
+                    .animation(.easeOut(duration: 2.8).repeatForever(autoreverses: false), value: pulse1)
+
+                // Shield icon — white with soft gray shadow
+                Image(systemName: "shield.fill")
+                    .font(.system(size: 72))
+                    .foregroundStyle(
+                        LinearGradient(
+                            colors: [Color.white, Color(NSColor.lightGray)],
+                            startPoint: .topLeading,
+                            endPoint: .bottomTrailing
+                        )
+                    )
+                    .shadow(color: .black.opacity(0.12), radius: 16, y: 6)
+            }
+            .frame(width: 210, height: 210)
+            .scaleEffect(appeared ? 1.0 : 0.72)
+            .opacity(appeared ? 1 : 0)
+            .animation(.spring(response: 0.68, dampingFraction: 0.72), value: appeared)
+            .onAppear {
+                pulse1 = true
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.9) { pulse2 = true }
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) { btnGlow = true }
+            }
+
+            // ── Title ─────────────────────────────────────────────────────
+            VStack(spacing: 6) {
+                Text("Welcome to Mergen")
+                    .font(.system(size: 36, weight: .bold, design: .rounded))
+                    .foregroundColor(.primary)
+                Text("Start with a thorough security audit of your Mac.")
+                    .font(.system(size: 13))
+                    .foregroundColor(.secondary)
+                    .multilineTextAlignment(.center)
+            }
+            .opacity(appeared ? 1 : 0)
+            .offset(y: appeared ? 0 : 10)
+            .animation(.easeOut(duration: 0.5).delay(0.15), value: appeared)
+
+            // ── Circular scan button ──────────────────────────────────────
+            Button(action: onScan) {
+                ZStack {
+                    Circle()
+                        .stroke(Color.primary.opacity(0.10), lineWidth: 1)
+                        .frame(width: btnHovered ? 116 : 110, height: btnHovered ? 116 : 110)
+                        .animation(.spring(response: 0.3, dampingFraction: 0.65), value: btnHovered)
+
+                    Circle()
+                        .fill(
+                            LinearGradient(
+                                colors: [
+                                    Color(NSColor.darkGray),
+                                    Color(red: 0.15, green: 0.15, blue: 0.15)
+                                ],
+                                startPoint: .top,
+                                endPoint: .bottom
+                            )
+                        )
+                        .frame(width: 98, height: 98)
+                        // Pulsing glow
+                        .shadow(
+                            color: .black.opacity(btnGlow ? 0.55 : 0.22),
+                            radius: btnGlow ? 28 : 14
+                        )
+                        .shadow(
+                            color: Color.white.opacity(btnGlow ? 0.18 : 0.06),
+                            radius: btnGlow ? 22 : 8
+                        )
+                        .animation(
+                            .easeInOut(duration: 2.2).repeatForever(autoreverses: true),
+                            value: btnGlow
+                        )
+                        // Hover pop (separate, non-repeating)
+                        .scaleEffect(btnHovered ? 1.05 : 1.0)
+                        .animation(.spring(response: 0.3, dampingFraction: 0.65), value: btnHovered)
+
+                    Text("Scan")
+                        .font(.system(size: 18, weight: .semibold, design: .rounded))
+                        .foregroundColor(.white)
+                }
+            }
+            .buttonStyle(.plain)
+            .onHover { h in btnHovered = h }
+            .opacity(appeared ? 1 : 0)
+            .animation(.easeOut(duration: 0.5).delay(0.28), value: appeared)
+
+            // ── Feature cards ─────────────────────────────────────────────
+            LazyVGrid(columns: [GridItem(.flexible()), GridItem(.flexible())], spacing: 10) {
+                FeatureCard(emoji: "🔒", title: "85 Security Checks", subtitle: "Full CIS Benchmark coverage")
+                FeatureCard(emoji: "⚡", title: "Auto-Fix", subtitle: "One-tap remediation for issues")
+                FeatureCard(emoji: "🔍", title: "Deep Analysis", subtitle: "Network, privacy & system settings")
+                FeatureCard(emoji: "📋", title: "Audit Reports", subtitle: "Export to HTML or JSON")
+            }
+            .frame(maxWidth: 480)
+            .opacity(appeared ? 1 : 0)
+            .animation(.easeOut(duration: 0.5).delay(0.40), value: appeared)
+
+            Spacer(minLength: 0)
+        }
+        .padding(32)
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .onAppear { appeared = true }
+    }
+}
+
+struct FeatureCard: View {
+    let emoji: String
+    let title: String
+    let subtitle: String
+
+    @State private var hovered = false
+
+    var body: some View {
+        HStack(spacing: 12) {
+            Text(emoji)
+                .font(.system(size: 20))
+                .frame(width: 34, height: 34)
+                .background(Color(NSColor.windowBackgroundColor))
+                .cornerRadius(8)
+                .shadow(color: .black.opacity(0.06), radius: 2, y: 1)
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text(title)
+                    .font(.system(size: 12, weight: .semibold))
+                    .foregroundColor(.primary)
+                Text(subtitle)
+                    .font(.system(size: 10))
+                    .foregroundColor(.secondary)
+                    .lineLimit(1)
+            }
+            Spacer(minLength: 0)
+        }
+        .padding(12)
+        .background(
+            RoundedRectangle(cornerRadius: 10)
+                .fill(Color(NSColor.windowBackgroundColor))
+                .shadow(color: .black.opacity(hovered ? 0.10 : 0.05), radius: hovered ? 8 : 4, y: 2)
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 10)
+                .stroke(Color(NSColor.separatorColor).opacity(0.6), lineWidth: 1)
+        )
+        .scaleEffect(hovered ? 1.02 : 1.0)
+        .animation(.easeInOut(duration: 0.15), value: hovered)
+        .onHover { h in hovered = h }
+    }
+}
+
+
+struct ContentView_Previews: PreviewProvider {
+    static var previews: some View {
+        ContentView()
+    }
+}
+</file>
+
+<file path="mergen/core/AuditLogger.swift">
+//
+//  AuditLogger.swift
+//  mergen
+//
+//  Writes structured log entries to ~/Library/Logs/mergen/mergen-YYYY-MM-DD.log.
+//  All writes are async on a background serial queue (never blocks the UI).
+//
+
+import Foundation
+
+final class AuditLogger {
+
+    static let shared = AuditLogger()
+
+    private let logURL: URL
+    private let queue  = DispatchQueue(label: "com.mergen.logger", qos: .background)
+    private let stamp  = DateFormatter()
+
+    private init() {
+        stamp.dateFormat = "yyyy-MM-dd HH:mm:ss"
+
+        let lib = FileManager.default
+            .urls(for: .libraryDirectory, in: .userDomainMask).first!
+        let dir = lib.appendingPathComponent("Logs/mergen", isDirectory: true)
+        try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+
+        let day = String(ISO8601DateFormatter().string(from: Date()).prefix(10))
+        logURL = dir.appendingPathComponent("mergen-\(day).log")
+    }
+
+    // MARK: - Public API
+
+    func logScanStart(category: String?) {
+        write("SCAN_START  category=\"\(category ?? "All")\"")
+    }
+
+    func logCheckResult(_ v: Vulnerability) {
+        let status = v.checkstatus ?? "unknown"
+        let result = v.status.map { " result=\"\($0)\"" } ?? ""
+        write("CHECK       cisID=\"\(v.cisID.isEmpty ? "-" : v.cisID)\" status=\(status) name=\"\(v.name)\"\(result)")
+    }
+
+    func logScanComplete(_ results: [Vulnerability]) {
+        let pass     = results.filter { $0.checkstatus == "Green"  }.count
+        let fail     = results.filter { $0.checkstatus == "Red"    }.count
+        let warn     = results.filter { $0.checkstatus == "Yellow" }.count
+        let advisory = results.filter { $0.checkstatus == "Blue"   }.count
+        write("SCAN_DONE   total=\(results.count) pass=\(pass) fail=\(fail) warn=\(warn) advisory=\(advisory)")
+    }
+
+    func logFixStart(_ v: Vulnerability) {
+        let priv = v.fixRequiresAdmin ? "admin" : "user"
+        let cmd  = v.fixCommand ?? "—"
+        write("FIX_START   cisID=\"\(v.cisID)\" name=\"\(v.name)\" priv=\(priv) cmd=\"\(cmd)\"")
+    }
+
+    func logFixResult(_ v: Vulnerability, success: Bool) {
+        write("FIX_RESULT  cisID=\"\(v.cisID)\" name=\"\(v.name)\" success=\(success)")
+    }
+
+    func logAdminError(code: Int, message: String) {
+        write("ADMIN_ERR   code=\(code) msg=\"\(message)\"")
+    }
+
+    /// URL of today's log file (for "Open in Finder" / "Reveal" actions).
+    var logFileURL: URL { logURL }
+
+    /// Returns the last `limit` log lines (most recent last).
+    func recentLines(limit: Int = 600) -> [String] {
+        guard let raw = try? String(contentsOf: logURL, encoding: .utf8) else { return [] }
+        let lines = raw.components(separatedBy: "\n").filter { !$0.isEmpty }
+        return Array(lines.suffix(limit))
+    }
+
+    // MARK: - Private
+
+    private func write(_ body: String) {
+        let line = "[\(stamp.string(from: Date()))] \(body)\n"
+        queue.async {
+            guard let data = line.data(using: .utf8) else { return }
+            if FileManager.default.fileExists(atPath: self.logURL.path),
+               let fh = try? FileHandle(forWritingTo: self.logURL) {
+                fh.seekToEndOfFile()
+                fh.write(data)
+                fh.closeFile()
+            } else {
+                try? data.write(to: self.logURL, options: .atomic)
+            }
+        }
+    }
+}
+</file>
+
+<file path="mergen/core/FixCommands.swift">
+//
+//  FixCommands.swift
+//  mergen
+//
+//  Central registry mapping CIS checks to their auto-remediation shell commands.
+//  No check module files need to be modified — the lookup is done by cisID / docID.
+//
+
+import Foundation
+
+extension Vulnerability {
+
+    // MARK: - Fix Registries
+
+    /// Fixes that run as the current user (no password prompt).
+    private static let userFixes: [String: String] = [
+        // 2.3.1.1  AirDrop off
+        "2.3.1.1":  "defaults write com.apple.NetworkBrowser DisableAirDrop -bool YES",
+        // 2.3.1.2  AirPlay Receiver off
+        "2.3.1.2":  "defaults write com.apple.controlcenter AirplayRecieverEnabled -int 0",
+        // 2.3.3.10 Bluetooth sharing off
+        "2.3.3.10": "defaults -currentHost write com.apple.Bluetooth PrefKeyServicesEnabled -bool false",
+        // 2.5.2.1  Siri off
+        "2.5.2.1":  "defaults write com.apple.Siri SiriProfessionalEnabled -bool false",
+        // 2.6.3.2  Siri & Dictation improvement off
+        "2.6.3.2":  "defaults write com.apple.assistant.support \"Siri Data Sharing Opt-In Status\" -int 2",
+        // 2.6.3.3  Improve assistive voice off
+        "2.6.3.3":  "defaults write com.apple.Accessibility AXSAudioDonationSiriImprovementEnabled -bool false",
+        // 2.6.4    Personalized ads off
+        "2.6.4":    "defaults write com.apple.AdLib allowApplePersonalizedAdvertising -bool false",
+        // 2.8.1    Universal Control off
+        "2.8.1":    "defaults -currentHost write com.apple.universalcontrol Disable -int 1",
+        // 2.11.1   Screen saver interval  (≤ 20 min)
+        "2.11.1":   "defaults -currentHost write com.apple.screensaver idleTime -int 1200",
+        // 2.11.2   Password on wake
+        "2.11.2":   "defaults -currentHost write com.apple.screensaver askForPassword -bool true && defaults -currentHost write com.apple.screensaver askForPasswordDelay -int 0",
+        // 6.1.1    Show filename extensions
+        "6.1.1":    "defaults write NSGlobalDomain AppleShowAllExtensions -bool true",
+        // 6.3.1    Safari: don't auto-open safe files
+        //          NOTE: On macOS Tahoe, Safari preferences are sandboxed — defaults write
+        //          is blocked by cfprefsd. This must be changed manually in Safari > Settings.
+        // "6.3.1": removed — not auto-fixable on Tahoe
+        // 6.3.3    Safari: fraud warning
+        "6.3.3":    "defaults write com.apple.Safari WarnAboutFraudulentWebsites -bool true",
+        // 6.3.4    Safari: cross-site tracking prevention — check reads com.apple.Safari BlockStoragePolicy
+        "6.3.4":    "defaults write com.apple.Safari BlockStoragePolicy -int 2",
+        // 6.3.6    Safari: advertising privacy
+        "6.3.6":    "defaults write com.apple.Safari WebKitPreferences.privateClickMeasurementEnabled -bool true",
+        // 6.3.10   Safari: status bar — check reads com.apple.Safari ShowOverlayStatusBar
+        "6.3.10":   "defaults write com.apple.Safari ShowOverlayStatusBar -bool true",
+        // 6.4.1    Terminal: secure keyboard entry
+        "6.4.1":    "defaults write com.apple.Terminal SecureKeyboardEntry -bool true",
+    ]
+
+    /// Fixes that require administrator privileges (shown as one password prompt).
+    private static let adminFixes: [String: String] = [
+        // 1.2  Critical updates install automatically
+        "1.2":       "defaults write /Library/Preferences/com.apple.SoftwareUpdate CriticalUpdateInstall -int 1",
+        // 1.3  Auto-download updates
+        "1.3":       "defaults write /Library/Preferences/com.apple.SoftwareUpdate AutomaticDownload -bool true",
+        // 1.4  App Store auto-updates
+        "1.4":       "defaults write /Library/Preferences/com.apple.commerce AutoUpdate -bool true",
+        // 1.5  Security responses / config data
+        "1.5":       "defaults write /Library/Preferences/com.apple.SoftwareUpdate ConfigDataInstall -bool true",
+        // 2.2.1  Firewall on
+        "2.2.1":     "/usr/libexec/ApplicationFirewall/socketfilterfw --setglobalstate on",
+        // 2.2.2  Stealth mode on
+        "2.2.2":     "/usr/libexec/ApplicationFirewall/socketfilterfw --setstealthmode on",
+        // 2.3.2.1  Set time automatically — check reads com.apple.timezone.auto.plist Active
+        "2.3.2.1":   "defaults write /Library/Preferences/com.apple.timezone.auto.plist Active -int 1",
+        // 2.3.3.1  Screen sharing off (stop is best-effort; disable persists across reboot)
+        "2.3.3.1":   "launchctl disable system/com.apple.screensharing; launchctl stop com.apple.screensharing 2>/dev/null; true",
+        // 2.3.3.2  File sharing off
+        "2.3.3.2":   "launchctl disable system/com.apple.smbd; launchctl stop com.apple.smbd 2>/dev/null; true",
+        // 2.3.3.3  Printer sharing off
+        "2.3.3.3":   "cupsctl --no-share-printers",
+        // 2.3.3.4  Remote login (SSH) off
+        "2.3.3.4":   "launchctl disable system/com.openssh.sshd; launchctl stop com.openssh.sshd 2>/dev/null; true",
+        // 2.3.3.5  Remote management off
+        "2.3.3.5":   "/System/Library/CoreServices/RemoteManagement/ARDAgent.app/Contents/Resources/kickstart -deactivate -stop 2>/dev/null; true",
+        // 2.3.3.6  Remote Apple Events off — check verifies launchctl disabled state
+        "2.3.3.6":   "launchctl disable system/com.apple.AEServer; launchctl stop com.apple.AEServer 2>/dev/null; true",
+        // 2.3.3.7  Internet sharing off
+        "2.3.3.7":   "defaults write /Library/Preferences/SystemConfiguration/com.apple.nat NAT -dict-add Enabled -int 0",
+        // 2.3.3.8  Content caching off
+        "2.3.3.8":   "/usr/bin/AssetCacheManagerUtil deactivate 2>/dev/null; true",
+        // 2.3.3.9  Media sharing off — check reads com.apple.amp.mediasharingd home-sharing-enabled
+        "2.3.3.9":   "defaults write com.apple.amp.mediasharingd home-sharing-enabled -int 0; launchctl stop com.apple.amp.mediasharingd 2>/dev/null; true",
+        // 2.6.3.1  Share Mac analytics off
+        "2.6.3.1":   "defaults write '/Library/Application Support/CrashReporter/DiagnosticMessagesHistory.plist' AutoSubmit -bool false",
+        // 2.6.5    Gatekeeper on
+        "2.6.5":     "spctl --master-enable",
+        // 2.10.1.2 Sleep enabled (Apple Silicon) — 15 min sleep, 10 min display sleep
+        "2.10.1.2":  "pmset -a sleep 15; pmset -a displaysleep 10",
+        // 2.10.2   Power nap off
+        "2.10.2":    "pmset -a powernap 0 && pmset -a darkwakes 0",
+        // 2.10.3   Wake for network access off
+        "2.10.3":    "pmset -a womp 0",
+        // 2.11.4   Login window shows name + password fields (not user list)
+        "2.11.4":    "defaults write /Library/Preferences/com.apple.loginwindow SHOWFULLNAME -bool true",
+        // 2.11.5   Password hints off
+        "2.11.5":    "defaults write /Library/Preferences/com.apple.loginwindow RetriesUntilHint -int 0",
+        // 2.13.1   Guest login off — check reads com.apple.loginwindow.plist GuestEnabled
+        "2.13.1":    "defaults write /Library/Preferences/com.apple.loginwindow.plist GuestEnabled -bool false",
+        // 2.13.2   Guest network access off — check reads com.apple.AppleFileServer guestAccess
+        "2.13.2":    "defaults write /Library/Preferences/com.apple.AppleFileServer guestAccess -int 0",
+        // 2.13.3   Auto-login off (delete is best-effort — key may already be absent)
+        "2.13.3":    "defaults delete /Library/Preferences/com.apple.loginwindow autoLoginUser 2>/dev/null; true",
+        // 4.1      Bonjour multicast advertising off
+        "4.1":       "defaults write /Library/Preferences/com.apple.mDNSResponder.plist NoMulticastAdvertisements -bool true",
+        // 4.2      Apache HTTP server off
+        "4.2":       "launchctl disable system/org.apache.httpd; launchctl stop org.apache.httpd 2>/dev/null; true",
+        // 4.3      NFS server off
+        "4.3":       "launchctl disable system/com.apple.nfsd",
+        // 5.2.1    Password lockout threshold ≤ 5 attempts
+        "5.2.1":     "pwpolicy -n /Local/Default -setglobalpolicy maxFailedLoginAttempts=5",
+        // 5.2.2    Minimum password length ≥ 15 characters
+        "5.2.2":     "pwpolicy -n /Local/Default -setglobalpolicy minChars=15",
+        // 5.4      Sudo authentication timeout = 0 (require password every time)
+        "5.4":       "echo Defaults timestamp_timeout=0 > /etc/sudoers.d/cis_timeout && chmod 440 /etc/sudoers.d/cis_timeout",
+        // 5.5      Sudo TTY tickets (per-terminal auth)
+        "5.5":       "echo Defaults timestamp_type=tty > /etc/sudoers.d/cis_tty && chmod 440 /etc/sudoers.d/cis_tty",
+        // 5.6      Root account off — set shell to /usr/bin/false (what the check validates)
+        "5.6":       "dscl . -create /Users/root UserShell /usr/bin/false",
+        // 5.11     Sudo log allowed commands
+        "5.11":      "echo Defaults log_allowed > /etc/sudoers.d/cis_logging && chmod 440 /etc/sudoers.d/cis_logging",
+    ]
+
+    /// Fixes keyed by `docID` for standalone checks that have no CIS ID.
+    private static let docIDAdminFixes: [Int32: String] = [
+        // FastUserSwitchingCheck (docID 35)
+        35: "defaults write /Library/Preferences/.GlobalPreferences MultipleSessionEnabled -bool false",
+    ]
+
+    // MARK: - Human-readable impact descriptions
+
+    /// One-line description of what will change after the fix is applied.
+    private static let fixDescriptions: [String: String] = [
+        // Section 1
+        "1.2":       "Critical security updates will install automatically.",
+        "1.3":       "macOS updates will be downloaded automatically in the background.",
+        "1.4":       "App Store application updates will install automatically.",
+        "1.5":       "Security responses and system files will install automatically.",
+        // Section 2 – AirDrop / AirPlay / Bluetooth
+        "2.3.1.1":   "AirDrop will be disabled for all networks.",
+        "2.3.1.2":   "AirPlay Receiver will be off — other devices can no longer cast to this Mac.",
+        "2.3.3.10":  "Bluetooth Sharing will be disabled.",
+        // Section 2 – Sharing services
+        "2.3.3.1":   "Screen Sharing service will be disabled and stopped.",
+        "2.3.3.2":   "File Sharing (SMB/AFP) service will be disabled and stopped.",
+        "2.3.3.3":   "Printer Sharing will be turned off.",
+        "2.3.3.4":   "Remote Login (SSH) service will be disabled and stopped.",
+        "2.3.3.5":   "Remote Management (ARD) will be deactivated and stopped.",
+        "2.3.3.6":   "Remote Apple Events will be disabled.",
+        "2.3.3.7":   "Internet Sharing will be disabled.",
+        "2.3.3.8":   "Content Caching service will be deactivated.",
+        "2.3.3.9":   "Media Sharing service will be disabled.",
+        // Section 2 – Time
+        "2.3.2.1":   "System clock will sync automatically with a network time server.",
+        // Section 2 – Firewall
+        "2.2.1":     "macOS Application Firewall will be turned on, blocking unauthorized incoming connections.",
+        "2.2.2":     "Firewall stealth mode will be enabled — your Mac will not respond to ping or port scans.",
+        // Section 2 – Siri / Intelligence / Analytics
+        "2.5.2.1":   "Siri will be disabled.",
+        "2.6.3.1":   "Sending diagnostic and usage data to Apple will be turned off.",
+        "2.6.3.2":   "Siri & Dictation improvement data sharing will be turned off.",
+        "2.6.3.3":   "Assistive Voice improvement data sharing will be disabled.",
+        "2.6.4":     "Apple personalized advertising will be disabled.",
+        // Section 2 – Gatekeeper / Power / Login / Universal Control
+        "2.6.5":     "Gatekeeper will be re-enabled — only apps from identified developers will run.",
+        "2.8.1":     "Universal Control will be disabled, preventing keyboard/mouse sharing with nearby devices.",
+        "2.10.1.2":  "Sleep will be set to 15 min and display sleep to 10 min.",
+        "2.10.2":    "Power Nap and dark wake will be disabled.",
+        "2.10.3":    "Wake for network access will be disabled.",
+        "2.11.1":    "Screen saver will activate after 20 minutes of inactivity.",
+        "2.11.2":    "Your password will be required immediately when the screen saver or sleep activates.",
+        "2.11.4":    "Login window will show username and password fields instead of a user list.",
+        "2.11.5":    "Password hints will no longer appear after failed login attempts.",
+        "2.13.1":    "Guest account will be disabled.",
+        "2.13.2":    "Guest access to shared folders will be disabled.",
+        "2.13.3":    "Automatic login will be disabled — a password will be required at every startup.",
+        // Section 4 – Network services
+        "4.1":       "Bonjour multicast advertising will be disabled.",
+        "4.2":       "Apache HTTP Server will be disabled and stopped.",
+        "4.3":       "NFS file server will be disabled.",
+        // Section 5 – Auth
+        "5.2.1":     "Account will lock after 5 consecutive failed password attempts.",
+        "5.2.2":     "Minimum password length will be set to 15 characters.",
+        "5.4":       "sudo will require your password every time — no grace period between commands.",
+        "5.5":       "sudo authentication will be scoped per terminal window (TTY tickets).",
+        "5.6":       "Root account will be disabled.",
+        "5.11":      "sudo will log all allowed commands to the system log.",
+        // Section 6 – UI / Safari / Terminal
+        "6.1.1":     "All file extensions will be visible in Finder.",
+        // 6.3.1 removed — Safari preferences are sandboxed on Tahoe, cannot be auto-fixed.
+        "6.3.3":     "Safari fraudulent website warning will be enabled.",
+        "6.3.4":     "Safari cross-site tracking prevention will be enabled.",
+        "6.3.6":     "Safari Private Click Measurement (ad privacy) will be enabled.",
+        "6.3.10":    "Safari status bar will be shown, displaying link URLs on hover.",
+        "6.4.1":     "Terminal secure keyboard entry will be enabled, blocking other apps from reading keystrokes.",
+    ]
+
+    /// docID-keyed descriptions for checks without a CIS ID.
+    private static let docIDFixDescriptions: [Int32: String] = [
+        35: "Fast User Switching will be disabled.",
+    ]
+
+    // MARK: - Public API
+
+    /// Shell command that remediates this finding, or `nil` if not auto-fixable.
+    var fixCommand: String? {
+        if let cmd = Vulnerability.userFixes[cisID]  { return cmd }
+        if let cmd = Vulnerability.adminFixes[cisID] { return cmd }
+        if let cmd = Vulnerability.docIDAdminFixes[docID] { return cmd }
+        return nil
+    }
+
+    /// Whether `fixCommand` needs to run with administrator privileges.
+    var fixRequiresAdmin: Bool {
+        if Vulnerability.userFixes[cisID]  != nil { return false }
+        if Vulnerability.adminFixes[cisID] != nil { return true }
+        if Vulnerability.docIDAdminFixes[docID] != nil { return true }
+        return false
+    }
+
+    /// Human-readable description of what the fix will change, or `nil` if unknown.
+    var fixDescription: String? {
+        if let d = Vulnerability.fixDescriptions[cisID]       { return d }
+        if let d = Vulnerability.docIDFixDescriptions[docID]  { return d }
+        return nil
+    }
+
+    /// `true` when this check failed AND has an auto-remediation available.
+    var isAutoFixable: Bool { checkstatus == "Red" && fixCommand != nil }
+}
+</file>
+
+<file path="mergen/core/FixManager.swift">
+//
+//  FixManager.swift
+//  mergen
+//
+//  Execution engine for auto-remediation.
+//
+//  Design notes:
+//  • User-level fixes  → Process(/bin/bash -c). Exit code 0 = ran cleanly.
+//  • Admin-level fixes → NSAppleScript "do shell script ... with administrator privileges".
+//    The script is wrapped in "bash -c '...; exit 0'" so that individual command
+//    failures (e.g. launchctl stop on an already-stopped service) don't abort the
+//    whole batch. The only hard failure is AppleScript error -128 (user cancelled).
+//    Real success is determined by re-running the check, not by the shell exit code.
+//
+
+import Foundation
+import AppKit
+
+enum FixResult {
+    case success          // command ran; check will verify outcome
+    case cancelled        // user dismissed the password dialog
+    case scriptError(String) // AppleScript or process failed to launch
+}
+
+enum FixManager {
+
+    // MARK: - User-level (no password)
+
+    /// Runs a shell command as the current user. Returns `.success` on exit 0.
+    static func runUserCommand(_ cmd: String) -> FixResult {
+        let proc = Process()
+        proc.executableURL = URL(fileURLWithPath: "/bin/bash")
+        proc.arguments     = ["-c", cmd]
+        proc.standardOutput = Pipe()
+        proc.standardError  = Pipe()
+        do {
+            try proc.run()
+            proc.waitUntilExit()
+            if proc.terminationStatus == 0 {
+                return .success
+            } else {
+                return .scriptError("exit \(proc.terminationStatus)")
+            }
+        } catch {
+            return .scriptError(error.localizedDescription)
+        }
+    }
+
+    // MARK: - Admin-level (one password dialog)
+
+    /// Runs a shell command with administrator privileges via NSAppleScript.
+    ///
+    /// The command is wrapped in `bash -c '...; exit 0'` so individual failures
+    /// inside the script do not cause the whole AppleScript call to fail.
+    /// Only AppleScript error -128 (user cancelled) returns `.cancelled`.
+    /// Any other AppleScript error is logged but treated as `.success` — the
+    /// caller must re-run the check to determine whether the fix actually worked.
+    static func runAdminCommand(_ cmd: String) -> FixResult {
+        // Wrap in bash and force exit 0 so intermediate failures don't cascade.
+        // Shell-escape single quotes inside cmd, then wrap in single-quoted bash arg.
+        let shellCmd    = cmd.replacingOccurrences(of: "'", with: "'\\''")
+        let bashWrapped = "bash -c '\(shellCmd); exit 0'"
+
+        // Escape for AppleScript double-quoted string.
+        let escaped = bashWrapped
+            .replacingOccurrences(of: "\\", with: "\\\\")
+            .replacingOccurrences(of: "\"", with: "\\\"")
+
+        let source = "do shell script \"\(escaped)\" with administrator privileges"
+        guard let script = NSAppleScript(source: source) else {
+            return .scriptError("NSAppleScript could not be initialised")
+        }
+
+        var errorDict: NSDictionary?
+        script.executeAndReturnError(&errorDict)
+
+        guard let err = errorDict else { return .success }
+
+        let code    = (err[NSAppleScript.errorNumber]  as? Int)    ?? 0
+        let message = (err[NSAppleScript.errorMessage] as? String) ?? "unknown"
+
+        // -128 = user clicked Cancel in the password dialog.
+        if code == -128 { return .cancelled }
+
+        // Any other code: the script itself errored (unusual with our bash wrapper).
+        // Log it and return success anyway — the re-check decides real outcome.
+        AuditLogger.shared.logAdminError(code: code, message: message)
+        return .success
+    }
+}
+</file>
+
+<file path="mergen/core/ScanManager.swift">
+//
+//  ScanManager.swift
+//  mergen
+//
+//  Created by Samet Sazak
+//
+
+import Foundation
+import Combine
+
+class ScanManager: ObservableObject {
+    @Published var scanResults: [Vulnerability] = []
+    @Published var progress: Double = 0
+    @Published var scanning: Bool = false
+    @Published var fixingIDs:     Set<UUID>  = []
+    @Published var fixResults:    [UUID: Bool] = [:]   // true = check passed after fix
+    @Published var fixCancelled:  Set<UUID>  = []      // user dismissed password dialog
+    private var totalModules: Int = 0
+    
+    func startScan(category: String?) {
+        scanning = true
+        AuditLogger.shared.logScanStart(category: category)
+
+        DispatchQueue.global(qos: .userInitiated).async {
+            let scanner = Scanner()
+            if let category = category {
+                scanner.loadModules(category: category)
+            } else {
+                scanner.loadModules()
+            }
+            self.totalModules = scanner.moduleCount
+            var completedModules = 0
+
+            scanner.modules.forEach { module in
+                let timeout: DispatchTimeInterval = .seconds(15)
+
+                let semaphore = DispatchSemaphore(value: 0)
+
+                let taskQueue = DispatchQueue(label: "com.sametsazak.mergen", qos: .userInteractive)
+                taskQueue.async {
+                    module.check()
+                    semaphore.signal()
+                }
+
+                let result = semaphore.wait(timeout: DispatchTime.now() + timeout)
+
+                if result == .timedOut {
+                    module.checkstatus = "Yellow"
+                    module.status = "Check timed out"
+                }
+
+                AuditLogger.shared.logCheckResult(module)
+
+                DispatchQueue.main.async {
+                    self.scanResults.append(module)
+                    completedModules += 1
+                    self.progress = Double(completedModules) / Double(self.totalModules)
+
+                    if self.progress >= 0.9999 {
+                        self.scanning = false
+                        AuditLogger.shared.logScanComplete(self.scanResults)
+                    }
+                }
+            }
+        }
+    }
+
+
+    func resetScan() {
+        scanning = false
+        progress = 0.0
+        scanResults = []
+        fixingIDs    = []
+        fixResults   = [:]
+        fixCancelled = []
+    }
+
+    // MARK: - Auto-Remediation
+
+    /// Applies the fix for a single vulnerability, then re-runs its check.
+    /// Success is determined by whether the check passes after the fix, not by exit code.
+    func applyFix(for vulnerability: Vulnerability) {
+        guard vulnerability.isAutoFixable else { return }
+        let id = vulnerability.id
+        fixingIDs.insert(id)
+        AuditLogger.shared.logFixStart(vulnerability)
+
+        DispatchQueue.global(qos: .userInitiated).async {
+            let cmd    = vulnerability.fixCommand!
+            let result: FixResult
+            if vulnerability.fixRequiresAdmin {
+                result = FixManager.runAdminCommand(cmd)
+            } else {
+                result = FixManager.runUserCommand(cmd)
+            }
+
+            // Re-run the check unless the user cancelled the password dialog.
+            if case .cancelled = result {
+                AuditLogger.shared.logFixResult(vulnerability, success: false)
+                DispatchQueue.main.async {
+                    self.fixingIDs.remove(id)
+                    self.fixCancelled.insert(id)
+                    self.objectWillChange.send()
+                }
+                return
+            }
+
+            vulnerability.check()
+            let success = vulnerability.checkstatus == "Green"
+            AuditLogger.shared.logFixResult(vulnerability, success: success)
+
+            DispatchQueue.main.async {
+                self.fixingIDs.remove(id)
+                self.fixResults[id] = success
+                self.objectWillChange.send()
+            }
+        }
+    }
+
+    /// Applies fixes for a list of vulnerabilities.
+    /// User-level fixes run one at a time (no password needed).
+    /// Admin fixes are batched into ONE password dialog, joined with `;` so a
+    /// single failing command doesn't block the rest. Real success is determined
+    /// by re-running each check after the batch completes.
+    func fixAll(_ vulnerabilities: [Vulnerability]) {
+        let fixable    = vulnerabilities.filter { $0.isAutoFixable }
+        let userFixes  = fixable.filter { !$0.fixRequiresAdmin }
+        let adminFixes = fixable.filter {  $0.fixRequiresAdmin }
+        guard !fixable.isEmpty else { return }
+
+        fixingIDs.formUnion(fixable.map { $0.id })
+        for v in fixable { AuditLogger.shared.logFixStart(v) }
+
+        DispatchQueue.global(qos: .userInitiated).async {
+
+            // ── User-level fixes (no password) ──────────────────────────────
+            for v in userFixes {
+                _ = FixManager.runUserCommand(v.fixCommand!)
+                v.check()
+                let success = v.checkstatus == "Green"
+                AuditLogger.shared.logFixResult(v, success: success)
+                DispatchQueue.main.async {
+                    self.fixingIDs.remove(v.id)
+                    self.fixResults[v.id] = success
+                    self.objectWillChange.send()
+                }
+            }
+
+            // ── Admin fixes — ONE password prompt ────────────────────────────
+            // Join with `;` (not `&&`) so each command runs independently.
+            // FixManager wraps the whole thing in `bash -c '...; exit 0'` so
+            // the AppleScript call itself never fails due to individual commands.
+            if !adminFixes.isEmpty {
+                let combined = adminFixes.compactMap { $0.fixCommand }
+                                         .joined(separator: " ; ")
+                let result = FixManager.runAdminCommand(combined)
+
+                if case .cancelled = result {
+                    // User dismissed the dialog — mark all admin fixes as cancelled.
+                    for v in adminFixes {
+                        AuditLogger.shared.logFixResult(v, success: false)
+                        DispatchQueue.main.async {
+                            self.fixingIDs.remove(v.id)
+                            self.fixCancelled.insert(v.id)
+                            self.objectWillChange.send()
+                        }
+                    }
+                    return
+                }
+
+                // Script ran — re-check each vulnerability to determine real outcome.
+                for v in adminFixes {
+                    v.check()
+                    let success = v.checkstatus == "Green"
+                    AuditLogger.shared.logFixResult(v, success: success)
+                    DispatchQueue.main.async {
+                        self.fixingIDs.remove(v.id)
+                        self.fixResults[v.id] = success
+                        self.objectWillChange.send()
+                    }
+                }
+            }
+        }
+    }
+}
+</file>
+
+<file path="mergen/core/Scanner.swift">
+//
+//  Scanner.swift
+//  mergen
+//
+//  Created by Samet Sazak
+//
+//  Updated for CIS Apple macOS 26 Tahoe Benchmark v1.0.0
+
+import Foundation
+
+class Scanner {
+    var modules: [Vulnerability] = []
+    var moduleCount: Int {
+        modules.count
+    }
+
+    func loadModules(category: String? = nil) {
+        modules = []
+
+        // MARK: - Section 1: Install Updates, Patches and Additional Security Software
+        modules.append(AppleSoftwareUpdateCheck())        // 1.1
+        modules.append(CriticalUpdateInstallCheck())      // 1.2
+        modules.append(AutomaticSoftwareUpdateCheck())    // 1.3
+        modules.append(AppStoreUpdatesCheck())            // 1.4
+        modules.append(SecurityUpdatesCheck())            // 1.5
+        modules.append(SoftwareUpdateDefermentCheck())    // 1.6
+
+        // MARK: - Section 2.1: iCloud
+        modules.append(iCloudKeychainCheck())             // 2.1.1.1
+        modules.append(iCloudDriveCheck())                // 2.1.1.3
+
+        // MARK: - Section 2.2: Firewall
+        modules.append(FirewallCheck())                   // 2.2.1
+        modules.append(FirewallStealthModeCheck())        // 2.2.2
+
+        // MARK: - Section 2.3: Sharing
+        modules.append(AirDropDisabledCheck())            // 2.3.1.1
+        modules.append(AirPlayReceiverDisabledCheck())    // 2.3.1.2
+        modules.append(SetTimeAndDateAutomaticallyEnabledCheck()) // 2.3.2.1
+        modules.append(TimeWithinLimitsCheck())           // 2.3.2.2
+        modules.append(ScreenSharingDisabledCheck())      // 2.3.3.1
+        modules.append(FileSharingDisabledCheck())        // 2.3.3.2
+        modules.append(PrinterSharingDisabledCheck())     // 2.3.3.3
+        modules.append(RemoteLoginDisabledCheck())        // 2.3.3.4
+        modules.append(RemoteManagementDisabledCheck())   // 2.3.3.5
+        modules.append(RemoteAppleEventsDisabledCheck())  // 2.3.3.6
+        modules.append(InternetSharingDisabledCheck())    // 2.3.3.7
+        modules.append(ContentCachingDisabledCheck())     // 2.3.3.8
+        modules.append(MediaSharingDisabledCheck())       // 2.3.3.9
+        modules.append(BluetoothSharingDisabledCheck())   // 2.3.3.10
+        modules.append(TimeMachineEnabledCheck())         // 2.3.4.1
+
+        // MARK: - Section 2.5: Apple Intelligence
+        modules.append(ExternalIntelligenceExtensionsCheck()) // 2.5.1.1
+        modules.append(WritingToolsCheck())               // 2.5.1.2
+        modules.append(MailSummarizationCheck())          // 2.5.1.3
+        modules.append(NotesSummarizationCheck())         // 2.5.1.4
+
+        // MARK: - Section 2.6: Privacy & Security
+        modules.append(LocationServicesCheck())           // 2.6.1.1
+        modules.append(LocationServicesMenuBarCheck())    // 2.6.1.2
+        modules.append(ShareMacAnalyticsCheck())          // 2.6.3.1
+        modules.append(ImproveSiriDictationCheck())       // 2.6.3.2
+        modules.append(ImproveAssistiveVoiceCheck())      // 2.6.3.3
+        modules.append(ShareWithAppDevelopersCheck())     // 2.6.3.4
+        modules.append(LimitAdTrackingCheck())            // 2.6.4
+        modules.append(GatekeeperBypassCheck())           // 2.6.5
+        modules.append(FileVaultCheck())                  // 2.6.6
+        modules.append(AdminPasswordForSystemPrefsCheck()) // 2.6.8
+        modules.append(LockdownModeCheck())               // 2.6.7 (advisory)
+
+        // MARK: - Section 2.7: Screen Saver
+        modules.append(ScreenSaverCornersCheck())         // 2.7.1
+
+        // MARK: - Section 2.9: Spotlight
+        modules.append(SpotlightImprovementCheck())       // 2.9.1
+
+        // MARK: - Section 2.10: Power
+        modules.append(SleepEnabledAppleSiliconCheck())   // 2.10.1.2
+        modules.append(PowerNapDisabledCheck())           // 2.10.2
+        modules.append(WakeForNetworkAccessCheck())       // 2.10.3
+
+        // MARK: - Section 2.11: Login
+        modules.append(ScreenSaverInactivityCheck())      // 2.11.1
+        modules.append(PasswordOnWakeCheck())             // 2.11.2
+        modules.append(LoginScreenMessageCheck())         // 2.11.3
+        modules.append(LoginWindowNamePasswordCheck())    // 2.11.4
+        modules.append(PasswordHintsCheck())              // 2.11.5
+
+        // MARK: - Section 2.13: Guest Access
+        modules.append(GuestLoginCheck())                 // 2.13.1
+        modules.append(GuestConnectCheck())               // 2.13.2
+        modules.append(AutomaticLoginDisabledCheck())     // 2.13.3
+
+        // MARK: - Section 3: Logging and Auditing
+        modules.append(SecurityAuditingCheck())           // 3.1
+        modules.append(AuditFlagsCheck())                 // 3.3
+
+        // MARK: - Section 4: Network Configurations
+        modules.append(BonjourCheck())                    // 4.1
+        modules.append(HttpServerCheck())                 // 4.2
+        modules.append(NfsServerCheck())                  // 4.3
+
+        // MARK: - Section 5: System Access, Authentication and Authorization
+        modules.append(SIPStatusCheck())                  // 5.1.2
+        modules.append(SecureKernelExtensionLoadingCheck()) // 5.1.x
+        modules.append(AMFIEnabledCheck())                // 5.1.3
+        modules.append(SSVEnabledCheck())                 // 5.1.4
+        modules.append(PasswordLockoutThresholdCheck())   // 5.2.1
+        modules.append(PasswordMinLengthCheck())          // 5.2.2
+        modules.append(SudoTimeoutCheck())                // 5.4
+        modules.append(SudoTTYTicketsCheck())             // 5.5
+        modules.append(RootAccountDisabledCheck())        // 5.6
+        modules.append(GuestHomeFolderCheck())            // 5.9
+        modules.append(XProtectStatusCheck())             // 5.10
+        modules.append(SudoLoggingCheck())                // 5.11
+
+        // MARK: - Section 6: User Interface
+        modules.append(FilenameExtensionsCheck())         // 6.1.1
+        modules.append(HomeFolderPermissionsCheck())      // 6.1.2
+        modules.append(SafariSafeFilesCheck())            // 6.3.1
+        modules.append(SafariFraudWarningCheck())         // 6.3.3
+        modules.append(SafariCrossSiteTrackingCheck())    // 6.3.4
+        modules.append(SafariAdvertisingPrivacyCheck())   // 6.3.6
+        modules.append(SafariStatusBarCheck())            // 6.3.10
+        modules.append(TerminalSecureKeyboardCheck())     // 6.4.1
+
+        // MARK: - Standalone Security Checks
+        modules.append(DiagnosticDataCheck())
+        modules.append(SiriEnabledCheck())
+        modules.append(CertificateTrustCheck())
+        modules.append(SSHCheck())
+        modules.append(ShowWiFiStatusCheck())
+        modules.append(BluetoothMenuBarCheck())
+        modules.append(FastUserSwitchingCheck())
+
+        // Removed in Tahoe benchmark: Java6Check, EFIVersionCheck, DVDOrCDSharingDisabledCheck
+
+        // Filter modules by category if specified
+        if let category = category {
+            modules = modules.filter { $0.category == category }
+        }
+    }
+
+}
+</file>
+
+<file path="mergen/core/Vulnerability.swift">
+//
+//  Vulnerabilities.swift
+//  mergen
+//
+//  Created by Samet Sazak
+//
+
+import Foundation
+
+class Vulnerability: Identifiable {
+    let id = UUID()
+    let name: String
+    let description: String
+    let category: String
+    let remediation: String
+    let severity: String
+    let documentation: String?
+    var status: String?
+    let mitigation: String
+    var error: Error?
+    var checkstatus: String?
+    let docID: Int32
+    /// CIS Benchmark section identifier, e.g. "2.2.1"
+    let cisID: String
+    /// True for checks that require manual review rather than automated assessment
+    let isManual: Bool
+
+    init(
+        name: String,
+        description: String,
+        category: String,
+        remediation: String,
+        severity: String,
+        documentation: String,
+        mitigation: String,
+        checkstatus: String? = nil,
+        docID: Int32,
+        cisID: String = "",
+        isManual: Bool = false
+    ) {
+        self.name = name
+        self.description = description
+        self.category = category
+        self.remediation = remediation
+        self.severity = severity
+        self.documentation = documentation
+        self.mitigation = mitigation
+        self.checkstatus = checkstatus
+        self.docID = docID
+        self.cisID = cisID
+        self.isManual = isManual
+    }
+
+    func check() {
+        fatalError("The 'check' method should be implemented in subclasses.")
+    }
+}
+</file>
+
+<file path="mergen/mergen.entitlements">
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict/>
+</plist>
+</file>
+
+<file path="mergen/mergenApp.swift">
+//
+//  mergenApp.swift
+//  mergen
+//
+//  Created by Samet Sazak
+//
+
+import SwiftUI
+
+@main
+struct MergenApp: App {
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+                .frame(minWidth: 1115, maxWidth: .infinity, minHeight: 615, maxHeight: .infinity)
+        }
+        .windowStyle(DefaultWindowStyle())
+    }
+}
+</file>
+
+<file path="mergen/mergenRelease.entitlements">
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict/>
+</plist>
+</file>
+
+<file path="mergen/Preview Content/..gitkeep">
+
+</file>
+
+<file path="mergen/Preview/.gitkeep">
+
+</file>
+
+<file path="mergen/Tests/TestPlan.xctestplan">
+{
+  "configurations" : [
+    {
+      "id" : "9D51A544-E6AE-4623-9701-51F137BCC816",
+      "name" : "Configuration 1",
+      "options" : {
+
+      }
+    }
+  ],
+  "defaultOptions" : {
+    "testTimeoutsEnabled" : true
+  },
+  "testTargets" : [
+
+  ],
+  "version" : 1
+}
+</file>
+
+<file path="mergen/view/FixAllSheet.swift">
+//
+//  FixAllSheet.swift
+//  mergen
+//
+//  Sheet showing all auto-fixable failed checks with individual and batch
+//  apply buttons.
+//
+
+import SwiftUI
+
+struct FixAllSheet: View {
+    @ObservedObject var scanManager: ScanManager
+    @Environment(\.dismiss) private var dismiss
+    @State private var showLog = false
+
+    private var fixable: [Vulnerability] {
+        scanManager.scanResults.filter { $0.isAutoFixable }
+    }
+
+    private var adminCount:   Int  { fixable.filter {  $0.fixRequiresAdmin }.count }
+    private var userCount:    Int  { fixable.filter { !$0.fixRequiresAdmin }.count }
+    private var isFixing:     Bool { !scanManager.fixingIDs.isEmpty }
+    private var hasFailures:  Bool { scanManager.fixResults.values.contains(false) }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+
+            // ── Header ──────────────────────────────────────────────────────
+            HStack(alignment: .top) {
+                VStack(alignment: .leading, spacing: 4) {
+                    Text("Fix All Issues")
+                        .font(.system(size: 18, weight: .bold))
+                    Text("\(fixable.count) issue\(fixable.count == 1 ? "" : "s") can be fixed automatically")
+                        .font(.subheadline)
+                        .foregroundColor(.secondary)
+                }
+                Spacer()
+                Button { dismiss() } label: {
+                    Image(systemName: "xmark.circle.fill")
+                        .font(.system(size: 20))
+                        .foregroundColor(.secondary.opacity(0.6))
+                }
+                .buttonStyle(.plain)
+            }
+            .padding(20)
+
+            Divider()
+
+            // ── Admin privilege notice ───────────────────────────────────────
+            if adminCount > 0 {
+                let adminColor = Color(red: 0.97, green: 0.63, blue: 0.22)
+                HStack(spacing: 0) {
+                    RoundedRectangle(cornerRadius: 0)
+                        .fill(adminColor)
+                        .frame(width: 4)
+                    HStack(spacing: 12) {
+                        Image(systemName: "lock.shield.fill")
+                            .font(.system(size: 20))
+                            .foregroundColor(adminColor)
+                        VStack(alignment: .leading, spacing: 3) {
+                            Text("\(adminCount) fix\(adminCount == 1 ? "" : "es") require administrator privileges")
+                                .font(.system(size: 13, weight: .semibold))
+                            Text("You will be prompted once for your password. All admin fixes are batched together.")
+                                .font(.caption)
+                                .foregroundColor(.secondary)
+                        }
+                    }
+                    .padding(.horizontal, 16)
+                    .padding(.vertical, 12)
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .background(adminColor.opacity(0.08))
+                Divider()
+            }
+
+            // ── List ─────────────────────────────────────────────────────────
+            ScrollView {
+                LazyVStack(spacing: 0) {
+                    ForEach(fixable, id: \.id) { v in
+                        FixRowItem(vulnerability: v, scanManager: scanManager)
+                        Divider().padding(.leading, 48)
+                    }
+                }
+            }
+
+            Divider()
+
+            // ── Footer ───────────────────────────────────────────────────────
+            HStack(spacing: 10) {
+                if isFixing {
+                    Label("Applying fixes…", systemImage: "gearshape.fill")
+                        .font(.system(size: 11))
+                        .foregroundColor(.secondary)
+                } else if hasFailures {
+                    Button {
+                        showLog = true
+                    } label: {
+                        Label("View Audit Log", systemImage: "doc.text.magnifyingglass")
+                            .font(.system(size: 11))
+                    }
+                    .buttonStyle(.bordered)
+                    .controlSize(.small)
+                }
+                Spacer()
+                Button("Close") { dismiss() }
+                    .buttonStyle(.bordered)
+                if !isFixing {
+                    Button {
+                        scanManager.fixAll(fixable)
+                    } label: {
+                        Label("Apply All Fixes", systemImage: "bolt.fill")
+                            .font(.system(size: 13, weight: .semibold))
+                            .foregroundColor(.white)
+                            .padding(.horizontal, 16)
+                            .padding(.vertical, 8)
+                            .background(
+                                LinearGradient(
+                                    colors: [
+                                        Color(red: 0.39, green: 0.44, blue: 0.98),
+                                        Color(red: 0.52, green: 0.34, blue: 0.96)
+                                    ],
+                                    startPoint: .leading,
+                                    endPoint: .trailing
+                                )
+                            )
+                            .cornerRadius(9)
+                            .shadow(color: Color.accentColor.opacity(0.30), radius: 5, y: 2)
+                    }
+                    .buttonStyle(.plain)
+                    .disabled(fixable.isEmpty)
+                    .opacity(fixable.isEmpty ? 0.5 : 1)
+                }
+            }
+            .padding(16)
+        }
+        .frame(width: 560, height: 500)
+        .sheet(isPresented: $showLog) {
+            LogViewerSheet()
+        }
+    }
+}
+
+// MARK: - Fix Row
+
+struct FixRowItem: View {
+    let vulnerability: Vulnerability
+    @ObservedObject var scanManager: ScanManager
+
+    private var isFixing:   Bool  { scanManager.fixingIDs.contains(vulnerability.id) }
+    private var result:     Bool? { scanManager.fixResults[vulnerability.id] }
+    private var isFixed:    Bool  { vulnerability.checkstatus == "Green" }
+    private var isCancelled: Bool { scanManager.fixCancelled.contains(vulnerability.id) }
+
+    private var rowIcon: String {
+        if isFixed            { return "checkmark.circle.fill" }
+        if let r = result     { return r ? "checkmark.circle.fill" : "xmark.circle.fill" }
+        return "xmark.circle.fill"
+    }
+
+    private var rowColor: Color {
+        if isFixed            { return .green }
+        if let r = result     { return r ? .green : .red }
+        return .red
+    }
+
+    var body: some View {
+        HStack(spacing: 12) {
+            Image(systemName: rowIcon)
+                .foregroundColor(rowColor)
+                .font(.system(size: 16))
+                .frame(width: 22)
+
+            VStack(alignment: .leading, spacing: 4) {
+                HStack(spacing: 6) {
+                    if !vulnerability.cisID.isEmpty {
+                        Text(vulnerability.cisID)
+                            .font(.system(size: 10, weight: .medium, design: .monospaced))
+                            .foregroundColor(.secondary)
+                            .padding(.horizontal, 5)
+                            .padding(.vertical, 2)
+                            .background(Color.primary.opacity(0.06))
+                            .cornerRadius(4)
+                    }
+                    Text(vulnerability.name)
+                        .font(.system(size: 13, weight: .medium))
+                        .lineLimit(1)
+                }
+
+                // Before: current finding
+                if let current = vulnerability.status, !current.isEmpty {
+                    HStack(spacing: 4) {
+                        Image(systemName: "arrow.right.circle")
+                            .font(.system(size: 9))
+                            .foregroundColor(.red.opacity(0.7))
+                        Text("Now: \(current)")
+                            .font(.system(size: 10))
+                            .foregroundColor(.secondary)
+                            .lineLimit(1)
+                    }
+                }
+
+                // After: what changes
+                if let after = vulnerability.fixDescription {
+                    HStack(spacing: 4) {
+                        Image(systemName: "checkmark.circle")
+                            .font(.system(size: 9))
+                            .foregroundColor(.green.opacity(0.8))
+                        Text("Fix: \(after)")
+                            .font(.system(size: 10))
+                            .foregroundColor(.green.opacity(0.85))
+                            .lineLimit(2)
+                    }
+                }
+
+                if vulnerability.fixRequiresAdmin {
+                    Label("Requires admin", systemImage: "lock.fill")
+                        .font(.system(size: 9))
+                        .foregroundColor(.orange)
+                }
+            }
+
+            Spacer()
+
+            // Action area
+            Group {
+                if isFixing {
+                    ProgressView()
+                        .scaleEffect(0.75)
+                        .frame(width: 64)
+                } else if isFixed {
+                    Text("Fixed ✓")
+                        .font(.system(size: 11, weight: .semibold))
+                        .foregroundColor(.green)
+                } else if isCancelled {
+                    Text("Cancelled")
+                        .font(.system(size: 11, weight: .semibold))
+                        .foregroundColor(.secondary)
+                } else if let r = result, !r {
+                    VStack(alignment: .trailing, spacing: 2) {
+                        Label("Still failing", systemImage: "exclamationmark.triangle.fill")
+                            .font(.system(size: 11, weight: .semibold))
+                            .foregroundColor(.red)
+                        if let status = vulnerability.status, !status.isEmpty {
+                            Text(status)
+                                .font(.system(size: 9))
+                                .foregroundColor(.secondary)
+                                .multilineTextAlignment(.trailing)
+                                .lineLimit(2)
+                        }
+                    }
+                } else {
+                    Button("Fix") {
+                        scanManager.applyFix(for: vulnerability)
+                    }
+                    .buttonStyle(.bordered)
+                    .controlSize(.small)
+                    .tint(.accentColor)
+                }
+            }
+            .frame(minWidth: 64, alignment: .trailing)
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 10)
+        .animation(.default, value: isFixing)
+        .animation(.default, value: isFixed)
+    }
+}
+</file>
+
+<file path="mergen/view/HTMLReportGenerator.swift">
+//
+//  HTMLReportGenerator.swift
+//  mergen
+//
+
+import Foundation
+import SwiftUI
+import UniformTypeIdentifiers
+
+struct HTMLReportGenerator {
+
+    let scanResults: [Vulnerability]
+
+    init(scanResults: [Vulnerability]) {
+        self.scanResults = scanResults
+    }
+
+    // MARK: - Public
+
+    func generateHTMLReport() -> String {
+        let automated   = scanResults.filter { !$0.isManual && $0.checkstatus != "Blue" }
+        let passCount   = automated.filter { $0.checkstatus == "Green" }.count
+        let failCount   = scanResults.filter { $0.checkstatus == "Red" }.count
+        let warnCount   = scanResults.filter { $0.checkstatus == "Yellow" }.count
+        let advisoryCount = scanResults.filter { $0.checkstatus == "Blue" }.count
+        let total       = automated.count
+        let score       = total > 0 ? Double(passCount) / Double(total) : 0.0
+        let scoreInt    = Int(score * 100)
+        let scoreLabel  = score >= 0.8 ? "GOOD" : score >= 0.5 ? "FAIR" : "AT RISK"
+        let scoreColor  = score >= 0.8 ? "#21d49c" : score >= 0.5 ? "#f7a13a" : "#f25c5c"
+
+        // Score ring SVG values
+        let circumference = 314.159
+        let dashOn  = String(format: "%.2f", score * circumference)
+        let dashOff = String(format: "%.2f", circumference - score * circumference)
+
+        // System info
+        let host       = Host.current().localizedName ?? "Unknown"
+        let osVersion  = ProcessInfo.processInfo.operatingSystemVersionString
+        let dateStr    = Self.formattedDate()
+        let checkCount = scanResults.count
+
+        // Group by CIS section
+        let sections = cisSections()
+        let sectionBars = buildSectionBars(sections: sections)
+        let resultBlocks = buildResultBlocks(sections: sections)
+        let remediationCards = buildRemediationCards()
+
+        return """
+        <!DOCTYPE html>
+        <html lang="en">
+        <head>
+        <meta charset="UTF-8">
+        <meta name="viewport" content="width=device-width,initial-scale=1">
+        <title>Mergen — Security Audit Report</title>
+        <style>
+        *,*::before,*::after{box-sizing:border-box;margin:0;padding:0}
+
+        :root{
+          --bg:#120828;--bg2:#1d1245;--card:rgba(255,255,255,.055);
+          --border:rgba(255,255,255,.10);--text:#fff;--muted:rgba(255,255,255,.55);
+          --faint:rgba(255,255,255,.28);
+          --green:#21d49c;--red:#f25c5c;--amber:#f7a13a;--blue:#4590f3;--lav:#a685ff;
+          --r:12px;
+        }
+
+        body{
+          font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',system-ui,sans-serif;
+          background:linear-gradient(135deg,#120828 0%,#1d1245 45%,#2e1f58 75%,#3c2870 100%);
+          min-height:100vh;color:var(--text);-webkit-font-smoothing:antialiased;
+        }
+
+        .cover{
+          min-height:100vh;display:flex;flex-direction:column;
+          align-items:center;justify-content:center;text-align:center;
+          padding:60px 40px;
+          background:linear-gradient(160deg,#0d0520 0%,#160d38 50%,#221a4a 100%);
+          page-break-after:always;position:relative;overflow:hidden;
+        }
+        .cover-glow{
+          position:absolute;width:700px;height:700px;border-radius:50%;
+          background:radial-gradient(circle,rgba(166,133,255,.18) 0%,transparent 68%);
+          top:50%;left:50%;transform:translate(-50%,-50%);pointer-events:none;
+        }
+        .cover-logo{
+          width:88px;height:88px;border-radius:22px;margin:0 auto 26px;
+          background:linear-gradient(135deg,#a685ff,#5520cc);
+          display:flex;align-items:center;justify-content:center;
+          font-size:42px;box-shadow:0 0 48px rgba(166,133,255,.45);
+          position:relative;z-index:1;
+        }
+        .cover-title{font-size:38px;font-weight:700;letter-spacing:-.5px;margin-bottom:8px;position:relative;z-index:1;}
+        .cover-sub{font-size:14px;color:var(--muted);margin-bottom:36px;position:relative;z-index:1;}
+        .cover-score{margin-bottom:36px;position:relative;z-index:1;}
+        .cover-meta{
+          display:flex;gap:28px;flex-wrap:wrap;justify-content:center;
+          position:relative;z-index:1;
+        }
+        .meta-item{display:flex;flex-direction:column;align-items:center;gap:4px;}
+        .meta-label{font-size:9px;font-weight:600;text-transform:uppercase;letter-spacing:1.2px;color:var(--faint);}
+        .meta-val{font-size:13px;color:var(--muted);}
+
+        .content{max-width:920px;margin:0 auto;padding:44px 40px;}
+
+        .section-heading{
+          display:flex;align-items:center;gap:10px;
+          margin:36px 0 18px;padding-bottom:10px;
+          border-bottom:1px solid var(--border);
+        }
+        .section-heading:first-child{margin-top:0;}
+        .section-heading h2{font-size:17px;font-weight:600;}
+        .dot{width:8px;height:8px;border-radius:50%;background:var(--lav);box-shadow:0 0 8px var(--lav);flex-shrink:0;}
+        .sub{font-size:13px;color:var(--muted);margin:-10px 0 18px;}
+
+        .stat-grid{display:grid;grid-template-columns:repeat(4,1fr);gap:12px;margin-bottom:24px;}
+        .stat-card{
+          background:var(--card);border:1px solid var(--border);border-radius:var(--r);
+          padding:20px 14px;text-align:center;position:relative;overflow:hidden;
+        }
+        .stat-card::before{
+          content:'';position:absolute;top:0;left:0;right:0;height:3px;
+          border-radius:var(--r) var(--r) 0 0;
+        }
+        .stat-card.green::before{background:var(--green);}
+        .stat-card.red::before{background:var(--red);}
+        .stat-card.amber::before{background:var(--amber);}
+        .stat-card.blue::before{background:var(--blue);}
+        .stat-num{font-size:34px;font-weight:700;line-height:1;margin-bottom:6px;}
+        .stat-card.green .stat-num{color:var(--green);}
+        .stat-card.red   .stat-num{color:var(--red);}
+        .stat-card.amber .stat-num{color:var(--amber);}
+        .stat-card.blue  .stat-num{color:var(--blue);}
+        .stat-lbl{font-size:11px;color:var(--muted);font-weight:500;text-transform:uppercase;letter-spacing:.7px;}
+
+        .bars-card{
+          background:var(--card);border:1px solid var(--border);border-radius:var(--r);
+          padding:20px;margin-bottom:32px;
+        }
+        .bars-title{font-size:12px;font-weight:600;color:var(--muted);text-transform:uppercase;letter-spacing:.8px;margin-bottom:14px;}
+        .bar-row{display:flex;align-items:center;gap:12px;margin-bottom:10px;}
+        .bar-row:last-child{margin-bottom:0;}
+        .bar-label{font-size:11px;color:var(--muted);font-family:'Menlo','SF Mono',monospace;width:200px;flex-shrink:0;}
+        .bar-track{flex:1;height:7px;background:rgba(255,255,255,.08);border-radius:4px;overflow:hidden;}
+        .bar-fill{height:100%;border-radius:4px;}
+        .bar-count{font-size:11px;color:var(--faint);font-family:'Menlo','SF Mono',monospace;width:38px;text-align:right;flex-shrink:0;}
+
+        .result-block{margin-bottom:32px;page-break-inside:avoid;}
+        .section-label{
+          font-size:12px;font-weight:600;color:var(--muted);
+          text-transform:uppercase;letter-spacing:.9px;
+          margin-bottom:10px;padding:7px 12px;
+          background:rgba(255,255,255,.04);border-radius:6px;
+          border-left:3px solid var(--lav);
+        }
+
+        table{width:100%;border-collapse:collapse;background:var(--card);
+          border:1px solid var(--border);border-radius:var(--r);overflow:hidden;font-size:13px;}
+        thead th{
+          padding:10px 13px;text-align:left;font-size:10px;font-weight:600;
+          color:var(--muted);text-transform:uppercase;letter-spacing:.7px;
+          background:rgba(255,255,255,.04);border-bottom:1px solid var(--border);
+        }
+        tbody tr{border-bottom:1px solid rgba(255,255,255,.05);}
+        tbody tr:last-child{border-bottom:none;}
+        td{padding:9px 13px;vertical-align:middle;}
+        .cis{
+          font-family:'Menlo','SF Mono',monospace;font-size:10px;color:var(--muted);
+          background:rgba(255,255,255,.07);padding:2px 6px;border-radius:4px;white-space:nowrap;
+        }
+        .check-name{font-weight:500;font-size:13px;}
+        .detail{font-size:11px;color:var(--muted);margin-top:3px;}
+
+        .badge{
+          display:inline-flex;align-items:center;padding:3px 9px;
+          border-radius:20px;font-size:11px;font-weight:600;white-space:nowrap;
+        }
+        .badge.pass{color:var(--green);background:rgba(33,212,156,.12);}
+        .badge.fail{color:var(--red);background:rgba(242,92,92,.12);}
+        .badge.warn{color:var(--amber);background:rgba(247,161,58,.12);}
+        .badge.info{color:var(--blue);background:rgba(69,144,243,.12);}
+
+        .sev{font-size:10px;font-weight:700;padding:2px 7px;border-radius:10px;text-transform:uppercase;letter-spacing:.4px;}
+        .sev.critical{color:var(--red);background:rgba(242,92,92,.15);}
+        .sev.high{color:var(--amber);background:rgba(247,161,58,.15);}
+        .sev.medium{color:#e0c840;background:rgba(224,200,64,.15);}
+        .sev.low{color:var(--blue);background:rgba(69,144,243,.15);}
+
+        .rem-card{
+          margin-bottom:14px;padding:16px;
+          background:var(--card);border:1px solid var(--border);
+          border-left:3px solid var(--red);border-radius:0 var(--r) var(--r) 0;
+          page-break-inside:avoid;
+        }
+        .rem-head{display:flex;align-items:center;gap:8px;margin-bottom:8px;flex-wrap:wrap;}
+        .rem-name{font-size:13px;font-weight:600;flex:1;}
+        .finding{font-size:12px;color:var(--muted);margin-bottom:8px;}
+        pre.rem-body{
+          font-family:'Menlo','SF Mono',monospace;font-size:11px;
+          color:rgba(255,255,255,.65);line-height:1.6;white-space:pre-wrap;
+          background:rgba(0,0,0,.25);padding:10px 12px;border-radius:8px;
+        }
+
+        .footer{
+          text-align:center;padding:22px 40px;color:var(--faint);font-size:11px;
+          border-top:1px solid var(--border);margin-top:20px;
+        }
+
+        @media print{
+          body{background:#120828 !important;-webkit-print-color-adjust:exact;print-color-adjust:exact;}
+          .cover{page-break-after:always;}
+          .result-block,.rem-card{page-break-inside:avoid;}
+          @page{margin:0;}
+        }
+        </style>
+        </head>
+        <body>
+
+        <!-- Cover -->
+        <div class="cover">
+          <div class="cover-glow"></div>
+          <div class="cover-logo">🛡</div>
+          <h1 class="cover-title">Security Audit Report</h1>
+          <p class="cover-sub">Generated by Mergen · CIS Apple macOS 26 Tahoe Benchmark v1.0.0</p>
+          <div class="cover-score">
+            <svg width="140" height="140" viewBox="0 0 120 120">
+              <circle cx="60" cy="60" r="50" fill="none" stroke="rgba(255,255,255,0.10)" stroke-width="10"/>
+              <circle cx="60" cy="60" r="50" fill="none"
+                stroke="\(scoreColor)" stroke-width="10"
+                stroke-dasharray="\(dashOn) \(dashOff)"
+                stroke-linecap="round"
+                transform="rotate(-90 60 60)"/>
+              <text x="60" y="55" text-anchor="middle"
+                fill="\(scoreColor)" font-size="22" font-weight="700"
+                font-family="-apple-system,BlinkMacSystemFont,sans-serif">\(scoreInt)%</text>
+              <text x="60" y="71" text-anchor="middle"
+                fill="rgba(255,255,255,0.45)" font-size="9" font-weight="600"
+                font-family="-apple-system,BlinkMacSystemFont,sans-serif"
+                letter-spacing="1">\(scoreLabel)</text>
+            </svg>
+          </div>
+          <div class="cover-meta">
+            <div class="meta-item"><div class="meta-label">HOST</div><div class="meta-val">\(escapeHTML(host))</div></div>
+            <div class="meta-item"><div class="meta-label">SYSTEM</div><div class="meta-val">\(escapeHTML(osVersion))</div></div>
+            <div class="meta-item"><div class="meta-label">DATE</div><div class="meta-val">\(dateStr)</div></div>
+            <div class="meta-item"><div class="meta-label">CHECKS</div><div class="meta-val">\(checkCount)</div></div>
+          </div>
+        </div>
+
+        <!-- Content -->
+        <div class="content">
+
+          <div class="section-heading"><div class="dot"></div><h2>Executive Summary</h2></div>
+          <div class="stat-grid">
+            <div class="stat-card green"><div class="stat-num">\(passCount)</div><div class="stat-lbl">Passed</div></div>
+            <div class="stat-card red"><div class="stat-num">\(failCount)</div><div class="stat-lbl">Failed</div></div>
+            <div class="stat-card amber"><div class="stat-num">\(warnCount)</div><div class="stat-lbl">Warnings</div></div>
+            <div class="stat-card blue"><div class="stat-num">\(advisoryCount)</div><div class="stat-lbl">Advisory</div></div>
+          </div>
+
+          <div class="bars-card">
+            <div class="bars-title">Pass Rate by Section</div>
+            \(sectionBars)
+          </div>
+
+          <div class="section-heading"><div class="dot"></div><h2>Check Results</h2></div>
+          \(resultBlocks)
+
+          <div class="section-heading"><div class="dot"></div><h2>Remediation Steps</h2></div>
+          \(remediationCards)
+
+        </div>
+
+        <div class="footer">Generated by Mergen · CIS Apple macOS 26 Tahoe Benchmark v1.0.0 · \(dateStr)</div>
+        </body>
+        </html>
+        """
+    }
+
+    // MARK: - Helpers
+
+    private func cisSections() -> [(label: String, items: [Vulnerability])] {
+        let sectionDefs: [(prefix: String, label: String)] = [
+            ("1", "§1 · Updates & Patches"),
+            ("2", "§2 · System Settings"),
+            ("3", "§3 · Logging & Auditing"),
+            ("4", "§4 · Network"),
+            ("5", "§5 · Auth & Authorization"),
+            ("6", "§6 · User Interface"),
+        ]
+
+        var sections: [(label: String, items: [Vulnerability])] = []
+        var used = Set<String>()
+
+        for (prefix, label) in sectionDefs {
+            let items = scanResults.filter { v in
+                let first = v.cisID.split(separator: ".").first.map(String.init) ?? ""
+                return first == prefix
+            }
+            if !items.isEmpty {
+                sections.append((label, items))
+                items.forEach { used.insert($0.id.uuidString) }
+            }
+        }
+
+        let other = scanResults.filter { !used.contains($0.id.uuidString) }
+        if !other.isEmpty {
+            sections.append(("Other", other))
+        }
+
+        return sections
+    }
+
+    private func buildSectionBars(sections: [(label: String, items: [Vulnerability])]) -> String {
+        sections.map { sec in
+            let automated = sec.items.filter { !$0.isManual && $0.checkstatus != "Blue" }
+            let pass      = automated.filter { $0.checkstatus == "Green" }.count
+            let total     = automated.count
+            let pct       = total > 0 ? Int(Double(pass) / Double(total) * 100) : 0
+            let color     = pct >= 80 ? "#21d49c" : pct >= 50 ? "#f7a13a" : "#f25c5c"
+            return """
+            <div class="bar-row">
+              <div class="bar-label">\(escapeHTML(sec.label))</div>
+              <div class="bar-track"><div class="bar-fill" style="width:\(pct)%;background:\(color)"></div></div>
+              <div class="bar-count">\(pass)/\(total)</div>
+            </div>
+            """
+        }.joined()
+    }
+
+    private func buildResultBlocks(sections: [(label: String, items: [Vulnerability])]) -> String {
+        sections.map { sec in
+            let rows = sec.items.map { v -> String in
+                let cisCell = v.cisID.isEmpty ? "<td>—</td>" : "<td><span class=\"cis\">\(escapeHTML(v.cisID))</span></td>"
+                let detail  = v.status.map { "<div class=\"detail\">\(escapeHTML($0))</div>" } ?? ""
+                let sevClass = severityClass(v.severity)
+                let badgeClass: String
+                let badgeLabel: String
+                switch v.checkstatus {
+                case "Green":  badgeClass = "pass"; badgeLabel = "Passed"
+                case "Red":    badgeClass = "fail"; badgeLabel = "Failed"
+                case "Yellow": badgeClass = "warn"; badgeLabel = "Warning"
+                case "Blue":   badgeClass = "info"; badgeLabel = "Advisory"
+                default:       badgeClass = "info"; badgeLabel = v.checkstatus ?? "Unknown"
+                }
+                return """
+                <tr>
+                  \(cisCell)
+                  <td><div class="check-name">\(escapeHTML(v.name))</div>\(detail)</td>
+                  <td><span class="sev \(sevClass)">\(escapeHTML(v.severity))</span></td>
+                  <td><span class="badge \(badgeClass)">\(badgeLabel)</span></td>
+                </tr>
+                """
+            }.joined()
+
+            return """
+            <div class="result-block">
+              <div class="section-label">\(escapeHTML(sec.label))</div>
+              <table>
+                <thead>
+                  <tr>
+                    <th style="width:80px">CIS ID</th>
+                    <th>Check</th>
+                    <th style="width:88px">Severity</th>
+                    <th style="width:96px">Result</th>
+                  </tr>
+                </thead>
+                <tbody>\(rows)</tbody>
+              </table>
+            </div>
+            """
+        }.joined()
+    }
+
+    private func buildRemediationCards() -> String {
+        let needsAction = scanResults.filter {
+            $0.checkstatus == "Red" || $0.checkstatus == "Yellow"
+        }.sorted {
+            severityRank($0.severity) > severityRank($1.severity)
+        }
+
+        if needsAction.isEmpty {
+            return "<p class=\"sub\">No remediation required — all checks passed.</p>"
+        }
+
+        let countStr = "\(needsAction.count) check\(needsAction.count == 1 ? "" : "s")"
+        let intro = "<p class=\"sub\">The following \(countStr) require attention, ordered by severity.</p>"
+
+        let cards = needsAction.map { v -> String in
+            let borderColor = v.checkstatus == "Red" ? "#f25c5c" : "#f7a13a"
+            let cisSpan = v.cisID.isEmpty ? "" : "<span class=\"cis\">\(escapeHTML(v.cisID))</span>"
+            let finding = v.status.map { escapeHTML($0) } ?? "Review this check manually."
+            let sevClass = severityClass(v.severity)
+            return """
+            <div class="rem-card" style="border-left-color:\(borderColor)">
+              <div class="rem-head">
+                \(cisSpan)
+                <span class="rem-name">\(escapeHTML(v.name))</span>
+                <span class="sev \(sevClass)">\(escapeHTML(v.severity))</span>
+              </div>
+              <p class="finding">Finding: \(finding)</p>
+              <pre class="rem-body">\(escapeHTML(v.remediation))</pre>
+            </div>
+            """
+        }.joined()
+
+        return intro + cards
+    }
+
+    private func severityClass(_ severity: String) -> String {
+        switch severity.lowercased() {
+        case "critical": return "critical"
+        case "high":     return "high"
+        case "medium":   return "medium"
+        default:         return "low"
+        }
+    }
+
+    private func severityRank(_ severity: String) -> Int {
+        switch severity.lowercased() {
+        case "critical": return 4
+        case "high":     return 3
+        case "medium":   return 2
+        default:         return 1
+        }
+    }
+
+    private func escapeHTML(_ s: String) -> String {
+        s.replacingOccurrences(of: "&", with: "&amp;")
+         .replacingOccurrences(of: "<", with: "&lt;")
+         .replacingOccurrences(of: ">", with: "&gt;")
+         .replacingOccurrences(of: "\"", with: "&quot;")
+    }
+
+    private static func formattedDate() -> String {
+        let f = DateFormatter()
+        f.dateStyle = .long
+        f.timeStyle = .short
+        return f.string(from: Date())
+    }
+}
+
+// MARK: - File Utils
+
+struct FileUtils {
+    static func saveHTMLStringToFile(_ htmlString: String) {
+        let savePanel = NSSavePanel()
+        savePanel.nameFieldStringValue = "MergenReport.html"
+        savePanel.allowedContentTypes = [UTType.html]
+
+        if savePanel.runModal() == .OK, let url = savePanel.url {
+            do {
+                try htmlString.write(to: url, atomically: true, encoding: .utf8)
+                print("HTML file saved to \(url)")
+            } catch {
+                print("Error saving HTML file: \(error)")
+            }
+        }
+    }
+}
+</file>
+
+<file path="mergen/view/JSONReportGenerator.swift">
+//
+//  JSONReportGenerator.swift
+//  mergen
+//
+//  Created by Samet Sazak on 7.04.2023.
+//
+
+import Foundation
+import SwiftUI
+
+struct ScanResult: Encodable {
+    let name: String
+    let description: String
+    let category: String
+    let remediation: String
+    let severity: String
+    let documentation: String?
+    let status: String?
+    let checkstatus: String?
+    let mitigation: String
+    let docID: Int32
+    let cisID: String
+    let isManual: Bool
+
+    init(vulnerability: Vulnerability) {
+        self.name = vulnerability.name
+        self.description = vulnerability.description
+        self.category = vulnerability.category
+        self.remediation = vulnerability.remediation
+        self.severity = vulnerability.severity
+        self.documentation = vulnerability.documentation
+        self.status = vulnerability.status
+        self.checkstatus = vulnerability.checkstatus
+        self.mitigation = vulnerability.mitigation
+        self.docID = vulnerability.docID
+        self.cisID = vulnerability.cisID
+        self.isManual = vulnerability.isManual
+    }
+}
+
+class JSONReportGenerator {
+    let scanResults: [Vulnerability]
+
+    init(scanResults: [Vulnerability]) {
+        self.scanResults = scanResults
+    }
+
+    func generateJSONReport() -> Data {
+        scanResultsToJSON()
+    }
+
+    private func scanResultsToJSON() -> Data {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = .prettyPrinted
+
+        let scanResultArray = scanResults.map { ScanResult(vulnerability: $0) }
+
+        do {
+            let jsonData = try encoder.encode(scanResultArray)
+            return jsonData
+        } catch {
+            print("Error encoding scan results to JSON: \(error)")
+            return Data()
+        }
+    }
+}
+</file>
+
+<file path="mergen/view/LogViewerSheet.swift">
+//
+//  LogViewerSheet.swift
+//  mergen
+//
+//  In-app viewer for ~/Library/Logs/mergen/mergen-YYYY-MM-DD.log.
+//
+
+import SwiftUI
+import AppKit
+
+struct LogViewerSheet: View {
+    @Environment(\.dismiss) private var dismiss
+    @State private var lines:       [String] = []
+    @State private var filter:      LogFilter = .all
+    @State private var searchText   = ""
+
+    enum LogFilter: String, CaseIterable {
+        case all    = "All"
+        case scan   = "Scan"
+        case check  = "Check"
+        case fix    = "Fix"
+        case errors = "Errors"
+
+        var keyword: String? {
+            switch self {
+            case .all:    return nil
+            case .scan:   return "SCAN"
+            case .check:  return "CHECK"
+            case .fix:    return "FIX"
+            case .errors: return "success=false"
+            }
+        }
+
+        var color: Color {
+            switch self {
+            case .all:    return .primary
+            case .scan:   return .accentColor
+            case .check:  return .secondary
+            case .fix:    return .orange
+            case .errors: return .red
+            }
+        }
+    }
+
+    private var filtered: [String] {
+        var out = lines
+        if let kw = filter.keyword {
+            out = out.filter { $0.contains(kw) }
+        }
+        if !searchText.isEmpty {
+            out = out.filter { $0.localizedCaseInsensitiveContains(searchText) }
+        }
+        return out
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+
+            // ── Header ───────────────────────────────────────────────────────
+            HStack {
+                VStack(alignment: .leading, spacing: 3) {
+                    Text("Audit Log")
+                        .font(.system(size: 16, weight: .bold))
+                    Text(AuditLogger.shared.logFileURL.path)
+                        .font(.system(size: 10, design: .monospaced))
+                        .foregroundColor(.secondary)
+                        .lineLimit(1)
+                        .truncationMode(.middle)
+                }
+                Spacer()
+                Button {
+                    NSWorkspace.shared.activateFileViewerSelecting(
+                        [AuditLogger.shared.logFileURL]
+                    )
+                } label: {
+                    Label("Reveal", systemImage: "folder")
+                        .font(.system(size: 11))
+                }
+                .buttonStyle(.bordered)
+                .controlSize(.small)
+
+                Button {
+                    let all = lines.joined(separator: "\n")
+                    NSPasteboard.general.clearContents()
+                    NSPasteboard.general.setString(all, forType: .string)
+                } label: {
+                    Label("Copy All", systemImage: "doc.on.doc")
+                        .font(.system(size: 11))
+                }
+                .buttonStyle(.bordered)
+                .controlSize(.small)
+
+                Button { dismiss() } label: {
+                    Image(systemName: "xmark.circle.fill")
+                        .font(.system(size: 18))
+                        .foregroundColor(.secondary.opacity(0.6))
+                }
+                .buttonStyle(.plain)
+            }
+            .padding(.horizontal, 16)
+            .padding(.vertical, 12)
+
+            Divider()
+
+            // ── Search + filter bar ──────────────────────────────────────────
+            HStack(spacing: 8) {
+                Image(systemName: "magnifyingglass")
+                    .foregroundColor(.secondary)
+                    .font(.system(size: 12))
+                TextField("Search log…", text: $searchText)
+                    .textFieldStyle(.plain)
+                    .font(.system(size: 12))
+                if !searchText.isEmpty {
+                    Button { searchText = "" } label: {
+                        Image(systemName: "xmark.circle.fill").foregroundColor(.secondary)
+                    }.buttonStyle(.plain)
+                }
+
+                Divider().frame(height: 16)
+
+                ForEach(LogFilter.allCases, id: \.rawValue) { f in
+                    Button(f.rawValue) { filter = f }
+                        .buttonStyle(.plain)
+                        .font(.system(size: 11, weight: filter == f ? .semibold : .regular))
+                        .foregroundColor(filter == f ? f.color : .secondary)
+                        .padding(.horizontal, 6)
+                        .padding(.vertical, 3)
+                        .background(
+                            RoundedRectangle(cornerRadius: 5)
+                                .fill(filter == f ? f.color.opacity(0.12) : Color.clear)
+                        )
+                }
+            }
+            .padding(.horizontal, 12)
+            .padding(.vertical, 7)
+            .background(Color.primary.opacity(0.03))
+
+            Divider()
+
+            // ── Log lines ───────────────────────────────────────────────────
+            if filtered.isEmpty {
+                VStack(spacing: 10) {
+                    Spacer()
+                    Image(systemName: "doc.text")
+                        .font(.system(size: 36))
+                        .foregroundColor(.secondary.opacity(0.3))
+                    Text(lines.isEmpty ? "No log entries yet. Run a scan to start logging." : "No entries match your filter.")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                    Spacer()
+                }
+                .frame(maxWidth: .infinity)
+            } else {
+                ScrollViewReader { proxy in
+                    ScrollView {
+                        LazyVStack(alignment: .leading, spacing: 0) {
+                            ForEach(Array(filtered.enumerated()), id: \.offset) { idx, line in
+                                LogLine(text: line)
+                                    .id(idx)
+                            }
+                        }
+                        .padding(.horizontal, 12)
+                        .padding(.vertical, 6)
+                    }
+                    .onAppear {
+                        proxy.scrollTo(filtered.count - 1, anchor: .bottom)
+                    }
+                }
+            }
+
+            Divider()
+
+            // ── Footer ──────────────────────────────────────────────────────
+            HStack {
+                Text("\(filtered.count) of \(lines.count) entries")
+                    .font(.system(size: 11))
+                    .foregroundColor(.secondary)
+                Spacer()
+                Button {
+                    loadLines()
+                } label: {
+                    Label("Refresh", systemImage: "arrow.clockwise")
+                        .font(.system(size: 11))
+                }
+                .buttonStyle(.bordered)
+                .controlSize(.small)
+
+                Button("Close") { dismiss() }
+                    .buttonStyle(.bordered)
+                    .controlSize(.regular)
+            }
+            .padding(12)
+        }
+        .frame(width: 780, height: 520)
+        .onAppear { loadLines() }
+    }
+
+    private func loadLines() {
+        lines = AuditLogger.shared.recentLines(limit: 600)
+    }
+}
+
+// MARK: - Log Line View
+
+private struct LogLine: View {
+    let text: String
+
+    private var lineColor: Color {
+        if text.contains("FIX_RESULT") && text.contains("success=false") { return .red }
+        if text.contains("FIX_RESULT") && text.contains("success=true")  { return .green }
+        if text.contains("FIX_START")  { return .orange }
+        if text.contains("SCAN_DONE")  { return .accentColor }
+        if text.contains("SCAN_START") { return .accentColor }
+        if text.contains("CHECK") {
+            if text.contains("status=Red")    { return .red.opacity(0.8) }
+            if text.contains("status=Yellow") { return .orange.opacity(0.8) }
+            if text.contains("status=Green")  { return .green.opacity(0.8) }
+        }
+        return .primary
+    }
+
+    private var timestamp: String {
+        guard text.hasPrefix("["), let end = text.firstIndex(of: "]") else { return "" }
+        return String(text[text.index(after: text.startIndex)..<end])
+    }
+
+    private var body_: String {
+        guard let end = text.firstIndex(of: "]") else { return text }
+        return String(text[text.index(end, offsetBy: 2)...])
+    }
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 8) {
+            Text(timestamp)
+                .font(.system(size: 10, design: .monospaced))
+                .foregroundColor(.secondary)
+                .frame(width: 140, alignment: .leading)
+                .lineLimit(1)
+
+            Text(body_)
+                .font(.system(size: 11, design: .monospaced))
+                .foregroundColor(lineColor)
+                .textSelection(.enabled)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+        .padding(.vertical, 2)
+    }
+}
+</file>
+
+<file path="mergen/view/ScanResultView.swift">
+//
+//  ScanResultView.swift
+//  mergen
+//
+
+import SwiftUI
+import AppKit
+import UniformTypeIdentifiers
+
+// MARK: - Filter Types
+
+enum StatusFilter: String, CaseIterable, Identifiable {
+    case all      = "All"
+    case failed   = "Failed"
+    case passed   = "Passed"
+    case warned   = "Warnings"
+    case advisory = "Advisory"
+
+    var id: String { rawValue }
+
+    var icon: String {
+        switch self {
+        case .all:      return "circle.grid.3x3"
+        case .failed:   return "xmark.circle.fill"
+        case .passed:   return "checkmark.circle.fill"
+        case .warned:   return "exclamationmark.triangle.fill"
+        case .advisory: return "info.circle.fill"
+        }
+    }
+
+    var color: Color {
+        switch self {
+        case .all:      return .primary
+        case .failed:   return Color(red: 0.85, green: 0.25, blue: 0.25)
+        case .passed:   return Color(red: 0.13, green: 0.66, blue: 0.47)
+        case .warned:   return Color(red: 0.80, green: 0.52, blue: 0.10)
+        case .advisory: return .secondary
+        }
+    }
+}
+
+enum ResultSortOrder: String, CaseIterable {
+    case cisID    = "CIS ID"
+    case severity = "Severity"
+    case name     = "Name"
+    case status   = "Status"
+}
+
+// MARK: - Results List View
+
+struct ResultsListView: View {
+    @ObservedObject var scanManager: ScanManager
+    let selectedCategory: String?
+    @Binding var selectedVulnerability: Vulnerability?
+    @Binding var searchText: String
+
+    @State private var statusFilter: StatusFilter = .all
+    @State private var severityFilter = "Any"
+    @State private var sortOrder: ResultSortOrder = .cisID
+    @State private var showFixSheet = false
+
+    private let severities = ["Any", "Critical", "High", "Medium", "Low"]
+
+    // MARK: Computed
+
+    private var base: [Vulnerability] {
+        selectedCategory == nil
+            ? scanManager.scanResults
+            : scanManager.scanResults.filter { $0.category == selectedCategory }
+    }
+
+    private var results: [Vulnerability] {
+        var out = base
+
+        if !searchText.isEmpty {
+            let q = searchText
+            out = out.filter {
+                $0.name.localizedCaseInsensitiveContains(q) ||
+                $0.description.localizedCaseInsensitiveContains(q) ||
+                $0.cisID.localizedCaseInsensitiveContains(q) ||
+                ($0.status ?? "").localizedCaseInsensitiveContains(q)
+            }
+        }
+
+        switch statusFilter {
+        case .failed:   out = out.filter { $0.checkstatus == "Red" }
+        case .passed:   out = out.filter { $0.checkstatus == "Green" }
+        case .warned:   out = out.filter { $0.checkstatus == "Yellow" }
+        case .advisory: out = out.filter { $0.checkstatus == "Blue" || $0.isManual }
+        case .all:      break
+        }
+
+        if severityFilter != "Any" {
+            out = out.filter { $0.severity.lowercased() == severityFilter.lowercased() }
+        }
+
+        return out
+    }
+
+    private var grouped: [(section: String, items: [Vulnerability])] {
+        let dict = Dictionary(grouping: results) { v -> String in
+            guard !v.cisID.isEmpty else { return "Other" }
+            switch v.cisID.split(separator: ".").first.map(String.init) ?? "" {
+            case "1": return "1 · Updates & Patches"
+            case "2": return "2 · System Settings"
+            case "3": return "3 · Logging & Auditing"
+            case "4": return "4 · Network"
+            case "5": return "5 · Auth & Authorization"
+            case "6": return "6 · User Interface"
+            default:  return "Other"
+            }
+        }
+        let order = [
+            "1 · Updates & Patches",
+            "2 · System Settings",
+            "3 · Logging & Auditing",
+            "4 · Network",
+            "5 · Auth & Authorization",
+            "6 · User Interface",
+            "Other"
+        ]
+        return order.compactMap { key in
+            guard let items = dict[key], !items.isEmpty else { return nil }
+            return (section: key, items: sortedItems(items))
+        }
+    }
+
+    private func sortedItems(_ items: [Vulnerability]) -> [Vulnerability] {
+        let sevRank  = ["Critical": 0, "High": 1, "Medium": 2, "Low": 3]
+        let statRank = ["Red": 0, "Yellow": 1, "Blue": 2, "Green": 3]
+        switch sortOrder {
+        case .cisID:
+            return items.sorted {
+                if $0.cisID.isEmpty && $1.cisID.isEmpty { return $0.name < $1.name }
+                if $0.cisID.isEmpty { return false }
+                if $1.cisID.isEmpty { return true }
+                return $0.cisID.localizedStandardCompare($1.cisID) == .orderedAscending
+            }
+        case .severity:
+            return items.sorted { (sevRank[$0.severity] ?? 99) < (sevRank[$1.severity] ?? 99) }
+        case .name:
+            return items.sorted { $0.name < $1.name }
+        case .status:
+            return items.sorted { (statRank[$0.checkstatus ?? ""] ?? 99) < (statRank[$1.checkstatus ?? ""] ?? 99) }
+        }
+    }
+
+    // Counts for filter pills (always show real totals from base, not filtered)
+    private var failedCount:   Int { base.filter { $0.checkstatus == "Red" }.count }
+    private var passedCount:   Int { base.filter { $0.checkstatus == "Green" }.count }
+    private var warnedCount:   Int { base.filter { $0.checkstatus == "Yellow" }.count }
+    private var advisoryCount: Int { base.filter { $0.checkstatus == "Blue" || $0.isManual }.count }
+    private var fixableCount:  Int { base.filter { $0.isAutoFixable }.count }
+    private var hasFilters: Bool { statusFilter != .all || severityFilter != "Any" || !searchText.isEmpty }
+
+    // MARK: Body
+
+    var body: some View {
+        VStack(spacing: 0) {
+
+                    // Search bar
+                    HStack(spacing: 8) {
+                        Image(systemName: "magnifyingglass")
+                            .foregroundColor(.secondary)
+                            .font(.system(size: 13))
+                        TextField("Search checks, CIS IDs, status…", text: $searchText)
+                            .textFieldStyle(.plain)
+                            .font(.system(size: 13))
+                        if !searchText.isEmpty {
+                            Button { searchText = "" } label: {
+                                Image(systemName: "xmark.circle.fill").foregroundColor(.secondary)
+                            }.buttonStyle(.plain)
+                        }
+                    }
+                    .padding(.horizontal, 12)
+                    .padding(.vertical, 9)
+                    .background(Color.primary.opacity(0.04))
+
+                    Divider()
+
+                    // Filter + Sort toolbar
+                    FilterSortBar(
+                        statusFilter: $statusFilter,
+                        severityFilter: $severityFilter,
+                        sortOrder: $sortOrder,
+                        severities: severities,
+                        failedCount: failedCount,
+                        passedCount: passedCount,
+                        warnedCount: warnedCount,
+                        advisoryCount: advisoryCount
+                    )
+
+                    Divider()
+
+                    // Severity distribution bar (shown when there are failures)
+                    let failedInBase = base.filter { $0.checkstatus == "Red" }
+                    if !failedInBase.isEmpty {
+                        SeverityDistributionBar(results: base)
+                        Divider()
+                    }
+
+                    // Live scan progress (shown while scanning; list still visible below)
+                    if scanManager.scanning {
+                        ScanProgressBanner(
+                            progress: scanManager.progress,
+                            completed: scanManager.scanResults.count
+                        )
+                        Divider()
+                    }
+
+                    // Stats + export row
+                    if !scanManager.scanResults.isEmpty {
+                        HStack(spacing: 8) {
+                            Text(hasFilters
+                                 ? "Showing \(results.count) of \(base.count) checks"
+                                 : "\(base.count) check\(base.count == 1 ? "" : "s")")
+                                .font(.caption)
+                                .foregroundColor(.secondary)
+                                .padding(.leading, 12)
+                            Spacer()
+                            if !scanManager.scanning {
+                                if fixableCount > 0 {
+                                    Button {
+                                        showFixSheet = true
+                                    } label: {
+                                        Label("Fix \(fixableCount) Issue\(fixableCount == 1 ? "" : "s")",
+                                              systemImage: "bolt.fill")
+                                            .font(.system(size: 11, weight: .semibold))
+                                    }
+                                    .buttonStyle(.borderedProminent)
+                                    .controlSize(.mini)
+                                    .tint(Color(red: 0.85, green: 0.25, blue: 0.25))
+                                    .sheet(isPresented: $showFixSheet) {
+                                        FixAllSheet(scanManager: scanManager)
+                                    }
+                                }
+                                ExportButtons(scanResults: scanManager.scanResults)
+                            }
+                        }
+                        .padding(.vertical, 5)
+                        .background(Color.primary.opacity(0.02))
+                        Divider()
+                    }
+
+                    // Results list or empty-filter state
+                    if results.isEmpty && !scanManager.scanning {
+                        EmptyFilterView(hasFilters: hasFilters) {
+                            statusFilter = .all
+                            severityFilter = "Any"
+                            searchText = ""
+                        }
+                    } else {
+                        List(selection: Binding(
+                            get: { selectedVulnerability?.id },
+                            set: { id in
+                                selectedVulnerability = scanManager.scanResults.first { $0.id == id }
+                            }
+                        )) {
+                            ForEach(grouped, id: \.section) { group in
+                                Section {
+                                    ForEach(group.items, id: \.id) { v in
+                                        VulnerabilityRow(vulnerability: v)
+                                            .tag(v.id)
+                                    }
+                                } header: {
+                                    SectionHeader(title: group.section, items: group.items)
+                                }
+                            }
+                        }
+                        .listStyle(.inset)
+                        .animation(.default, value: scanManager.scanResults.count)
+                    }
+        }
+        .navigationTitle(selectedCategory ?? "All Checks")
+        .onChange(of: selectedCategory) { _ in
+            statusFilter = .all
+            severityFilter = "Any"
+        }
+    }
+}
+
+// MARK: - Filter + Sort Bar
+
+struct FilterSortBar: View {
+    @Binding var statusFilter: StatusFilter
+    @Binding var severityFilter: String
+    @Binding var sortOrder: ResultSortOrder
+    let severities: [String]
+    let failedCount: Int
+    let passedCount: Int
+    let warnedCount: Int
+    let advisoryCount: Int
+
+    var body: some View {
+        HStack(spacing: 4) {
+            FilterPill(filter: .all,      isSelected: statusFilter == .all,      count: nil)           { statusFilter = .all }
+            FilterPill(filter: .failed,   isSelected: statusFilter == .failed,   count: failedCount)   { statusFilter = .failed }
+            FilterPill(filter: .passed,   isSelected: statusFilter == .passed,   count: passedCount)   { statusFilter = .passed }
+            FilterPill(filter: .warned,   isSelected: statusFilter == .warned,   count: warnedCount)   { statusFilter = .warned }
+            FilterPill(filter: .advisory, isSelected: statusFilter == .advisory, count: advisoryCount) { statusFilter = .advisory }
+
+            Spacer(minLength: 4)
+
+            Menu {
+                ForEach(severities, id: \.self) { sev in
+                    Button(sev) { severityFilter = sev }
+                }
+            } label: {
+                HStack(spacing: 3) {
+                    Image(systemName: "slider.horizontal.3")
+                    Text(severityFilter == "Any" ? "Severity" : severityFilter)
+                }
+                .font(.system(size: 11))
+                .foregroundColor(severityFilter == "Any" ? .secondary : .accentColor)
+            }
+            .menuStyle(.borderlessButton)
+            .fixedSize()
+
+            Color.secondary.opacity(0.25)
+                .frame(width: 1, height: 14)
+
+            Menu {
+                ForEach(ResultSortOrder.allCases, id: \.rawValue) { order in
+                    Button {
+                        sortOrder = order
+                    } label: {
+                        if sortOrder == order {
+                            Label(order.rawValue, systemImage: "checkmark")
+                        } else {
+                            Text(order.rawValue)
+                        }
+                    }
+                }
+            } label: {
+                HStack(spacing: 3) {
+                    Image(systemName: "arrow.up.arrow.down")
+                    Text(sortOrder.rawValue)
+                }
+                .font(.system(size: 11))
+                .foregroundColor(.secondary)
+            }
+            .menuStyle(.borderlessButton)
+            .fixedSize()
+        }
+        .padding(.horizontal, 10)
+        .padding(.vertical, 6)
+    }
+}
+
+struct FilterPill: View {
+    let filter: StatusFilter
+    let isSelected: Bool
+    let count: Int?
+    let action: () -> Void
+    @State private var isHovered = false
+
+    private var pillColor: Color {
+        filter == .all ? Color.primary : filter.color
+    }
+
+    var body: some View {
+        Button(action: action) {
+            HStack(spacing: 4) {
+                Image(systemName: filter.icon)
+                    .font(.system(size: 11, weight: .medium))
+                if filter == .all {
+                    Text("All")
+                        .font(.system(size: 12, weight: .semibold))
+                } else if let c = count {
+                    Text("\(c)")
+                        .font(.system(size: 12, weight: .bold))
+                }
+            }
+            .foregroundColor(isSelected ? (filter == .all ? .white : .white) : .secondary)
+            .padding(.horizontal, 10)
+            .padding(.vertical, 5)
+            .background(
+                RoundedRectangle(cornerRadius: 20)
+                    .fill(isSelected
+                          ? pillColor
+                          : (isHovered ? Color.primary.opacity(0.06) : Color.clear))
+            )
+            .shadow(color: isSelected ? pillColor.opacity(0.30) : .clear, radius: 4, y: 2)
+        }
+        .buttonStyle(.plain)
+        .animation(.easeInOut(duration: 0.15), value: isSelected)
+        .onHover { h in withAnimation(.easeInOut(duration: 0.1)) { isHovered = h } }
+    }
+}
+
+// MARK: - Scan Progress Banner
+
+struct ScanProgressBanner: View {
+    let progress: Double
+    let completed: Int
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            HStack {
+                HStack(spacing: 6) {
+                    Image(systemName: "antenna.radiowaves.left.and.right")
+                        .font(.system(size: 11))
+                        .foregroundColor(.primary)
+                    Text("Scanning…")
+                        .font(.system(size: 12, weight: .semibold))
+                        .foregroundColor(.primary)
+                }
+                Spacer()
+                Text("\(completed) done · \(Int(progress * 100))%")
+                    .font(.system(size: 11, weight: .medium, design: .rounded))
+                    .foregroundColor(.secondary)
+                    .monospacedDigit()
+            }
+            ProgressView(value: progress)
+                .progressViewStyle(.linear)
+                .tint(.primary)
+                .scaleEffect(y: 1.3)
+        }
+        .padding(.horizontal, 14)
+        .padding(.vertical, 10)
+        .background(
+            LinearGradient(
+                colors: [Color.primary.opacity(0.08), Color.primary.opacity(0.04)],
+                startPoint: .leading,
+                endPoint: .trailing
+            )
+        )
+    }
+}
+
+// MARK: - Export Buttons
+
+struct ExportButtons: View {
+    let scanResults: [Vulnerability]
+
+    var body: some View {
+        HStack(spacing: 4) {
+            Button(action: exportHTML) {
+                Label("HTML", systemImage: "doc.richtext")
+                    .font(.system(size: 11))
+            }
+            .buttonStyle(.bordered)
+            .controlSize(.mini)
+
+            Button(action: exportJSON) {
+                Label("JSON", systemImage: "curlybraces")
+                    .font(.system(size: 11))
+            }
+            .buttonStyle(.bordered)
+            .controlSize(.mini)
+        }
+        .padding(.trailing, 8)
+    }
+
+    private func exportHTML() {
+        let html = HTMLReportGenerator(scanResults: scanResults).generateHTMLReport()
+        let panel = NSSavePanel()
+        panel.nameFieldStringValue = "MergenReport.html"
+        panel.allowedContentTypes = [.html]
+        if panel.runModal() == .OK, let url = panel.url {
+            try? html.write(to: url, atomically: true, encoding: .utf8)
+        }
+    }
+
+    private func exportJSON() {
+        let data = JSONReportGenerator(scanResults: scanResults).generateJSONReport()
+        let panel = NSSavePanel()
+        panel.nameFieldStringValue = "MergenReport.json"
+        panel.allowedContentTypes = [.json]
+        if panel.runModal() == .OK, let url = panel.url {
+            try? data.write(to: url)
+        }
+    }
+}
+
+// MARK: - Empty Filter State
+
+struct EmptyFilterView: View {
+    let hasFilters: Bool
+    let clearFilters: () -> Void
+
+    var body: some View {
+        VStack(spacing: 16) {
+            Spacer()
+            ZStack {
+                Circle()
+                    .fill(Color.secondary.opacity(0.07))
+                    .frame(width: 72, height: 72)
+                Image(systemName: hasFilters ? "line.3.horizontal.decrease.circle" : "checkmark.seal.fill")
+                    .font(.system(size: 32))
+                    .foregroundColor(.secondary.opacity(0.45))
+            }
+            VStack(spacing: 6) {
+                Text(hasFilters ? "No results" : "No checks yet")
+                    .font(.system(size: 15, weight: .semibold))
+                    .foregroundColor(.secondary)
+                Text(hasFilters
+                     ? "No checks match your current filters."
+                     : "Run a scan to see results.")
+                    .font(.caption)
+                    .foregroundColor(.secondary.opacity(0.7))
+                    .multilineTextAlignment(.center)
+            }
+            if hasFilters {
+                Button("Clear Filters") { clearFilters() }
+                    .buttonStyle(.bordered)
+                    .controlSize(.small)
+                    .tint(.primary)
+            }
+            Spacer()
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+}
+
+// MARK: - Section Header
+
+struct SectionHeader: View {
+    let title: String
+    let items: [Vulnerability]
+
+    private var failCount: Int { items.filter { $0.checkstatus == "Red" }.count }
+    private var warnCount: Int { items.filter { $0.checkstatus == "Yellow" }.count }
+    private var passCount: Int { items.filter { $0.checkstatus == "Green" }.count }
+
+    var body: some View {
+        HStack(spacing: 6) {
+            Text(title)
+                .font(.system(size: 11, weight: .bold))
+                .foregroundColor(.primary.opacity(0.6))
+                .textCase(nil)
+            Spacer()
+            HStack(spacing: 4) {
+                if failCount > 0 { StatusBadge(count: failCount, color: Color(red: 0.96, green: 0.36, blue: 0.36)) }
+                if warnCount > 0 { StatusBadge(count: warnCount, color: Color(red: 0.97, green: 0.63, blue: 0.22)) }
+                if passCount > 0 { StatusBadge(count: passCount, color: Color(red: 0.13, green: 0.73, blue: 0.54)) }
+            }
+        }
+        .padding(.vertical, 2)
+    }
+}
+
+struct StatusBadge: View {
+    let count: Int
+    let color: Color
+
+    var body: some View {
+        Text("\(count)")
+            .font(.system(size: 10, weight: .bold, design: .rounded))
+            .foregroundColor(color)
+            .padding(.horizontal, 6)
+            .padding(.vertical, 2)
+            .background(color.opacity(0.14))
+            .cornerRadius(20)
+    }
+}
+
+// MARK: - Vulnerability Row
+
+struct VulnerabilityRow: View {
+    let vulnerability: Vulnerability
+
+    private var statusColor: Color {
+        switch vulnerability.checkstatus {
+        case "Green":  return Color(red: 0.13, green: 0.73, blue: 0.54)
+        case "Red":    return Color(red: 0.96, green: 0.36, blue: 0.36)
+        case "Yellow": return Color(red: 0.97, green: 0.63, blue: 0.22)
+        case "Blue":   return Color(red: 0.27, green: 0.55, blue: 0.95)
+        default:       return .gray
+        }
+    }
+
+    private var statusIcon: String {
+        switch vulnerability.checkstatus {
+        case "Green":  return "checkmark.circle.fill"
+        case "Red":    return "xmark.circle.fill"
+        case "Yellow": return "exclamationmark.triangle.fill"
+        case "Blue":   return "info.circle.fill"
+        default:       return "questionmark.circle"
+        }
+    }
+
+    private var severityColor: Color {
+        switch vulnerability.severity.lowercased() {
+        case "critical": return Color(red: 0.96, green: 0.36, blue: 0.36)
+        case "high":     return Color(red: 0.97, green: 0.63, blue: 0.22)
+        case "medium":   return Color(red: 0.85, green: 0.72, blue: 0.10)
+        case "low":      return Color(red: 0.27, green: 0.55, blue: 0.95)
+        default:         return .gray
+        }
+    }
+
+    private var leftBarColor: Color {
+        switch vulnerability.checkstatus {
+        case "Red":    return statusColor
+        case "Yellow": return statusColor
+        default:       return .clear
+        }
+    }
+
+    var body: some View {
+        HStack(spacing: 0) {
+
+            // Left accent bar
+            RoundedRectangle(cornerRadius: 2)
+                .fill(leftBarColor)
+                .frame(width: 3)
+                .padding(.vertical, 6)
+
+            HStack(spacing: 11) {
+                Image(systemName: statusIcon)
+                    .foregroundColor(statusColor)
+                    .font(.system(size: 16))
+                    .frame(width: 20)
+
+                VStack(alignment: .leading, spacing: 3) {
+                    HStack(spacing: 6) {
+                        if !vulnerability.cisID.isEmpty {
+                            Text(vulnerability.cisID)
+                                .font(.system(size: 10, weight: .semibold, design: .monospaced))
+                                .foregroundColor(.secondary)
+                                .padding(.horizontal, 5)
+                                .padding(.vertical, 2)
+                                .background(Color.primary.opacity(0.07))
+                                .cornerRadius(4)
+                        }
+                        Text(vulnerability.name)
+                            .font(.system(size: 13, weight: .medium))
+                            .lineLimit(1)
+                    }
+                    if let status = vulnerability.status, !status.isEmpty {
+                        Text(status)
+                            .font(.system(size: 11))
+                            .foregroundColor(.secondary)
+                            .lineLimit(1)
+                    }
+                }
+
+                Spacer()
+
+                if vulnerability.severity.lowercased() == "critical" || vulnerability.severity.lowercased() == "high" {
+                    Text(vulnerability.severity)
+                        .font(.system(size: 10, weight: .bold))
+                        .foregroundColor(severityColor)
+                        .padding(.horizontal, 7)
+                        .padding(.vertical, 3)
+                        .background(severityColor.opacity(0.12))
+                        .cornerRadius(20)
+                }
+            }
+            .padding(.leading, 9)
+        }
+        .padding(.vertical, 4)
+    }
+}
+
+// MARK: - Severity Distribution Bar
+
+struct SeverityDistributionBar: View {
+    let results: [Vulnerability]
+
+    private var failed:   [Vulnerability] { results.filter { $0.checkstatus == "Red" } }
+    private var critical: Int { failed.filter { $0.severity.lowercased() == "critical" }.count }
+    private var high:     Int { failed.filter { $0.severity.lowercased() == "high"     }.count }
+    private var medium:   Int { failed.filter { $0.severity.lowercased() == "medium"   }.count }
+    private var low:      Int { failed.filter { $0.severity.lowercased() == "low"      }.count }
+    private var total:    Int { failed.count }
+
+    var body: some View {
+        Group {
+            if total > 0 {
+                VStack(alignment: .leading, spacing: 5) {
+                    HStack {
+                        Text("Risk Profile")
+                            .font(.system(size: 10, weight: .semibold))
+                            .foregroundColor(.secondary)
+                        Spacer()
+                        Text("\(total) failed")
+                            .font(.system(size: 10))
+                            .foregroundColor(.secondary)
+                    }
+
+                    // Stacked bar
+                    GeometryReader { geo in
+                        let tw = geo.size.width
+                        let tc = CGFloat(total)
+                        ZStack(alignment: .leading) {
+                            // Background track
+                            RoundedRectangle(cornerRadius: 3)
+                                .fill(Color.primary.opacity(0.06))
+                            // Segments
+                            HStack(spacing: 0) {
+                                if critical > 0 {
+                                    Color.red
+                                        .frame(width: tw * CGFloat(critical) / tc)
+                                }
+                                if high > 0 {
+                                    Color.orange
+                                        .frame(width: tw * CGFloat(high) / tc)
+                                }
+                                if medium > 0 {
+                                    Color(red: 0.85, green: 0.70, blue: 0)
+                                        .frame(width: tw * CGFloat(medium) / tc)
+                                }
+                                if low > 0 {
+                                    Color.blue // fills remainder
+                                }
+                            }
+                        }
+                        .clipShape(RoundedRectangle(cornerRadius: 3))
+                    }
+                    .frame(height: 6)
+
+                    // Legend
+                    HStack(spacing: 10) {
+                        if critical > 0 { SevLegendDot(label: "\(critical) Critical", color: .red) }
+                        if high     > 0 { SevLegendDot(label: "\(high) High",         color: .orange) }
+                        if medium   > 0 { SevLegendDot(label: "\(medium) Med",        color: Color(red: 0.85, green: 0.70, blue: 0)) }
+                        if low      > 0 { SevLegendDot(label: "\(low) Low",           color: .blue) }
+                    }
+                }
+                .padding(.horizontal, 12)
+                .padding(.vertical, 7)
+                .background(Color.primary.opacity(0.02))
+            }
+        }
+    }
+}
+
+private struct SevLegendDot: View {
+    let label: String
+    let color: Color
+    var body: some View {
+        HStack(spacing: 4) {
+            Circle().fill(color).frame(width: 6, height: 6)
+            Text(label)
+                .font(.system(size: 9))
+                .foregroundColor(.secondary)
+        }
+    }
+}
+</file>
+
+<file path="mergen/view/VulnerabilityDetailView.swift">
+//
+//  VulnerabilityDetailView.swift
+//  mergen
+//
+
+import SwiftUI
+import AppKit
+
+// MARK: - Detail Panel (right column)
+
+struct DetailPanelView: View {
+    let vulnerability: Vulnerability?
+    @ObservedObject var scanManager: ScanManager
+
+    var body: some View {
+        Group {
+            if let v = vulnerability {
+                VulnerabilityDetailView(vulnerability: v, scanManager: scanManager)
+            } else {
+                EmptyDetailView()
+            }
+        }
+    }
+}
+
+// MARK: - Empty State
+
+struct EmptyDetailView: View {
+    var body: some View {
+        VStack(spacing: 14) {
+            ZStack {
+                Circle()
+                    .fill(Color.secondary.opacity(0.07))
+                    .frame(width: 80, height: 80)
+                Image(systemName: "doc.text.magnifyingglass")
+                    .font(.system(size: 36))
+                    .foregroundColor(.secondary.opacity(0.35))
+            }
+            VStack(spacing: 5) {
+                Text("Select a check")
+                    .font(.system(size: 15, weight: .semibold))
+                    .foregroundColor(.secondary)
+                Text("Click any row to see description,\nremediation steps, and auto-fix options.")
+                    .font(.caption)
+                    .foregroundColor(.secondary.opacity(0.65))
+                    .multilineTextAlignment(.center)
+            }
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+}
+
+// MARK: - Main Detail View
+
+struct VulnerabilityDetailView: View {
+    let vulnerability: Vulnerability
+    @ObservedObject var scanManager: ScanManager
+    @State private var remediationCopied = false
+
+    // MARK: Helpers
+
+    private var statusColor: Color {
+        switch vulnerability.checkstatus {
+        case "Green":  return Color(red: 0.13, green: 0.73, blue: 0.54)
+        case "Red":    return Color(red: 0.96, green: 0.36, blue: 0.36)
+        case "Yellow": return Color(red: 0.97, green: 0.63, blue: 0.22)
+        case "Blue":   return .secondary
+        default:       return .gray
+        }
+    }
+
+    private var statusIcon: String {
+        switch vulnerability.checkstatus {
+        case "Green":  return "checkmark.circle.fill"
+        case "Red":    return "xmark.circle.fill"
+        case "Yellow": return "exclamationmark.triangle.fill"
+        case "Blue":   return "info.circle.fill"
+        default:       return "questionmark.circle.fill"
+        }
+    }
+
+    private var statusLabel: String {
+        switch vulnerability.checkstatus {
+        case "Green":  return "Passed"
+        case "Red":    return "Failed"
+        case "Yellow": return "Warning"
+        case "Blue":   return "Advisory"
+        default:       return "Unknown"
+        }
+    }
+
+    private var severityColor: Color {
+        switch vulnerability.severity.lowercased() {
+        case "critical": return Color(red: 0.96, green: 0.36, blue: 0.36)
+        case "high":     return Color(red: 0.97, green: 0.63, blue: 0.22)
+        case "medium":   return Color(red: 0.85, green: 0.72, blue: 0.10)
+        case "low":      return .secondary
+        default:         return .gray
+        }
+    }
+
+    // True when remediation looks like it contains shell commands
+    private var hasShellCommands: Bool {
+        let commands = ["sudo ", "defaults ", "spctl ", "systemsetup ", "csrutil ", "fdesetup ", "/usr/", "/bin/", "/sbin/"]
+        return commands.contains { vulnerability.remediation.contains($0) }
+    }
+
+    // MARK: Body
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 0) {
+
+                // ── Header ──────────────────────────────────────────────────
+                VStack(alignment: .leading, spacing: 14) {
+
+                    // Status icon + name + badges
+                    HStack(alignment: .top, spacing: 12) {
+                        Image(systemName: statusIcon)
+                            .font(.system(size: 26))
+                            .foregroundColor(statusColor)
+                            .frame(width: 30)
+
+                        VStack(alignment: .leading, spacing: 6) {
+                            Text(vulnerability.name)
+                                .font(.system(size: 16, weight: .semibold))
+                                .fixedSize(horizontal: false, vertical: true)
+
+                            HStack(spacing: 6) {
+                                BadgeView(text: statusLabel, color: statusColor)
+                                BadgeView(text: vulnerability.severity, color: severityColor)
+                                if !vulnerability.cisID.isEmpty {
+                                    BadgeView(text: "CIS \(vulnerability.cisID)", color: .secondary, style: .outlined)
+                                }
+                                if vulnerability.isManual {
+                                    BadgeView(text: "Manual", color: .secondary)
+                                }
+                            }
+                        }
+                    }
+
+                    // Result status callout
+                    if let status = vulnerability.status, !status.isEmpty {
+                        HStack(spacing: 0) {
+                            // Left colored border
+                            RoundedRectangle(cornerRadius: 2)
+                                .fill(statusColor)
+                                .frame(width: 4)
+                            HStack(spacing: 9) {
+                                Image(systemName: statusIcon)
+                                    .foregroundColor(statusColor)
+                                    .font(.system(size: 13))
+                                Text(status)
+                                    .font(.system(size: 13))
+                                    .foregroundColor(.primary)
+                                    .fixedSize(horizontal: false, vertical: true)
+                            }
+                            .padding(.horizontal, 12)
+                            .padding(.vertical, 10)
+                        }
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .background(statusColor.opacity(0.07))
+                        .cornerRadius(9)
+                        .overlay(
+                            RoundedRectangle(cornerRadius: 9)
+                                .stroke(statusColor.opacity(0.18), lineWidth: 1)
+                        )
+                    }
+                }
+                .padding(20)
+                .frame(maxWidth: .infinity, alignment: .leading)
+
+                Divider()
+
+                // ── Manual advisory callout ──────────────────────────────
+                if vulnerability.isManual || vulnerability.checkstatus == "Blue" {
+                    let infoColor = Color.secondary
+                    HStack(spacing: 0) {
+                        RoundedRectangle(cornerRadius: 2)
+                            .fill(infoColor)
+                            .frame(width: 4)
+                        HStack(spacing: 10) {
+                            Image(systemName: "info.circle.fill")
+                                .foregroundColor(infoColor)
+                                .font(.system(size: 16))
+                            VStack(alignment: .leading, spacing: 3) {
+                                Text("Manual Review Required")
+                                    .font(.system(size: 13, weight: .semibold))
+                                    .foregroundColor(infoColor)
+                                Text("This check cannot be fully automated. Follow the remediation steps to verify compliance manually.")
+                                    .font(.caption)
+                                    .foregroundColor(.secondary)
+                            }
+                        }
+                        .padding(.horizontal, 12)
+                        .padding(.vertical, 11)
+                    }
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .background(infoColor.opacity(0.07))
+                    .cornerRadius(10)
+                    .overlay(RoundedRectangle(cornerRadius: 10).stroke(infoColor.opacity(0.18), lineWidth: 1))
+                    .padding(.horizontal, 20)
+                    .padding(.top, 16)
+                }
+
+                // ── Sections ─────────────────────────────────────────────
+                VStack(alignment: .leading, spacing: 22) {
+
+                    DetailSection(title: "Description", icon: "doc.text") {
+                        Text(vulnerability.description)
+                            .font(.system(size: 13))
+                            .fixedSize(horizontal: false, vertical: true)
+                    }
+
+                    DetailSection(title: "Remediation", icon: "wrench.and.screwdriver") {
+                        VStack(alignment: .leading, spacing: 10) {
+                            if hasShellCommands {
+                                // Shell-command-heavy remediation: use monospaced block
+                                Text(vulnerability.remediation)
+                                    .font(.system(size: 12, design: .monospaced))
+                                    .fixedSize(horizontal: false, vertical: true)
+                                    .padding(10)
+                                    .frame(maxWidth: .infinity, alignment: .leading)
+                                    .background(Color.primary.opacity(0.05))
+                                    .cornerRadius(7)
+                            } else {
+                                Text(vulnerability.remediation)
+                                    .font(.system(size: 13))
+                                    .fixedSize(horizontal: false, vertical: true)
+                            }
+                            HStack(spacing: 8) {
+                                Button(action: copyRemediation) {
+                                    Label(remediationCopied ? "Copied!" : "Copy Remediation",
+                                          systemImage: remediationCopied ? "checkmark" : "doc.on.doc")
+                                        .font(.system(size: 12))
+                                }
+                                .buttonStyle(.bordered)
+                                .controlSize(.small)
+                                .tint(remediationCopied ? .green : .accentColor)
+
+                                if vulnerability.isAutoFixable || scanManager.fixResults[vulnerability.id] != nil {
+                                    AutoFixButton(vulnerability: vulnerability, scanManager: scanManager)
+                                }
+                            }
+
+                            // Before / After preview
+                            if let desc = vulnerability.fixDescription,
+                               vulnerability.checkstatus == "Red" {
+                                VStack(alignment: .leading, spacing: 6) {
+                                    if let current = vulnerability.status, !current.isEmpty {
+                                        HStack(alignment: .top, spacing: 6) {
+                                            Image(systemName: "xmark.circle.fill")
+                                                .foregroundColor(.red.opacity(0.7))
+                                                .font(.system(size: 11))
+                                            VStack(alignment: .leading, spacing: 1) {
+                                                Text("Current state")
+                                                    .font(.system(size: 9, weight: .semibold))
+                                                    .foregroundColor(.secondary)
+                                                Text(current)
+                                                    .font(.system(size: 11))
+                                                    .foregroundColor(.primary)
+                                                    .fixedSize(horizontal: false, vertical: true)
+                                            }
+                                        }
+                                    }
+                                    HStack(alignment: .top, spacing: 6) {
+                                        Image(systemName: "checkmark.circle.fill")
+                                            .foregroundColor(.green.opacity(0.8))
+                                            .font(.system(size: 11))
+                                        VStack(alignment: .leading, spacing: 1) {
+                                            Text("After fix")
+                                                .font(.system(size: 9, weight: .semibold))
+                                                .foregroundColor(.secondary)
+                                            Text(desc)
+                                                .font(.system(size: 11))
+                                                .foregroundColor(.green.opacity(0.9))
+                                                .fixedSize(horizontal: false, vertical: true)
+                                        }
+                                    }
+                                }
+                                .padding(10)
+                                .frame(maxWidth: .infinity, alignment: .leading)
+                                .background(Color.primary.opacity(0.04))
+                                .cornerRadius(8)
+                                .overlay(
+                                    RoundedRectangle(cornerRadius: 8)
+                                        .stroke(Color.primary.opacity(0.08), lineWidth: 1)
+                                )
+                            }
+                        }
+                    }
+
+                    DetailSection(title: "Mitigation", icon: "shield") {
+                        Text(vulnerability.mitigation)
+                            .font(.system(size: 13))
+                            .fixedSize(horizontal: false, vertical: true)
+                    }
+
+                    if let doc = vulnerability.documentation, !doc.isEmpty {
+                        DetailSection(title: "Reference", icon: "book.closed") {
+                            if doc.hasPrefix("http"), let url = URL(string: doc) {
+                                Link(destination: url) {
+                                    HStack(spacing: 5) {
+                                        Text(doc)
+                                            .font(.system(size: 12))
+                                            .foregroundColor(.primary)
+                                            .lineLimit(3)
+                                            .multilineTextAlignment(.leading)
+                                        Spacer()
+                                        Image(systemName: "arrow.up.right.square")
+                                            .font(.caption)
+                                            .foregroundColor(.primary)
+                                    }
+                                }
+                                .buttonStyle(.plain)
+                            } else {
+                                Text(doc)
+                                    .font(.system(size: 12))
+                                    .foregroundColor(.secondary)
+                                    .fixedSize(horizontal: false, vertical: true)
+                            }
+                        }
+                    }
+                }
+                .padding(20)
+            }
+        }
+        .navigationTitle(vulnerability.name)
+    }
+
+    private func copyRemediation() {
+        NSPasteboard.general.clearContents()
+        NSPasteboard.general.setString(vulnerability.remediation, forType: .string)
+        remediationCopied = true
+        DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
+            remediationCopied = false
+        }
+    }
+}
+
+// MARK: - Supporting Views
+
+struct DetailSection<Content: View>: View {
+    let title: String
+    let icon: String
+    @ViewBuilder let content: () -> Content
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Label(title, systemImage: icon)
+                .font(.system(size: 11, weight: .bold))
+                .foregroundColor(.secondary)
+                .textCase(nil)
+            content()
+                .padding(12)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .background(Color.primary.opacity(0.04))
+                .cornerRadius(10)
+                .overlay(RoundedRectangle(cornerRadius: 10).stroke(Color.primary.opacity(0.07), lineWidth: 1))
+        }
+    }
+}
+
+// MARK: - Auto-Fix Button
+
+struct AutoFixButton: View {
+    let vulnerability: Vulnerability
+    @ObservedObject var scanManager: ScanManager
+    @State private var showLog = false
+
+    private var isFixing:    Bool  { scanManager.fixingIDs.contains(vulnerability.id) }
+    private var result:      Bool? { scanManager.fixResults[vulnerability.id] }
+    private var isFixed:     Bool  { vulnerability.checkstatus == "Green" }
+    private var isCancelled: Bool  { scanManager.fixCancelled.contains(vulnerability.id) }
+
+    var body: some View {
+        Group {
+            if isFixing {
+                HStack(spacing: 5) {
+                    ProgressView().scaleEffect(0.7)
+                    Text("Fixing…").font(.system(size: 12))
+                }
+                .foregroundColor(.secondary)
+            } else if isFixed {
+                Label("Fixed!", systemImage: "checkmark.seal.fill")
+                    .font(.system(size: 12))
+                    .foregroundColor(.green)
+            } else if isCancelled {
+                Label("Cancelled", systemImage: "xmark.circle")
+                    .font(.system(size: 12))
+                    .foregroundColor(.secondary)
+            } else if let r = result, !r {
+                VStack(alignment: .leading, spacing: 4) {
+                    Label("Still failing", systemImage: "exclamationmark.triangle")
+                        .font(.system(size: 12))
+                        .foregroundColor(.red)
+                    if let status = vulnerability.status, !status.isEmpty {
+                        Text(status)
+                            .font(.system(size: 10))
+                            .foregroundColor(.secondary)
+                            .fixedSize(horizontal: false, vertical: true)
+                    }
+                    Button {
+                        showLog = true
+                    } label: {
+                        Label("View Audit Log", systemImage: "doc.text.magnifyingglass")
+                            .font(.system(size: 10))
+                    }
+                    .buttonStyle(.borderless)
+                    .foregroundColor(.primary)
+                }
+                .sheet(isPresented: $showLog) {
+                    LogViewerSheet()
+                }
+            } else {
+                Button {
+                    scanManager.applyFix(for: vulnerability)
+                } label: {
+                    Label(
+                        vulnerability.fixRequiresAdmin ? "Fix (Admin)" : "Fix Automatically",
+                        systemImage: "bolt.fill"
+                    )
+                    .font(.system(size: 12))
+                }
+                .buttonStyle(.bordered)
+                .controlSize(.small)
+                .tint(.primary)
+            }
+        }
+        .animation(.default, value: isFixing)
+        .animation(.default, value: isFixed)
+    }
+}
+
+enum BadgeStyle { case filled, outlined }
+
+struct BadgeView: View {
+    let text: String
+    let color: Color
+    var style: BadgeStyle = .filled
+
+    var body: some View {
+        Text(text)
+            .font(.system(size: 11, weight: .semibold))
+            .foregroundColor(style == .filled ? color : .secondary)
+            .padding(.horizontal, 9)
+            .padding(.vertical, 4)
+            .background(style == .filled ? color.opacity(0.13) : Color.primary.opacity(0.06))
+            .cornerRadius(20)
+            .overlay(
+                RoundedRectangle(cornerRadius: 20)
+                    .stroke(style == .outlined ? Color.secondary.opacity(0.25) : Color.clear, lineWidth: 1)
+            )
+    }
+}
+</file>
+
+<file path="README.md">
+## A note from the author
+
+I started Mergen as a side project to learn Swift and build something real out of it. It reached more people than I expected and got great feedback but after the initial release, it sat untouched for a long time.
+
+Recently I've been experimenting with vibe-coded scripts and tools, and I realized I could use Claude to bring Mergen back up to date. So here we are. The CLI is new, everything is synced with the latest macOS version, auto-fix is in, and a few other things got polished along the way.
+
+That said, AI-assisted code is still code. It can have bugs, and it won't always be the cleanest solution. I've tested on a couple of different systems and things are holding up, but there may still be rough edges. All checks are based on the latest CIS Benchmark. You can fix issues with one click in the app or via the CLI.
+
+I'm keeping the releases updated. If you find a bug or something feels off, please open an issue on GitHub, it's genuinely appreciated.
+
+---
+
+<div align="center">
+
+# 🛡️ Mergen v2
+
+**Native macOS security audit — CIS Apple macOS 26 Tahoe Benchmark v1.0.0**
+
+[![Platform](https://img.shields.io/badge/platform-macOS%2013%2B-lightgrey?style=flat-square)](https://github.com/sametsazak/mergen)
+[![Swift](https://img.shields.io/badge/swift-5.9-orange?style=flat-square)](https://swift.org)
+[![Go](https://img.shields.io/badge/go-1.21+-00ADD8?style=flat-square)](https://go.dev)
+[![License](https://img.shields.io/badge/license-MIT-blue?style=flat-square)](LICENSE)
+[![Version](https://img.shields.io/badge/version-2.2-brightgreen?style=flat-square)](https://github.com/sametsazak/mergen/releases)
+[![CIS Benchmark](https://img.shields.io/badge/CIS-macOS%2026%20Tahoe%20v1.0.0-red?style=flat-square)](https://www.cisecurity.org)
+[![Homebrew](https://img.shields.io/badge/homebrew-install-FBB040?style=flat-square&logo=homebrew&logoColor=white)](https://github.com/sametsazak/homebrew-mergen)
+
+Mergen audits your Mac against 85 CIS Benchmark controls and **fixes most failures automatically**.
+Available as a native **SwiftUI app** and a **Go CLI** — pick whichever fits your workflow.
+
+![Screenshot](img/main.png)
+![Screenshot](img/main2.png)
+![Screenshot](img/mergen-report.png)
+
+</div>
+
+---
+
+## Table of Contents
+
+- [Overview](#overview)
+- [SwiftUI App](#swiftui-app)
+- [CLI (`mergen-cli`)](#cli-mergen-cli)
+- [Checks Reference](#checks-reference)
+- [How Auto-Fix Works](#how-auto-fix-works)
+- [macOS 26 Tahoe Compatibility](#macos-26-tahoe-compatibility)
+- [Contributing](#contributing)
+- [License](#license)
+
+---
+
+## Overview
+
+Mergen audits macOS security configuration against the **CIS Apple macOS 26 Tahoe Benchmark v1.0.0**. It covers software updates, firewall, sharing services, privacy, authentication, encryption, and more.
+
+Unlike shell scripts that only report findings, Mergen can **remediate failures directly** — applying the correct system change and immediately re-verifying the result.
+
+> All feedback, issues, and pull requests are welcome.
+
+---
+
+## SwiftUI App
+
+The GUI option — point and click, no Terminal needed. Covers the same 85 checks as the CLI with a visual interface, Fix All sheet, and in-app audit log viewer.
+
+### Features
+
+**Scanning**
+- 85 automated checks across CIS sections 1–6
+- Live results — list populates as checks complete
+- 15-second per-check timeout so hung checks never stall the scan
+- Apple Intelligence / AI privacy checks (CIS 2.5.x, new in Tahoe)
+
+**Auto-Remediation**
+- Fix individual checks from the detail panel
+- **Fix All sheet** — see every fixable failure, apply them all at once
+- Two privilege tiers: user-level runs silently; admin uses one password prompt
+- After every fix the check re-runs to verify the result
+
+**Audit Logging**
+- Every scan and fix is logged to `~/Library/Logs/mergen/mergen-YYYY-MM-DD.log`
+- In-app log viewer: color-coded entries, filter by type, search, copy-all
+
+**Reporting**
+- HTML report: styled, standalone, shareable — dark purple gradient theme
+- JSON export: full metadata per check including CIS ID, status, severity, and remediation
+
+**Interface**
+- 2-pane layout: Results list → Detail panel
+- Filter pills: All / Failed / Passed / Warnings / Advisory
+- Sort by CIS ID, Severity, Name, or Status
+- Search across name, CIS ID, description, and finding text
+- Security score ring with percentage, GOOD / FAIR / AT RISK label, and pass/fail/warn counts
+
+### Installation
+
+**Via Homebrew (recommended):**
+```bash
+brew install --cask sametsazak/mergen/mergen-app
+```
+
+**Or download the DMG** from the [latest release](https://github.com/sametsazak/mergen/releases/latest).
+
+**Build from source:**
+```bash
+git clone https://github.com/sametsazak/mergen.git
+```
+Open `mergen.xcodeproj` in Xcode and run. No third-party dependencies. No network calls.
+
+**Requirements:** macOS 13 Ventura or later · Tested on macOS 26 Tahoe
+
+### Usage
+
+1. Launch Mergen and press **Scan**
+2. Use the **Failed** filter pill and sort by Severity to prioritize
+3. Click any check to see description, finding, and remediation steps
+4. Press **Fix N** in the top bar to open the Fix All sheet
+5. Export results as **HTML** or **JSON**
+
+### Admin Privilege Notice
+
+Some fixes require elevated privileges. When an admin fix runs:
+- macOS shows the **standard system authentication dialog**
+- Your password is handled entirely by macOS via `do shell script ... with administrator privileges`
+- **Mergen never stores, logs, or transmits your password**
+- Every fix command is visible in [`FixCommands.swift`](mergen/core/FixCommands.swift)
+
+When using **Fix All**, all admin fixes are batched into a **single password prompt**.
+
+---
+
+## CLI (`mergen-cli`)
+
+A fully-featured Go CLI covering the same 85 CIS checks, built for power users, sysadmins, and CI pipelines.
+
+```
+  ███╗   ███╗███████╗██████╗  ██████╗ ███████╗███╗   ██╗
+  ████╗ ████║██╔════╝██╔══██╗██╔════╝ ██╔════╝████╗  ██║
+  ██╔████╔██║█████╗  ██████╔╝██║  ███╗█████╗  ██╔██╗ ██║
+  ██║╚██╔╝██║██╔══╝  ██╔══██╗██║   ██║██╔══╝  ██║╚██╗██║
+  ██║ ╚═╝ ██║███████╗██║  ██║╚██████╔╝███████╗██║ ╚████║
+  ╚═╝     ╚═╝╚══════╝╚═╝  ╚═╝ ╚═════╝ ╚══════╝╚═╝  ╚═══╝
+  macOS Security Audit CLI  ·  CIS Apple macOS 26 Tahoe Benchmark v1.0.0
+```
+
+![Screenshot](img/mergen-cli.png)
+### Installation
+
+**Via Homebrew (recommended):**
+```bash
+brew install sametsazak/mergen/mergen
+```
+
+**Build from source:**
+```bash
+git clone https://github.com/sametsazak/mergen.git
+cd mergen/mergen-cli
+go build -o mergen .
+sudo mv mergen /usr/local/bin/   # optional: install system-wide
+```
+
+**Requirements:** Go 1.21+, macOS 13+
+
+### Commands
+
+#### `mergen` — Interactive TUI
+
+Running `mergen` with no arguments launches a keyboard-driven interactive menu:
+
+```
+  What would you like to do?
+
+ ▶ ⚡  Scan All Checks          [a]  Run all 85 security checks concurrently
+   §   Scan by Section          [s]  Choose a specific CIS section to audit
+   ✗   Show Only Failures       [f]  Scan and display only failing checks
+   ⚙   Fix Issues               [x]  Auto-remediate all fixable failures
+   ☑   Dry Run Fix              [d]  Preview fixes without applying them
+   ≡   List All Checks          [l]  Browse every registered check
+   ⎘   Generate HTML Report     [h]  Run scan and export a styled HTML report
+   ⎘   Generate JSON Report     [j]  Run scan and export machine-readable JSON
+   ✕   Quit                     [q]  Exit mergen
+
+  ↑↓ / jk navigate  ·  enter select  ·  shortcut key  ·  q quit
+```
+
+#### `mergen scan` — Run Security Checks
+
+```bash
+mergen scan [flags]
+```
+
+**Flags:**
+
+| Flag | Short | Default | Description |
+|------|-------|---------|-------------|
+| `--section` | `-s` | — | Run only checks in a CIS section (1–6) |
+| `--category` | `-c` | — | Filter by category (e.g. `CIS Benchmark`) |
+| `--failed` | `-f` | false | Show only failed checks |
+| `--quiet` | `-q` | false | Print summary only |
+| `--json` | — | false | Output results as JSON array |
+| `--workers` | `-w` | 8 | Number of parallel check workers |
+
+**Exit codes:** `0` = all checks pass · `1` = one or more failures
+
+#### `mergen fix` — Auto-Remediate Failures
+
+```bash
+mergen fix [flags]
+```
+
+| Flag | Short | Default | Description |
+|------|-------|---------|-------------|
+| `--id` | — | — | Fix a single check by CIS ID (e.g. `2.2.1`) |
+| `--yes` | `-y` | false | Apply all fixes without confirmation |
+| `--dry-run` | — | false | Preview fixes without applying |
+
+#### `mergen list` — Browse All Checks
+
+```bash
+mergen list [--section 1-6]
+```
+
+#### `mergen report` — Export HTML or JSON
+
+```bash
+mergen report                             # HTML → ./mergen-report.html
+mergen report --format json               # JSON → ./mergen-report.json
+mergen report --format html -o ~/Desktop/audit.html
+```
+
+### Examples
+
+```bash
+# Full scan
+mergen scan
+
+# Show only failures
+mergen scan --failed
+
+# Machine-readable output
+mergen scan --json | jq '.[] | select(.status == "fail")'
+
+# Fix everything that can be fixed
+mergen fix --yes
+
+# Preview what would be fixed
+mergen fix --dry-run
+
+# Export HTML report
+mergen report --format html -o ~/Desktop/security-audit.html
+```
+
+### CI / CD Integration
+
+```yaml
+# GitHub Actions example
+- name: Run security audit
+  run: |
+    cd mergen-cli
+    go build -o mergen .
+    ./mergen scan --quiet --json > audit.json
+  continue-on-error: true
+
+- name: Upload audit report
+  uses: actions/upload-artifact@v3
+  with:
+    name: security-audit
+    path: audit.json
+```
+
+```bash
+# Fail CI if any checks fail
+mergen scan --json | jq -e '[.[] | select(.status == "fail")] | length == 0' || exit 1
+```
+
+---
+
+## Checks Reference
+
+### §1 — Software Updates
+
+| CIS ID | Check | Severity | Auto-Fix |
+|--------|-------|----------|----------|
+| 1.1 | Apple software updated within 30 days | High | — |
+| 1.2 | Critical updates auto-install enabled | Medium | ✓ Admin |
+| 1.3 | Auto-update enabled | High | ✓ Admin |
+| 1.4 | App Store auto-updates enabled | Medium | ✓ Admin |
+| 1.5 | Security responses auto-install enabled | High | ✓ Admin |
+| 1.6 | Software update deferment policy | Low | — |
+
+### §2 — System Settings
+
+| CIS ID | Check | Severity | Auto-Fix |
+|--------|-------|----------|----------|
+| 2.1.1.1 | iCloud Keychain (advisory) | Low | — |
+| 2.1.1.3 | iCloud Drive Desktop/Documents sync disabled | Medium | — |
+| 2.2.1 | Firewall enabled | Critical | ✓ Admin |
+| 2.2.2 | Firewall stealth mode enabled | High | ✓ Admin |
+| 2.3.1.1 | AirDrop disabled | Medium | ✓ User |
+| 2.3.1.2 | AirPlay Receiver disabled | Low | ✓ User |
+| 2.3.2.1 | Time set automatically | Medium | ✓ Admin |
+| 2.3.2.2 | Time within appropriate limits | Low | — |
+| 2.3.3.1 | Screen sharing disabled | High | ✓ Admin |
+| 2.3.3.2 | File sharing disabled | High | ✓ Admin |
+| 2.3.3.3 | Printer sharing disabled | Low | ✓ Admin |
+| 2.3.3.4 | Remote login (SSH) disabled | Critical | ✓ Admin |
+| 2.3.3.5 | Remote management disabled | High | ✓ Admin |
+| 2.3.3.6 | Remote Apple Events disabled | Medium | ✓ Admin |
+| 2.3.3.7 | Internet sharing disabled | High | ✓ Admin |
+| 2.3.3.8 | Content caching disabled | Low | ✓ Admin |
+| 2.3.3.9 | Media sharing disabled | Low | ✓ Admin |
+| 2.3.3.10 | Bluetooth sharing disabled | Low | ✓ User |
+| 2.5.1.1 | External Intelligence Extensions disabled | Medium | — |
+| 2.5.1.2 | Apple Intelligence Writing Tools disabled | Medium | — |
+| 2.5.1.3 | Apple Intelligence Mail Summarization disabled | Low | — |
+| 2.5.1.4 | Apple Intelligence Notes Summarization disabled | Low | — |
+| 2.5.2.1 | Siri disabled | Low | ✓ User |
+| 2.6.1.1 | Location services enabled | Low | — |
+| 2.6.1.2 | Location services shown in menu bar | Low | — |
+| 2.6.3.1 | Diagnostic data sharing disabled | Low | ✓ Admin |
+| 2.6.3.2 | Improve Siri & Dictation disabled | Low | ✓ User |
+| 2.6.3.3 | Improve assistive voice features disabled | Low | ✓ User |
+| 2.6.3.4 | Share with app developers disabled | Low | — |
+| 2.6.4 | Personalized ads disabled | Low | ✓ User |
+| 2.6.5 | Gatekeeper enabled | High | ✓ Admin |
+| 2.6.7 | Lockdown Mode status (advisory) | Low | — |
+| 2.6.8 | Admin password required for System Settings | Medium | — |
+| 2.7.1 | Screen saver hot corners configured | Low | — |
+| 2.8.1 | Universal Control disabled | Low | ✓ User |
+| 2.9.1 | Spotlight search query sharing disabled | Low | ✓ User |
+| 2.10.1.2 | Sleep enabled (Apple Silicon) | Medium | ✓ Admin |
+| 2.10.2 | Power Nap disabled | Low | ✓ Admin |
+| 2.10.3 | Wake for network access disabled | Low | ✓ Admin |
+| 2.11.1 | Screen saver activates within 20 minutes | Medium | ✓ User |
+| 2.11.2 | Password required on wake | High | ✓ User |
+| 2.11.3 | Login window message configured | Low | — |
+| 2.11.4 | Login window shows name and password fields | Medium | ✓ Admin |
+| 2.11.5 | Password hints disabled | Medium | ✓ Admin |
+| 2.13.1 | Guest login disabled | High | ✓ Admin |
+| 2.13.2 | Guest access to shared folders disabled | High | ✓ Admin |
+| 2.13.3 | Automatic login disabled | Critical | ✓ Admin |
+
+### §3 — Logging & Auditing
+
+| CIS ID | Check | Severity | Auto-Fix |
+|--------|-------|----------|----------|
+| 3.1 | Security auditing enabled | Medium | — |
+| 3.3 | Audit flags configured | Medium | — |
+
+### §4 — Network
+
+| CIS ID | Check | Severity | Auto-Fix |
+|--------|-------|----------|----------|
+| 4.1 | Bonjour advertising disabled | Low | ✓ Admin |
+| 4.2 | Apache HTTP server disabled | High | ✓ Admin |
+| 4.3 | NFS server disabled | High | ✓ Admin |
+
+### §5 — Authentication & Authorization
+
+| CIS ID | Check | Severity | Auto-Fix |
+|--------|-------|----------|----------|
+| 5.1.1 | System Integrity Protection (SIP) enabled | Critical | — |
+| 5.1.3 | AMFI (Apple Mobile File Integrity) enabled | High | — |
+| 5.1.4 | Signed System Volume (SSV) enabled | High | — |
+| 5.2.1 | Password lockout threshold ≤ 5 attempts | High | ✓ Admin |
+| 5.2.2 | Minimum password length ≥ 15 characters | High | ✓ Admin |
+| 5.4 | Sudo timeout configured | Medium | ✓ Admin |
+| 5.5 | Sudo TTY tickets enabled | Medium | ✓ Admin |
+| 5.6 | Root account disabled | High | ✓ Admin |
+| 5.9 | Guest home folder does not exist | Low | — |
+| 5.10 | XProtect protection enabled | High | — |
+| 5.11 | Sudo logging enabled | Medium | ✓ Admin |
+| — | FileVault full-disk encryption enabled | Critical | — |
+| — | Certificate trust settings valid | High | — |
+
+### §6 — User Interface
+
+| CIS ID | Check | Severity | Auto-Fix |
+|--------|-------|----------|----------|
+| 6.1.1 | Filename extensions shown in Finder | Low | ✓ User |
+| 6.1.2 | Home folder permissions restrictive | Medium | — |
+| 6.3.1 | Safari auto-open safe files disabled | Medium | ✓ User |
+| 6.3.3 | Safari fraudulent website warning enabled | Medium | ✓ User |
+| 6.3.4 | Safari cross-site tracking prevention enabled | Medium | ✓ User |
+| 6.3.6 | Safari advertising privacy (Private Click Measurement) | Low | ✓ User |
+| 6.3.8 | Safari internet plugins disabled | Medium | ✓ User |
+| 6.3.10 | Safari status bar shown | Low | ✓ User |
+| 6.4.1 | Terminal secure keyboard entry enabled | Medium | ✓ User |
+
+### Additional Checks
+
+| Check | Severity | Auto-Fix |
+|-------|----------|----------|
+| Bluetooth status shown in menu bar | Low | — |
+| Fast user switching disabled | Medium | ✓ Admin |
+| Time Machine volumes encrypted | High | — |
+| EFI firmware version valid (Intel only) | High | — |
+| Java 6 runtime disabled | High | — |
+
+---
+
+## How Auto-Fix Works
+
+Mergen applies fixes at two privilege levels:
+
+| Level | How it runs | Typical checks |
+|-------|-------------|----------------|
+| **User** | Runs as you, no password needed | Safari, screen saver, AirDrop, Siri, privacy settings |
+| **Admin** | Standard macOS auth dialog (AppleScript) | Firewall, sharing services, software update policy, login settings |
+
+After every fix attempt the original check re-runs. The result — Fixed or Still failing — reflects the actual check outcome, not just whether the command exited cleanly.
+
+In both the app and CLI, all admin fixes within a single session are batched into **one password prompt**.
+
+---
+
+## macOS 26 Tahoe Compatibility
+
+| Change in Tahoe | How Mergen handles it |
+|-----------------|----------------------|
+| `com.apple.alf` plist removed | Firewall checks use `socketfilterfw --getglobalstate` |
+| `com.apple.auditd` removed | Section 3 checks report Yellow/Warn, not Red/Fail |
+| Screen saver keys moved to `-currentHost` domain | Checks try `-currentHost` first, fall back to user domain |
+| `spctl --status` writes to stderr | Both stdout and stderr captured |
+| New Apple Intelligence privacy controls | CIS 2.5.1.x checks use MDM profile queries |
+
+---
+
+## Contributing
+
+Issues, pull requests, and new checks are all welcome.
+
+**To add a check to the SwiftUI app:** subclass `Vulnerability` in `mergen/checkmodules/`, register it in `Scanner.swift`, and optionally add a fix command to `FixCommands.swift`.
+
+**To add a check to the CLI:** create a new file in `mergen-cli/internal/checks/`, implement an `init()` function that calls `Register(newCheck(...))`. The check auto-registers via Go's `init()` mechanism.
+
+**Fix command rule:** The fix must write to the exact same key/plist/API that the check reads. Otherwise the re-check will always report failure even if the command succeeded.
+
+---
+
+## License
+
+MIT License — Copyright (c) 2023–2026 Samet Sazak
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+</file>
+
+<file path=".gitignore">
+# Xcode
+#
+# gitignore contributors: remember to update Global/Xcode.gitignore, Objective-C.gitignore & Swift.gitignore
+
+## User settings
+xcuserdata/
+
+## compatibility with Xcode 8 and earlier (ignoring not required starting Xcode 9)
+*.xcscmblueprint
+*.xccheckout
+
+## compatibility with Xcode 3 and earlier (ignoring not required starting Xcode 4)
+build/
+DerivedData/
+*.moved-aside
+*.pbxuser
+!default.pbxuser
+*.mode1v3
+!default.mode1v3
+*.mode2v3
+!default.mode2v3
+*.perspectivev3
+!default.perspectivev3
+
+## Obj-C/Swift specific
+*.hmap
+
+## App packaging
+*.ipa
+*.dSYM.zip
+*.dSYM
+
+## Playgrounds
+timeline.xctimeline
+playground.xcworkspace
+
+# Swift Package Manager
+#
+# Add this line if you want to avoid checking in source code from Swift Package Manager dependencies.
+# Packages/
+# Package.pins
+# Package.resolved
+# *.xcodeproj
+#
+# Xcode automatically generates this directory with a .xcworkspacedata file and xcuserdata
+# hence it is not needed unless you have added a package configuration file to your project
+# .swiftpm
+
+.build/
+
+# CocoaPods
+#
+# We recommend against adding the Pods directory to your .gitignore. However
+# you should judge for yourself, the pros and cons are mentioned at:
+# https://guides.cocoapods.org/using/using-cocoapods.html#should-i-check-the-pods-directory-into-source-control
+#
+# Pods/
+#
+# Add this line if you want to avoid checking in source code from the Xcode workspace
+# *.xcworkspace
+
+# Carthage
+#
+# Add this line if you want to avoid checking in source code from Carthage dependencies.
+# Carthage/Checkouts
+
+Carthage/Build/
+
+# Accio dependency management
+Dependencies/
+.accio/
+
+# fastlane
+#
+# It is recommended to not store the screenshots in the git repo.
+# Instead, use fastlane to re-generate the screenshots whenever they are needed.
+# For more information about the recommended setup visit:
+# https://docs.fastlane.tools/best-practices/source-control/#source-control
+
+fastlane/report.xml
+fastlane/Preview.html
+fastlane/screenshots/**/*.png
+fastlane/test_output
+
+# Code Injection
+#
+# After new code Injection tools there's a generated folder /iOSInjectionProject
+# https://github.com/johnno1962/injectionforxcode
+
+iOSInjectionProject/
+AppIcon.appiconset/.DS_Store
+mergen/.DS_Store
+mergen/Assets.xcassets/.DS_Store
+mergen/checkmodules/.DS_Store
+.DS_Store
+</file>
+
+</files>

--- a/MANUAL_AUDIT_GUIDE.md
+++ b/MANUAL_AUDIT_GUIDE.md
@@ -1,0 +1,334 @@
+# Manual macOS Security Audit Guide
+
+**Based on Mergen v2 (CIS Apple macOS 26 Tahoe Benchmark v1.0.0)**
+
+A walkthrough for running every check Mergen performs — by hand. GUI navigation where Tahoe exposes it, Terminal commands where it doesn't. Use this if you'd rather understand each control than install another auditor.
+
+> Source of truth: detection and fix commands extracted verbatim from `mergen-cli/internal/checks/*.go` (37 files) and `mergen/core/FixCommands.swift`. Severity ratings reflect the Go CLI's own ratings, which sometimes differ from the README — the code is authoritative.
+
+---
+
+## How to use this guide
+
+1. Open **Terminal** (Applications → Utilities → Terminal, or `Cmd+Space` → "Terminal").
+2. Confirm you're on a supported macOS:
+   ```bash
+   sw_vers
+   ```
+   This guide is calibrated for macOS 26 Tahoe; 13 Ventura and later are mostly compatible (Tahoe-specific differences are flagged inline).
+3. **Take a Time Machine backup before running any fix command** — System Settings → General → Time Machine → Back Up Now. Several fixes change auth policy, sharing services, or sudo behavior; rolling back is much easier with a snapshot.
+4. Work through each table top-to-bottom. For each row:
+   - Run the **Verify** command. Compare against the row's pass condition (described in the check's name and severity).
+   - If it fails: prefer the **GUI path** (left column inside System Settings); fall back to the **Fix** command if there's no GUI.
+   - Tick the **☐** checkbox once you've verified or fixed it.
+5. Re-run the verify command after a fix to confirm the change took effect.
+
+### Legend
+
+| Marker | Meaning |
+|---|---|
+| **Critical** | Exploitable without significant effort. Fix first. |
+| **High** | Significant exposure if not remediated. Fix in same session. |
+| **Medium** | Defense-in-depth. Fix when practical. |
+| **Low** | Privacy hardening / advisory. Fix at your convenience. |
+| **User** fix | No password needed. Run in a normal Terminal. |
+| **Admin** fix | Needs `sudo`. You'll be prompted for your password. |
+| **—** in Fix column | No automated remediation; the GUI path or note is the only way. |
+
+### Tahoe-specific gotchas (read once)
+
+- **`com.apple.alf` plist is gone.** All firewall queries use `socketfilterfw` directly.
+- **`com.apple.auditd` is gone.** §3 (Logging & Auditing) checks always WARN — not your fault, no fix.
+- **Screen saver keys live under `-currentHost`.** Verify commands try `-currentHost` first, fall back to user domain.
+- **Safari preferences are sandboxed by `cfprefsd`.** `defaults write com.apple.Safari …` may silently fail. Prefer the Safari → Settings GUI for §6.3 checks.
+- **Apple Intelligence (§2.5.1.x) controls require an MDM profile.** Without MDM, those checks can only return WARN. Manual GUI toggles in System Settings → Apple Intelligence & Siri are the practical workaround.
+
+---
+
+## §1 — Software Updates (6 checks)
+
+| ☐ | CIS | Name (Severity) | GUI path | Verify | Fix |
+|---|---|---|---|---|---|
+| ☐ | 1.1 | Apple software updated within 30 days (High) | System Settings → General → Software Update → Update All | `defaults read /Library/Preferences/com.apple.SoftwareUpdate LastFullSuccessfulDate` (date must be within 30 days) | — (use GUI) |
+| ☐ | 1.2 | Critical updates auto-install (Medium) | System Settings → General → Software Update → ⓘ → enable "Install Security Responses and system files" | `defaults read /Library/Preferences/com.apple.SoftwareUpdate CriticalUpdateInstall` (expect `1`) | Admin: `sudo defaults write /Library/Preferences/com.apple.SoftwareUpdate CriticalUpdateInstall -int 1` |
+| ☐ | 1.3 | Auto-update enabled (Medium) | (same panel as 1.2 → "Download new updates when available") | `defaults read /Library/Preferences/com.apple.SoftwareUpdate AutomaticDownload` (expect `1`) | Admin: `sudo defaults write /Library/Preferences/com.apple.SoftwareUpdate AutomaticDownload -bool true` |
+| ☐ | 1.4 | App Store auto-updates enabled (Medium) | App Store → Settings → "Automatic Updates" | `defaults read /Library/Preferences/com.apple.commerce AutoUpdate` (expect `1`) | Admin: `sudo defaults write /Library/Preferences/com.apple.commerce AutoUpdate -bool true` |
+| ☐ | 1.5 | Security responses auto-install (High) | (same panel as 1.2) | `defaults read /Library/Preferences/com.apple.SoftwareUpdate ConfigDataInstall` (expect `1`) | Admin: `sudo defaults write /Library/Preferences/com.apple.SoftwareUpdate ConfigDataInstall -bool true` |
+| ☐ | 1.6 | Update deferment policy (Low) | MDM only (Jamf / Mosyle / etc.) | `defaults read /Library/Preferences/com.apple.SoftwareUpdate enforcedSoftwareUpdateDelay` (expect non-zero integer) | — (MDM-managed) |
+
+---
+
+## §2 — System Settings
+
+### §2.1 — iCloud (2 checks)
+
+| ☐ | CIS | Name (Severity) | GUI path | Verify | Fix |
+|---|---|---|---|---|---|
+| ☐ | 2.1.1.1 | iCloud Keychain disabled (Medium, advisory) | System Settings → [Your Name] → iCloud → Passwords & Keychain → toggle off | `osascript -l JavaScript -e "$.NSUserDefaults.alloc.initWithSuiteName('com.apple.applicationaccess').objectForKey('allowCloudKeychainSync').js"` (expect `false`; blank = no MDM, decide manually) | — (use GUI) |
+| ☐ | 2.1.1.3 | iCloud Drive Desktop/Documents sync off (Medium) | System Settings → [Your Name] → iCloud → iCloud Drive → Options → uncheck "Desktop & Documents Folders" | `defaults read com.apple.finder FXICloudDriveDesktop; defaults read com.apple.finder FXICloudDriveDocuments` (both absent or `0`) | User: `defaults write com.apple.finder FXICloudDriveDesktop -bool false && defaults write com.apple.finder FXICloudDriveDocuments -bool false` |
+
+### §2.2 — Firewall (2 checks)
+
+> Tahoe: `com.apple.alf` plist removed; queries go through `socketfilterfw` only.
+
+| ☐ | CIS | Name (Severity) | GUI path | Verify | Fix |
+|---|---|---|---|---|---|
+| ☐ | 2.2.1 | Firewall enabled (High) | System Settings → Network → Firewall → toggle on | `/usr/libexec/ApplicationFirewall/socketfilterfw --getglobalstate` (output contains `enabled`) | Admin: `sudo /usr/libexec/ApplicationFirewall/socketfilterfw --setglobalstate on` |
+| ☐ | 2.2.2 | Firewall stealth mode (Medium) | System Settings → Network → Firewall → Options → enable "Stealth Mode" | `/usr/libexec/ApplicationFirewall/socketfilterfw --getstealthmode` (output contains `enabled`) | Admin: `sudo /usr/libexec/ApplicationFirewall/socketfilterfw --setstealthmode on` |
+
+### §2.3.1 — AirDrop / AirPlay (2 checks)
+
+| ☐ | CIS | Name (Severity) | GUI path | Verify | Fix |
+|---|---|---|---|---|---|
+| ☐ | 2.3.1.1 | AirDrop disabled (Medium) | Control Center → AirDrop → Off, or Finder → AirDrop window → "Allow me to be discovered by: No One" | `defaults read com.apple.NetworkBrowser DisableAirDrop` (expect `1`) | User: `defaults write com.apple.NetworkBrowser DisableAirDrop -bool YES` |
+| ☐ | 2.3.1.2 | AirPlay Receiver disabled (Low) | System Settings → General → AirDrop & Handoff → AirPlay Receiver → Off | `defaults read com.apple.controlcenter AirplayRecieverEnabled` (absent or `0`) | User: `defaults write com.apple.controlcenter AirplayRecieverEnabled -int 0` |
+
+### §2.3.2 — Date & Time (2 checks)
+
+| ☐ | CIS | Name (Severity) | GUI path | Verify | Fix |
+|---|---|---|---|---|---|
+| ☐ | 2.3.2.1 | Time set automatically (Medium) | System Settings → General → Date & Time → enable "Set time and date automatically" | `defaults read /Library/Preferences/com.apple.timezone.auto.plist Active` (expect `1`) | Admin: `sudo defaults write /Library/Preferences/com.apple.timezone.auto.plist Active -int 1` |
+| ☐ | 2.3.2.2 | Clock within reasonable bounds (Low) | (same panel — set time zone correctly) | `date` (compare against a known good source like `https://time.is/`) | — (enable 2.3.2.1) |
+
+### §2.3.3 — Sharing Services (10 checks)
+
+> Most of these can be confirmed in one place: **System Settings → General → Sharing**. Toggle off anything you don't actively need.
+
+| ☐ | CIS | Name (Severity) | GUI path | Verify | Fix |
+|---|---|---|---|---|---|
+| ☐ | 2.3.3.1 | Screen Sharing disabled (High) | System Settings → General → Sharing → Screen Sharing → off | `launchctl list com.apple.screensharing` (must error: "Could not find service") | Admin: `sudo launchctl disable system/com.apple.screensharing; sudo launchctl stop com.apple.screensharing 2>/dev/null; true` |
+| ☐ | 2.3.3.2 | File Sharing disabled (High) | (same panel → File Sharing → off) | `launchctl print-disabled system \| grep com.apple.smbd` (expect `"com.apple.smbd" => disabled`) | Admin: `sudo launchctl disable system/com.apple.smbd; sudo launchctl stop com.apple.smbd 2>/dev/null; true` |
+| ☐ | 2.3.3.3 | Printer Sharing disabled (Low) | (same panel → Printer Sharing → off) | `cupsctl 2>/dev/null \| grep _share_printers` (must NOT contain `_share_printers=1`) | Admin: `sudo cupsctl --no-share-printers` |
+| ☐ | 2.3.3.4 | Remote Login (SSH) disabled (High) | (same panel → Remote Login → off) | `launchctl print-disabled system \| grep com.openssh.sshd` (expect `"com.openssh.sshd" => disabled`) | Admin: `sudo launchctl disable system/com.openssh.sshd; sudo launchctl stop com.openssh.sshd 2>/dev/null; true` |
+| ☐ | 2.3.3.5 | Remote Management (ARD) disabled (High) | (same panel → Remote Management → off) | `launchctl list com.apple.RemoteDesktop.agent` (must error) | Admin: `sudo /System/Library/CoreServices/RemoteManagement/ARDAgent.app/Contents/Resources/kickstart -deactivate -stop 2>/dev/null; true` |
+| ☐ | 2.3.3.6 | Remote Apple Events disabled (Medium) | (same panel → Remote Apple Events → off) | `launchctl print-disabled system \| grep com.apple.AEServer` (expect `"com.apple.AEServer" => disabled`) | Admin: `sudo launchctl disable system/com.apple.AEServer; sudo launchctl stop com.apple.AEServer 2>/dev/null; true` |
+| ☐ | 2.3.3.7 | Internet Sharing disabled (High) | (same panel → Internet Sharing → off) | `defaults read /Library/Preferences/SystemConfiguration/com.apple.nat 2>/dev/null` (must NOT contain `Enabled = 1`) | Admin: `sudo defaults write /Library/Preferences/SystemConfiguration/com.apple.nat NAT -dict-add Enabled -int 0` |
+| ☐ | 2.3.3.8 | Content Caching disabled (Low) | (same panel → Content Caching → off) | `/usr/bin/AssetCacheManagerUtil status 2>&1` (must NOT contain `activated: true`) | Admin: `sudo /usr/bin/AssetCacheManagerUtil deactivate 2>/dev/null; true` |
+| ☐ | 2.3.3.9 | Media Sharing disabled (Low) | (same panel → Media Sharing → off) | `defaults read com.apple.amp.mediasharingd home-sharing-enabled` (absent or `0`) | Admin: `sudo defaults write com.apple.amp.mediasharingd home-sharing-enabled -int 0; sudo launchctl stop com.apple.amp.mediasharingd 2>/dev/null; true` |
+| ☐ | 2.3.3.10 | Bluetooth Sharing disabled (Medium) | System Settings → General → Sharing → Bluetooth Sharing → off | `defaults -currentHost read com.apple.Bluetooth PrefKeyServicesEnabled` (absent or `0`) | User: `defaults -currentHost write com.apple.Bluetooth PrefKeyServicesEnabled -bool false` |
+
+### §2.3.4 — Time Machine (1 check)
+
+| ☐ | CIS | Name (Severity) | GUI path | Verify | Fix |
+|---|---|---|---|---|---|
+| ☐ | 2.3.4.1 | Time Machine backup configured (Medium) | System Settings → General → Time Machine → Add Backup Disk | `tmutil destinationinfo` (output contains `Name` or `Kind`) | — (use GUI) |
+
+### §2.5 — Apple Intelligence & Siri (5 checks)
+
+> Tahoe: 2.5.1.x require an MDM configuration profile to enforce. Without MDM these checks can't be auto-fixed; toggle the matching feature off in System Settings → Apple Intelligence & Siri instead.
+
+| ☐ | CIS | Name (Severity) | GUI path | Verify | Fix |
+|---|---|---|---|---|---|
+| ☐ | 2.5.1.1 | External Intelligence Extensions disabled (Medium) | System Settings → Apple Intelligence & Siri → Extensions → off | `osascript -l JavaScript -e "$.NSUserDefaults.alloc.initWithSuiteName('com.apple.applicationaccess').objectForKey('allowExternalIntelligenceIntegrations').js"` (expect `false`) | — (MDM only) |
+| ☐ | 2.5.1.2 | Writing Tools disabled (Medium) | System Settings → Apple Intelligence & Siri → Writing Tools → off | `osascript -l JavaScript -e "$.NSUserDefaults.alloc.initWithSuiteName('com.apple.applicationaccess').objectForKey('allowWritingTools').js"` (expect `false`) | — (MDM only) |
+| ☐ | 2.5.1.3 | Mail Summarization disabled (Low) | Mail → Settings → "Summarize messages" → off | `osascript -l JavaScript -e "$.NSUserDefaults.alloc.initWithSuiteName('com.apple.applicationaccess').objectForKey('allowMailSummary').js"` (expect `false`) | — (MDM only) |
+| ☐ | 2.5.1.4 | Notes Summarization disabled (Low) | Notes → Settings → AI features → off | `osascript -l JavaScript -e "$.NSUserDefaults.alloc.initWithSuiteName('com.apple.applicationaccess').objectForKey('allowNotesTranscription').js"` (expect `false`) | — (MDM only) |
+| ☐ | 2.5.2.1 | Siri disabled (Low) | System Settings → Apple Intelligence & Siri → Siri → off | `defaults read com.apple.Siri SiriProfessionalEnabled` (absent or `0`) | User: `defaults write com.apple.Siri SiriProfessionalEnabled -bool false` |
+
+### §2.6 — Privacy & Security (10 checks)
+
+| ☐ | CIS | Name (Severity) | GUI path | Verify | Fix |
+|---|---|---|---|---|---|
+| ☐ | 2.6.1.1 | Location services enabled (Low) | System Settings → Privacy & Security → Location Services → toggle on | `launchctl list com.apple.locationd` (must succeed) | — (use GUI) |
+| ☐ | 2.6.1.2 | Location services menu bar icon (Low) | System Settings → Privacy & Security → Location Services → scroll to bottom → enable "Show location icon in menu bar when system services request your location" | `defaults read com.apple.systemuiserver menuExtras` (output contains `Location.menu`) | — (use GUI) |
+| ☐ | 2.6.3.1 | Diagnostic data sharing off (Low) | System Settings → Privacy & Security → Analytics & Improvements → "Share Mac Analytics" → off | `defaults read '/Library/Application Support/CrashReporter/DiagnosticMessagesHistory.plist' AutoSubmit 2>/dev/null` (absent or NOT `1`) | Admin: `sudo defaults write '/Library/Application Support/CrashReporter/DiagnosticMessagesHistory.plist' AutoSubmit -bool false` |
+| ☐ | 2.6.3.2 | Improve Siri & Dictation off (Low) | System Settings → Privacy & Security → Analytics & Improvements → "Improve Siri & Dictation" → off | `defaults read com.apple.assistant.support 'Siri Data Sharing Opt-In Status' 2>/dev/null` (absent or NOT `1`) | User: `defaults write com.apple.assistant.support 'Siri Data Sharing Opt-In Status' -int 2` |
+| ☐ | 2.6.3.3 | Improve assistive voice off (Low) | (same panel → "Improve Assistive Voice Features" → off) | `defaults read com.apple.Accessibility AXSAudioDonationSiriImprovementEnabled` (absent or `0`) | User: `defaults write com.apple.Accessibility AXSAudioDonationSiriImprovementEnabled -bool false` |
+| ☐ | 2.6.3.4 | Share with app developers off (Low) | (same panel → "Share with App Developers" → off) | `osascript -l JavaScript -e "$.NSUserDefaults.alloc.initWithSuiteName('com.apple.applicationaccess').objectForKey('allowDiagnosticSubmission').js" 2>/dev/null` (expect `false`) | — (MDM only; use GUI) |
+| ☐ | 2.6.4 | Personalized ads disabled (Low) | System Settings → Privacy & Security → Apple Advertising → "Personalized Ads" → off | `defaults read com.apple.AdLib allowApplePersonalizedAdvertising` (absent or `0`) | User: `defaults write com.apple.AdLib allowApplePersonalizedAdvertising -bool false` |
+| ☐ | 2.6.5 | Gatekeeper enabled (High) | System Settings → Privacy & Security → Security → "Allow applications from": App Store, or App Store and identified developers | `spctl --status 2>&1` (output contains `assessments enabled`) | Admin: `sudo spctl --master-enable` |
+| ☐ | 2.6.7 | Lockdown Mode (Low, advisory) | System Settings → Privacy & Security → Lockdown Mode → enable (only if you face elevated targeting) | `defaults read /Library/Preferences/com.apple.security.lockdown LockdownModeEnabled` (`1` = enabled) | — (use GUI; advisory) |
+| ☐ | 2.6.8 | Admin password required for System Settings (Medium) | (no GUI in Tahoe — manual edit of `/etc/authorization` required) | `security authorizationdb read system.preferences 2>/dev/null` (output contains `<false/>` AND `<string>admin</string>`) | — (advanced; see [Apple Authorization Services docs](https://developer.apple.com/documentation/security/authorization_services)) |
+
+### §2.7 — Hot Corners (1 check)
+
+| ☐ | CIS | Name (Severity) | GUI path | Verify | Fix |
+|---|---|---|---|---|---|
+| ☐ | 2.7.1 | No hot corner set to "Disable Screen Saver" (Low) | System Settings → Desktop & Dock → Hot Corners → ensure no corner = "Disable Screen Saver" | `defaults read com.apple.dock wvous-tl-corner; defaults read com.apple.dock wvous-tr-corner; defaults read com.apple.dock wvous-bl-corner; defaults read com.apple.dock wvous-br-corner` (none may output `6`) | — (use GUI) |
+
+### §2.8 — Continuity (1 check)
+
+| ☐ | CIS | Name (Severity) | GUI path | Verify | Fix |
+|---|---|---|---|---|---|
+| ☐ | 2.8.1 | Universal Control disabled (Low) | System Settings → Displays → Advanced → "Allow your pointer and keyboard to move between any nearby Mac or iPad" → off | `defaults -currentHost read com.apple.universalcontrol Disable` (expect `1`) | User: `defaults -currentHost write com.apple.universalcontrol Disable -int 1` |
+
+### §2.9 — Spotlight (1 check)
+
+| ☐ | CIS | Name (Severity) | GUI path | Verify | Fix |
+|---|---|---|---|---|---|
+| ☐ | 2.9.1 | Spotlight query sharing off (Low) | System Settings → Spotlight → "Help Apple improve Search" → off | `osascript -l JavaScript -e "$.NSUserDefaults.alloc.initWithSuiteName('com.apple.assistant.support').objectForKey('Search Queries Data Sharing Status').js" 2>/dev/null` (expect `2`) | User: `defaults write com.apple.assistant.support 'Search Queries Data Sharing Status' -int 2` |
+
+### §2.10 — Energy / Power (3 checks)
+
+| ☐ | CIS | Name (Severity) | GUI path | Verify | Fix |
+|---|---|---|---|---|---|
+| ☐ | 2.10.1.2 | Sleep enabled (Apple Silicon) (Medium) | System Settings → Lock Screen → "Turn display off when inactive" ≤ 20 min | `pmset -b -g 2>/dev/null \| grep -E '^ sleep\|^ displaysleep'` (non-empty) | Admin: `sudo pmset -a sleep 15 && sudo pmset -a displaysleep 10` |
+| ☐ | 2.10.2 | Power Nap disabled (Intel only) (Low) | System Settings → Energy Saver → "Enable Power Nap" → off (Intel Macs only; not present on Apple Silicon) | `pmset -g custom 2>/dev/null \| grep powernap` (must NOT contain `1`) | Admin: `sudo pmset -a powernap 0 && sudo pmset -a darkwakes 0` |
+| ☐ | 2.10.3 | Wake for network access disabled (Low) | System Settings → Energy Saver → "Wake for network access" → off | `pmset -g custom 2>/dev/null \| grep womp` (must NOT contain `1`) | Admin: `sudo pmset -a womp 0` |
+
+### §2.11 — Login & Screen Saver (5 checks)
+
+> Tahoe: screen saver keys live under `-currentHost`. The verify commands try `-currentHost` first.
+
+| ☐ | CIS | Name (Severity) | GUI path | Verify | Fix |
+|---|---|---|---|---|---|
+| ☐ | 2.11.1 | Screen saver activates ≤ 20 min (Medium) | System Settings → Lock Screen → "Start Screen Saver when inactive" ≤ 20 min | `defaults -currentHost read com.apple.screensaver idleTime` (expect 1–1200) | User: `defaults -currentHost write com.apple.screensaver idleTime -int 1200` |
+| ☐ | 2.11.2 | Password required on wake (High) | System Settings → Lock Screen → "Require password after screen saver begins or display is turned off" → Immediately | `defaults -currentHost read com.apple.screensaver askForPassword` (expect `1`) | User: `defaults -currentHost write com.apple.screensaver askForPassword -bool true && defaults -currentHost write com.apple.screensaver askForPasswordDelay -int 0` |
+| ☐ | 2.11.3 | Login window banner message (Low) | System Settings → Lock Screen → "Show message when locked" | `defaults read /Library/Preferences/com.apple.loginwindow LoginwindowText` (non-empty string) | Admin: `sudo defaults write /Library/Preferences/com.apple.loginwindow LoginwindowText 'Authorized use only'` |
+| ☐ | 2.11.4 | Login shows name + password fields (Low) | System Settings → Users & Groups → Edit (next to Automatic login as) → "Display login window as: Name and password" | `defaults read /Library/Preferences/com.apple.loginwindow SHOWFULLNAME` (expect `1`) | Admin: `sudo defaults write /Library/Preferences/com.apple.loginwindow SHOWFULLNAME -bool true` |
+| ☐ | 2.11.5 | Password hints disabled (Medium) | System Settings → Users & Groups → Edit → uncheck "Show password hints" | `defaults read /Library/Preferences/com.apple.loginwindow RetriesUntilHint` (absent or `0`) | Admin: `sudo defaults write /Library/Preferences/com.apple.loginwindow RetriesUntilHint -int 0` |
+
+### §2.13 — Guest & Auto-Login (3 checks)
+
+| ☐ | CIS | Name (Severity) | GUI path | Verify | Fix |
+|---|---|---|---|---|---|
+| ☐ | 2.13.1 | Guest login disabled (High) | System Settings → Users & Groups → Guest User → toggle off | `defaults read /Library/Preferences/com.apple.loginwindow.plist GuestEnabled` (absent or `0`) | Admin: `sudo defaults write /Library/Preferences/com.apple.loginwindow.plist GuestEnabled -bool false` |
+| ☐ | 2.13.2 | Guest shared-folder access off (Medium) | System Settings → Users & Groups → Guest User ⓘ → uncheck "Allow guests to connect to shared folders" | `defaults read /Library/Preferences/com.apple.AppleFileServer guestAccess` (absent or `0`) | Admin: `sudo defaults write /Library/Preferences/com.apple.AppleFileServer guestAccess -int 0` |
+| ☐ | 2.13.3 | Automatic login disabled (High) | System Settings → Users & Groups → "Automatic login as" → Off | `defaults read /Library/Preferences/com.apple.loginwindow autoLoginUser` (must error / empty) | Admin: `sudo defaults delete /Library/Preferences/com.apple.loginwindow autoLoginUser 2>/dev/null; true` |
+
+---
+
+## §3 — Logging & Auditing (2 checks)
+
+> **Tahoe note:** `com.apple.auditd` was removed by Apple. Both checks below report WARN on Tahoe — there is nothing you can do about it from userspace. Skip and tick the boxes.
+
+| ☐ | CIS | Name (Severity) | GUI path | Verify | Fix |
+|---|---|---|---|---|---|
+| ☐ | 3.1 | Security auditing enabled (Medium) | n/a (Tahoe) | `launchctl list com.apple.auditd` (succeed = pass; on Tahoe expect "Could not find" → WARN) | — (Tahoe: removed) |
+| ☐ | 3.2 | Audit flags configured (Medium) | n/a (Tahoe) | `grep ^flags /etc/security/audit_control 2>/dev/null` (expect `lo, aa, ad, fd, fm`; on Tahoe file is absent → WARN) | — (Tahoe: file removed; pre-Tahoe: `sudo vi /etc/security/audit_control` and set `flags=lo,aa,ad,fd,fm,-all`) |
+
+---
+
+## §4 — Network (3 checks)
+
+| ☐ | CIS | Name (Severity) | GUI path | Verify | Fix |
+|---|---|---|---|---|---|
+| ☐ | 4.1 | Bonjour multicast advertising disabled (Low) | (no GUI) | `defaults read /Library/Preferences/com.apple.mDNSResponder.plist NoMulticastAdvertisements` (expect `1`) | Admin: `sudo defaults write /Library/Preferences/com.apple.mDNSResponder.plist NoMulticastAdvertisements -bool true` |
+| ☐ | 4.2 | Apache HTTP server disabled (High) | (no GUI) | `launchctl list org.apache.httpd` (must error) | Admin: `sudo launchctl disable system/org.apache.httpd; sudo launchctl stop org.apache.httpd 2>/dev/null; true` |
+| ☐ | 4.3 | NFS server disabled (High) | (no GUI) | `launchctl print-disabled system \| grep com.apple.nfsd` (expect `"com.apple.nfsd" => disabled`) | Admin: `sudo launchctl disable system/com.apple.nfsd` |
+
+---
+
+## §5 — Authentication & Authorization (13 checks)
+
+### §5.1 — System Protections (3 checks, **all Recovery Mode only**)
+
+> See the **Recovery Mode procedure** at the bottom of this guide for how to boot into recovery and run these.
+
+| ☐ | CIS | Name (Severity) | Recovery Mode action | Verify (from regular Terminal) |
+|---|---|---|---|---|
+| ☐ | 5.1.1 | SIP enabled (Critical) | `csrutil enable` from Recovery Terminal, then restart | `csrutil status` (output contains `enabled`) |
+| ☐ | 5.1.3 | AMFI enabled (Critical) | `nvram boot-args=""` from Recovery Terminal (clears any disable flag), then restart | `nvram -p` (must NOT contain `amfi_get_out_of_my_way=1`) |
+| ☐ | 5.1.4 | Signed System Volume enabled (Critical) | `csrutil authenticated-root enable` from Recovery Terminal, then restart | `csrutil authenticated-root status` (output contains `enabled`) |
+
+### §5.2 — Password Policy (2 checks)
+
+| ☐ | CIS | Name (Severity) | GUI path | Verify | Fix |
+|---|---|---|---|---|---|
+| ☐ | 5.2.1 | Lockout after ≤ 5 failed attempts (High) | (no GUI; CLI only) | `pwpolicy -getaccountpolicies 2>/dev/null` (look for `policyAttributeMaximumFailedAuthentications` ≤ 5) | Admin: `sudo pwpolicy -n /Local/Default -setglobalpolicy maxFailedLoginAttempts=5` |
+| ☐ | 5.2.2 | Minimum password length ≥ 15 chars (High) | (no GUI; CLI only) | `pwpolicy -getaccountpolicies 2>/dev/null` (look for `minChars=15` or higher) | Admin: `sudo pwpolicy -n /Local/Default -setglobalpolicy minChars=15` |
+
+### §5.4 – §5.11 — Sudo, Root, Filesystem, XProtect (6 checks)
+
+| ☐ | CIS | Name (Severity) | GUI path | Verify | Fix |
+|---|---|---|---|---|---|
+| ☐ | 5.4 | Sudo timeout = 0 (Medium) | (no GUI) | `sudo -V 2>&1 \| grep 'Authentication timestamp timeout'` (expect `0.0 minutes`) | Admin: `echo 'Defaults timestamp_timeout=0' \| sudo tee /etc/sudoers.d/cis_timeout && sudo chmod 440 /etc/sudoers.d/cis_timeout` |
+| ☐ | 5.5 | Sudo TTY tickets enabled (Medium) | (no GUI) | `sudo -V` (output contains `Type of authentication timestamp record: tty`) | Admin: `echo 'Defaults timestamp_type=tty' \| sudo tee /etc/sudoers.d/cis_tty && sudo chmod 440 /etc/sudoers.d/cis_tty` |
+| ☐ | 5.6 | Root account disabled (High) | Directory Utility → Edit menu → Disable Root User | `dscl . -read /Users/root UserShell` (expect `/usr/bin/false` or `nologin`) | Admin: `sudo dscl . -create /Users/root UserShell /usr/bin/false` (or `sudo dsenableroot -d`) |
+| ☐ | 5.9 | Guest home folder removed (Low) | (no GUI) | `ls /Users/ 2>/dev/null` (must NOT contain `Guest`) | Admin: `sudo rm -rf /Users/Guest` (after disabling guest login per 2.13.1) |
+| ☐ | 5.10 | XProtect running (High) | (managed by Apple — keep Software Update enabled) | `xprotect status` (`enabled: true`) — fallback: `launchctl list com.apple.XProtect.daemon.scan` (succeeds) | — (do not disable; ensure §1 software updates are on) |
+| ☐ | 5.11 | Sudo logs allowed commands (Medium) | (no GUI) | `sudo -V` (output contains `Log when a command is allowed by sudoers`) | Admin: `echo 'Defaults log_allowed' \| sudo tee /etc/sudoers.d/cis_logging && sudo chmod 440 /etc/sudoers.d/cis_logging` |
+
+### §5 — Encryption / Cert Trust (2 checks; no CIS sub-ID in Mergen)
+
+| ☐ | Name (Severity) | GUI path | Verify | Fix |
+|---|---|---|---|---|
+| ☐ | FileVault full-disk encryption enabled (Critical) | System Settings → Privacy & Security → FileVault → Turn On FileVault | `fdesetup status` (output contains `FileVault is On`) | — (use GUI; safe-store the recovery key) |
+| ☐ | Certificate trust settings clean (High) | Keychain Access → System → Certificates — review any custom trust overrides | `security dump-trust-settings 2>&1` (expect `No Trust Settings were found`) | — (delete suspicious overrides in Keychain Access manually) |
+
+---
+
+## §6 — User Interface
+
+### §6.1 — Finder (2 checks)
+
+| ☐ | CIS | Name (Severity) | GUI path | Verify | Fix |
+|---|---|---|---|---|---|
+| ☐ | 6.1.1 | Show all filename extensions (Low) | Finder → Settings → Advanced → check "Show all filename extensions" | `defaults read NSGlobalDomain AppleShowAllExtensions` (expect `1`) | User: `defaults write NSGlobalDomain AppleShowAllExtensions -bool true` |
+| ☐ | 6.1.2 | Home folder permissions ≤ 750 (Medium) | (no GUI) | `ls -la /Users/ 2>/dev/null` (no home folder, except `Shared`, has `r` in the "others" position) | User: `chmod 700 ~/` (run for each affected user) |
+
+### §6.3 — Safari (6 checks)
+
+> Tahoe: Safari prefs are sandboxed by `cfprefsd`. The `defaults write` commands often silently no-op. **Use the Safari Settings GUI** as the primary fix path on Tahoe; the commands are kept here for verification and pre-Tahoe systems.
+
+| ☐ | CIS | Name (Severity) | GUI path | Verify | Fix |
+|---|---|---|---|---|---|
+| ☐ | 6.3.1 | Auto-open safe downloads off (Medium) | Safari → Settings → General → uncheck "Open 'safe' files after downloading" | `defaults read com.apple.Safari AutoOpenSafeDownloads` (absent or `0`) | User (may be sandboxed on Tahoe — prefer GUI): `defaults write com.apple.Safari AutoOpenSafeDownloads -bool false` |
+| ☐ | 6.3.3 | Fraudulent website warning on (Medium) | Safari → Settings → Security → check "Warn when visiting a fraudulent website" | `defaults read com.apple.Safari WarnAboutFraudulentWebsites` (expect `1`; absent = WARN, default is on) | User: `defaults write com.apple.Safari WarnAboutFraudulentWebsites -bool true` |
+| ☐ | 6.3.4 | Cross-site tracking prevention on (Medium) | Safari → Settings → Privacy → check "Prevent cross-site tracking" | `defaults read com.apple.Safari BlockStoragePolicy` (expect `2`) | User: `defaults write com.apple.Safari BlockStoragePolicy -int 2` |
+| ☐ | 6.3.6 | Private Click Measurement on (Low) | Safari → Settings → Privacy → check "Allow privacy-preserving measurement of ad effectiveness" | `defaults read com.apple.Safari WebKitPreferences.privateClickMeasurementEnabled` (absent or NOT `0`) | User: `defaults write com.apple.Safari WebKitPreferences.privateClickMeasurementEnabled -bool true` |
+| ☐ | 6.3.8 | Internet plugins blocked (Medium) | Safari → Settings → Websites → Plug-ins → set per-site to "Off" / "Ask" | `defaults read com.apple.Safari PlugInFirstVisitPolicy` (expect `2`) | User: `defaults write com.apple.Safari PlugInFirstVisitPolicy -int 2` |
+| ☐ | 6.3.10 | Status bar shown (Low) | Safari → View menu → Show Status Bar | `defaults read com.apple.Safari ShowOverlayStatusBar` (expect `1`) | User: `defaults write com.apple.Safari ShowOverlayStatusBar -bool true` |
+
+### §6.4 — Terminal (1 check)
+
+| ☐ | CIS | Name (Severity) | GUI path | Verify | Fix |
+|---|---|---|---|---|---|
+| ☐ | 6.4.1 | Secure Keyboard Entry on (Medium) | Terminal → Terminal menu → "Secure Keyboard Entry" | `osascript -l JavaScript -e "$.NSUserDefaults.alloc.initWithSuiteName('com.apple.Terminal').objectForKey('SecureKeyboardEntry').js"` (expect `true`) | User: `defaults write com.apple.Terminal SecureKeyboardEntry -bool true` |
+
+---
+
+## Additional Checks (5)
+
+These appear in Mergen without a CIS sub-ID assignment.
+
+| ☐ | Name (Severity) | GUI path | Verify | Fix |
+|---|---|---|---|---|
+| ☐ | Bluetooth status in menu bar (Low) | System Settings → Control Center → Bluetooth → "Show in Menu Bar" | `defaults read com.apple.controlcenter.plist 'NSStatusItem Visible Bluetooth'` (expect `1`) | — (use GUI) |
+| ☐ | Fast User Switching disabled (Medium) | System Settings → Control Center → Fast User Switching → off | `defaults read /Library/Preferences/.GlobalPreferences MultipleSessionEnabled` (absent or `0`) | Admin: `sudo defaults write /Library/Preferences/.GlobalPreferences MultipleSessionEnabled -bool false` |
+| ☐ | Time Machine volumes encrypted (High) | System Settings → General → Time Machine → select disk → Options → enable encryption | `defaults read /Library/Preferences/com.apple.TimeMachine.plist 2>/dev/null` (must NOT contain `NotEncrypted`) | — (use GUI; encryption can only be set when adding the disk) |
+| ☐ | EFI firmware up to date (Intel only) (High) | System Settings → General → Software Update — install all updates | If `sysctl -n machdep.cpu.brand_string` contains `Intel`: `system_profiler SPHardwareDataType \| grep 'Boot ROM'` (compare against [Apple's published versions](https://eclecticlight.co/2024/01/01/efi-and-firmware-versions/)). Skip if Apple Silicon. | — (run all Software Updates) |
+| ☐ | Java 6 runtime not present (High) | (no GUI) | `java -version 2>&1` (must NOT contain `1.6` or `version "1.6`; "command not found" = pass) | — (install a supported JDK like Temurin 21 from adoptium.net; remove Java 6 from `/Library/Java/JavaVirtualMachines/`) |
+
+---
+
+## Recovery Mode procedure (for §5.1.1, §5.1.3, §5.1.4)
+
+You only need this if SIP, AMFI, or SSV is currently disabled — which is unusual unless you intentionally turned them off for development.
+
+**Apple Silicon (M1/M2/M3/M4):**
+1. Shut the Mac down completely (Apple menu → Shut Down).
+2. Press and hold the **Power** button until you see "Loading startup options."
+3. Click **Options** → **Continue**.
+4. Authenticate as an admin user.
+5. Menu bar → **Utilities** → **Terminal**.
+6. Run the recovery command for the failing check (e.g. `csrutil enable`).
+7. Restart from the Apple menu.
+
+**Intel:**
+1. Shut down.
+2. Press the **Power** button, then immediately hold **Cmd+R** until the Apple logo appears.
+3. Authenticate, then **Utilities** → **Terminal**.
+4. Run the command, restart.
+
+After restart, run the **Verify** command from a normal Terminal session to confirm the change.
+
+---
+
+## Closing checklist
+
+- [ ] All §1–§6 boxes ticked or noted as WARN/skip
+- [ ] All Critical and High items either pass or have a documented reason for failing
+- [ ] Time Machine snapshot taken before any fix was applied
+- [ ] FileVault is on, recovery key stored somewhere safe (password manager, printed copy in a sealed envelope, etc.)
+- [ ] Software Update is set to download and install automatically (1.2–1.5)
+
+If something breaks after a fix:
+- `sudo defaults delete <plist> <key>` removes the write you made.
+- `sudo launchctl enable system/<service>; sudo launchctl start <service>` re-enables a service you disabled.
+- For sudoers rules added under `/etc/sudoers.d/cis_*`: `sudo rm /etc/sudoers.d/cis_*` to revert.
+- Restore from the Time Machine snapshot you took at step 3 if all else fails.
+
+---
+
+*Generated 2026-04-27 from `securesigner/mergen` (fork of `sametsazak/mergen`). Verify against upstream when CIS Benchmark version changes.*


### PR DESCRIPTION
Adds `MANUAL_AUDIT_GUIDE.md` at the repo root — a hand-runnable checklist of every CIS check Mergen performs, for users who'd rather verify and fix things themselves than install the binary.

## What's in it

- All ~85 CIS checks plus the 5 unnumbered extras, grouped by CIS section
- Compact tables with checkbox column: `☐ | CIS | Name (Severity) | GUI path | Verify | Fix`
- GUI-first (System Settings paths on Tahoe), Terminal verify/fix as fallback
- Tahoe-specific gotchas called out up front: `auditd` removed, Safari sandboxed by `cfprefsd`, Apple Intelligence checks need MDM
- Recovery Mode procedure for SIP / AMFI / SSV (§5.1.x)
- Rollback notes — how to undo a fix if it breaks something

## Why

Some users don't want to install another auditor on a hardened machine, or want to actually understand each control rather than treating remediation as a black box. The guide is derived directly from `mergen-cli/internal/checks/*.go` and `mergen/core/FixCommands.swift`, so it stays in lockstep with what the tool itself does.

## Maintenance

When a CIS Benchmark version bumps and check files in `mergen-cli/internal/checks/` change, the corresponding row in this guide needs updating. The footer of the guide notes the source files and date so future maintainers know where to re-extract from.